### PR TITLE
Update sdk and sample, to carry metadata and data length to receiver side

### DIFF
--- a/sdk/include/mcm_dp.h
+++ b/sdk/include/mcm_dp.h
@@ -51,8 +51,8 @@ typedef struct {
     struct {
         uint16_t seq_num; /* Sequence number */
         uint32_t timestamp; /* Timestamp */
-    } metadata;
-    size_t len;
+    } metadata; /**< filled by sender side */
+    size_t len; /**< size of data filled in "data" */
     void* data;
 } mcm_buffer;
 

--- a/sdk/samples/sender_app.c
+++ b/sdk/samples/sender_app.c
@@ -94,8 +94,9 @@ int read_test_data(FILE* fp, mcm_buffer* buf, uint32_t width, uint32_t height, v
         perror("Error when read frame file");
         ret = -1;
     }
-    //TODO: metadata is not carried to receiver side
+
     buf->metadata.seq_num = buf->metadata.timestamp = frm_idx++;
+    buf->len = frame_size;
 
     return ret;
 }

--- a/sdk/src/mcm_dp.c
+++ b/sdk/src/mcm_dp.c
@@ -13,7 +13,7 @@
 #include "mcm_dp.h"
 #include "media_proxy_ctrl.h"
 
-static void parse_memIF_param(mcm_conn_param* request, memif_socket_args_t* memif_socket_args, memif_conn_args_t* memif_conn_args)
+static void parse_memif_param(mcm_conn_param* request, memif_socket_args_t* memif_socket_args, memif_conn_args_t* memif_conn_args)
 {
     char type_str[8] = "";
     char interface_name[32];
@@ -142,7 +142,7 @@ mcm_conn_context* mcm_create_connection(mcm_conn_param* param)
         break;
     case PROTO_MEMIF:;
         memif_conn_param memif_param = {};
-        parse_memIF_param(param, &(memif_param.socket_args), &(memif_param.conn_args));
+        parse_memif_param(param, &(memif_param.socket_args), &(memif_param.conn_args));
         /* Connect memif connection. */
         conn_ctx = mcm_create_connection_memif(param, &memif_param);
         conn_ctx->session_id = 0;


### PR DESCRIPTION
mcm_buffer.metadata/len are supposed to be filled by user from sender side. The information will be sent to receiver side, and can be retrieved by application.