### PR TITLE
High impact Coverity scan fixes

### DIFF
--- a/media-proxy/src/api_server_tcp.cc
+++ b/media-proxy/src/api_server_tcp.cc
@@ -288,6 +288,7 @@ void RunTCPServer(ProxyContext* ctx)
     address.sin_port = htons(port);
     if (bind(sock, (struct sockaddr*)&address, sizeof(address)) < 0) {
         fprintf(stderr, "error: cannot bind socket to port %d: %s\n", port, strerror(errno));
+        close(sock);
         return;
     }
 

--- a/media-proxy/src/api_server_tcp.cc
+++ b/media-proxy/src/api_server_tcp.cc
@@ -266,8 +266,6 @@ void RunTCPServer(ProxyContext* ctx)
     connection_t* connection = NULL;
     control_context* ctl_ctx = NULL;
     pthread_t thread;
-    size_t connection_t_size = sizeof(connection_t);
-    size_t control_context_size = sizeof(control_context);
 
     port = ctx->getTCPListenPort();
     if (port <= 0) {
@@ -303,21 +301,21 @@ void RunTCPServer(ProxyContext* ctx)
 
     while (keepRunning) {
         /* accept incoming connections */
-        connection = (connection_t*)malloc(connection_t_size);
+        connection = (connection_t*)malloc(sizeof(connection_t));
         if (!connection) continue;
 
-        memset(connection, 0x0, connection_t_size);
+        memset(connection, 0x0, sizeof(connection_t));
         connection->sock = accept(sock, &connection->address, (socklen_t*)&connection->addr_len);
         if (connection->sock <= 0) {
             free(connection);
         } else {
             /* start a new thread but do not wait for it */
-            ctl_ctx = (control_context*)malloc(control_context_size);
+            ctl_ctx = (control_context*)malloc(sizeof(control_context));
             if (!ctl_ctx) {
                 free(connection);
                 continue;
             }
-            memset(ctl_ctx, 0x0, control_context_size);
+            memset(ctl_ctx, 0x0, sizeof(control_context));
             ctl_ctx->proxy_ctx = ctx;
             ctl_ctx->conn = connection;
             if (pthread_create(&thread, 0, msg_loop, (void*)ctl_ctx) == 0) {

--- a/media-proxy/src/api_server_tcp.cc
+++ b/media-proxy/src/api_server_tcp.cc
@@ -277,7 +277,7 @@ void RunTCPServer(ProxyContext* ctx)
 
     /* create socket */
     sock = socket(AF_INET, SOCK_STREAM, 0);
-    if (sock == -1) {
+    if (sock < 0) {
         fprintf(stderr, "error: cannot create socket\n");
         return;
     }
@@ -312,14 +312,14 @@ void RunTCPServer(ProxyContext* ctx)
         } else {
             /* start a new thread but do not wait for it */
             ctl_ctx = (control_context*)malloc(control_context_size);
-            if(!ctl_ctx) {
+            if (!ctl_ctx) {
                 free(connection);
                 continue;
             }
             memset(ctl_ctx, 0x0, control_context_size);
             ctl_ctx->proxy_ctx = ctx;
             ctl_ctx->conn = connection;
-            if(pthread_create(&thread, 0, msg_loop, (void*)ctl_ctx) == 0) {
+            if (pthread_create(&thread, 0, msg_loop, (void*)ctl_ctx) == 0) {
                 pthread_detach(thread);
             } else {
                 free(connection);

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <sstream>
 #include <vector>
+#include <bsd/string.h>
 
 #include "proxy_context.h"
 #include <mcm_dp.h>
@@ -107,7 +108,7 @@ void ProxyContext::ParseStInitParam(const TxControlRequest* request, struct mtl_
     st_param->num_ports = init.number_ports();
 
     std::string port_p = init.primary_port();
-    strncpy(st_param->port[MTL_PORT_P], port_p.c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(st_param->port[MTL_PORT_P], port_p.c_str(), MTL_PORT_MAX_LEN);
 
     for (int i = 0; i < init.primary_sip_addr_size(); ++i) {
         st_param->sip_addr[MTL_PORT_P][i] = init.primary_sip_addr(i);
@@ -150,7 +151,7 @@ void ProxyContext::ParseStInitParam(const RxControlRequest* request, struct mtl_
     st_param->num_ports = init.number_ports();
 
     std::string port_p = init.primary_port();
-    strncpy(st_param->port[MTL_PORT_P], port_p.c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(st_param->port[MTL_PORT_P], port_p.c_str(), MTL_PORT_MAX_LEN);
 
     for (int i = 0; i < init.primary_sip_addr_size(); ++i) {
         st_param->sip_addr[MTL_PORT_P][i] = init.primary_sip_addr(i);
@@ -189,7 +190,7 @@ void ProxyContext::ParseStInitParam(const RxControlRequest* request, struct mtl_
 
 void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* st_param)
 {
-    strncpy(st_param->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(st_param->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     inet_pton(AF_INET, getDataPlaneAddress().c_str(), st_param->sip_addr[MTL_PORT_P]);
     st_param->pmd[MTL_PORT_P] = mtl_pmd_by_port_name(st_param->port[MTL_PORT_P]);
     st_param->num_ports = 1;
@@ -223,16 +224,16 @@ void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_in
 
 void ProxyContext::ParseMemIFParam(const TxControlRequest* request, memif_ops_t& memif_ops)
 {
-    strncpy(memif_ops.app_name, request->memif_ops().app_name().c_str(), sizeof(memif_ops.app_name));
-    strncpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(), sizeof(memif_ops.interface_name));
-    strncpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(), sizeof(memif_ops.socket_path));
+    strlcpy(memif_ops.app_name, request->memif_ops().app_name().c_str(), sizeof(memif_ops.app_name));
+    strlcpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(), sizeof(memif_ops.interface_name));
+    strlcpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(), sizeof(memif_ops.socket_path));
 }
 
 void ProxyContext::ParseMemIFParam(const RxControlRequest* request, memif_ops_t& memif_ops)
 {
-    strncpy(memif_ops.app_name, request->memif_ops().app_name().c_str(), sizeof(memif_ops.app_name));
-    strncpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(), sizeof(memif_ops.interface_name));
-    strncpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(), sizeof(memif_ops.socket_path));
+    strlcpy(memif_ops.app_name, request->memif_ops().app_name().c_str(), sizeof(memif_ops.app_name));
+    strlcpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(), sizeof(memif_ops.interface_name));
+    strlcpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(), sizeof(memif_ops.socket_path));
 }
 
 void ProxyContext::ParseSt20RxOps(const RxControlRequest* request, struct st20p_rx_ops* ops_rx)
@@ -241,7 +242,7 @@ void ProxyContext::ParseSt20RxOps(const RxControlRequest* request, struct st20p_
     StRxPort rx_port = st20_rx.rx_port();
 
     std::string port = rx_port.port();
-    strncpy(ops_rx->port.port[MTL_PORT_P], port.c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops_rx->port.port[MTL_PORT_P], port.c_str(), MTL_PORT_MAX_LEN);
     for (int i = 0; i < rx_port.sip_addr_size(); ++i) {
         ops_rx->port.sip_addr[MTL_PORT_P][i] = rx_port.sip_addr(i);
     }
@@ -285,7 +286,7 @@ void ProxyContext::ParseSt20TxOps(const TxControlRequest* request, struct st20p_
     StTxPort tx_port = st20_tx.tx_port();
 
     std::string port = tx_port.port();
-    strncpy(ops_tx->port.port[MTL_PORT_P], port.c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops_tx->port.port[MTL_PORT_P], port.c_str(), MTL_PORT_MAX_LEN);
     for (int i = 0; i < tx_port.dip_addr_size(); ++i) {
         ops_tx->port.dip_addr[MTL_PORT_P][i] = tx_port.dip_addr(i);
     }
@@ -331,7 +332,7 @@ void ProxyContext::ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx
     inet_pton(AF_INET, request->remote_addr.ip, ops_rx->port.sip_addr[MTL_PORT_P]);
     ops_rx->port.udp_port[MTL_PORT_P] = atoi(request->local_addr.port);
     // ops_rx->port.udp_port[MTL_PORT_P] = RX_ST20_UDP_PORT;
-    strncpy(ops_rx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops_rx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops_rx->port.num_port = 1;
     ops_rx->port.payload_type = 112;
     ops_rx->name = strdup(session_name);
@@ -396,7 +397,7 @@ void ProxyContext::ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx
 
     inet_pton(AF_INET, request->remote_addr.ip, ops_tx->port.dip_addr[MTL_PORT_P]);
     ops_tx->port.udp_port[MTL_PORT_P] = atoi(request->remote_addr.port);
-    strncpy(ops_tx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops_tx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops_tx->port.num_port = 1;
     ops_tx->port.payload_type = 112;
     ops_tx->name = strdup(session_name);
@@ -439,7 +440,7 @@ void ProxyContext::ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx
 
     inet_pton(AF_INET, request->remote_addr.ip, ops->port.dip_addr[MTL_PORT_P]);
     ops->port.udp_port[MTL_PORT_P] = atoi(request->remote_addr.port);
-    strncpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->port.num_port = 1;
     ops->port.payload_type = 114;
     ops->name = strdup(session_name);
@@ -485,7 +486,7 @@ void ProxyContext::ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx
     ops->port.udp_port[MTL_PORT_P] = atoi(request->local_addr.port);
 
     // ops->port.udp_port[MTL_PORT_P] = RX_ST20_UDP_PORT;
-    strncpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->port.num_port = 1;
     ops->port.payload_type = 114;
     ops->name = strdup(session_name);
@@ -528,7 +529,7 @@ void ProxyContext::ParseSt30TxOps(const mcm_conn_param* request, struct st30_tx_
 
     inet_pton(AF_INET, request->remote_addr.ip, ops->dip_addr[MTL_PORT_P]);
     ops->udp_port[MTL_PORT_P] = atoi(request->remote_addr.port);
-    strncpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->num_port = 1;
     ops->payload_type = 111;
     ops->name = strdup(session_name);
@@ -563,7 +564,7 @@ void ProxyContext::ParseSt30RxOps(const mcm_conn_param* request, struct st30_rx_
     inet_pton(AF_INET, request->remote_addr.ip, ops->sip_addr[MTL_PORT_P]);
     ops->udp_port[MTL_PORT_P] = atoi(request->local_addr.port);
 
-    strncpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->num_port = 1;
     ops->payload_type = 111;
     ops->name = strdup(session_name);
@@ -598,7 +599,7 @@ void ProxyContext::ParseSt40TxOps(const mcm_conn_param* request, struct st40_tx_
 
     inet_pton(AF_INET, request->remote_addr.ip, ops->dip_addr[MTL_PORT_P]);
     ops->udp_port[MTL_PORT_P] = atoi(request->remote_addr.port);
-    strncpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->num_port = 1;
     ops->payload_type = 113;
     ops->name = strdup(session_name);
@@ -633,7 +634,7 @@ void ProxyContext::ParseSt40RxOps(const mcm_conn_param* request, struct st40_rx_
     inet_pton(AF_INET, request->remote_addr.ip, ops->sip_addr[MTL_PORT_P]);
     ops->udp_port[MTL_PORT_P] = atoi(request->local_addr.port);
 
-    strncpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
+    strlcpy(ops->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->num_port = 1;
     ops->payload_type = 113;
     ops->rtp_ring_size = 1024;
@@ -815,6 +816,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         rx_ctx = mtl_st22p_rx_session_create(mDevHandle, &opts, &memif_ops);
         if (rx_ctx == NULL) {
             INFO("%s, Fail to create RX session.", __func__);
+            delete st_ctx;
             return -1;
         }
 
@@ -829,6 +831,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         rx_ctx = mtl_st30_rx_session_create(mDevHandle, &opts, &memif_ops);
         if (rx_ctx == NULL) {
             INFO("%s, Fail to create RX session.", __func__);
+            delete st_ctx;
             return -1;
         }
 
@@ -843,6 +846,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         rx_ctx = mtl_st40_rx_session_create(mDevHandle, &opts, &memif_ops);
         if (rx_ctx == NULL) {
             INFO("%s, Fail to create RX session.", __func__);
+            delete st_ctx;
             return -1;
         }
 
@@ -856,6 +860,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         rx_ctx = mtl_udp_h264_rx_session_create(mDevHandle, &local_addr, &memif_ops, schs);
         if (rx_ctx == NULL) {
             INFO("%s, Fail to create UDP H264 TX session.", __func__);
+            delete st_ctx;
             return -1;
         }
         st_ctx->rx_udp_h264_session = rx_ctx;
@@ -871,6 +876,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         rx_ctx = mtl_st20p_rx_session_create(mDevHandle, &opts, &memif_ops);
         if (rx_ctx == NULL) {
             INFO("%s, Fail to create RX session.\n", __func__);
+            delete st_ctx;
             return -1;
         }
 
@@ -933,6 +939,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         tx_ctx = mtl_st22p_tx_session_create(mDevHandle, &opts, &memif_ops);
         if (tx_ctx == NULL) {
             INFO("%s, Fail to create TX session.", __func__);
+            delete st_ctx;
             return -1;
         }
 
@@ -947,6 +954,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         tx_ctx = mtl_st30_tx_session_create(mDevHandle, &opts, &memif_ops);
         if (tx_ctx == NULL) {
             INFO("%s, Fail to create TX session.", __func__);
+            delete st_ctx;
             return -1;
         }
 
@@ -961,6 +969,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         tx_ctx = mtl_st40_tx_session_create(mDevHandle, &opts, &memif_ops);
         if (tx_ctx == NULL) {
             INFO("%s, Fail to create TX session.", __func__);
+            delete st_ctx;
             return -1;
         }
 
@@ -976,6 +985,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         tx_ctx = mtl_st20p_tx_session_create(mDevHandle, &opts, &memif_ops);
         if (tx_ctx == NULL) {
             INFO("%s, Fail to create TX session.", __func__);
+            delete st_ctx;
             return -1;
         }
 

--- a/media-proxy/src/udp_h264_rx_sample.c
+++ b/media-proxy/src/udp_h264_rx_sample.c
@@ -64,8 +64,8 @@ int rx_udp_h264_shm_init(rx_udp_h264_session_context_t* rx_ctx, memif_ops_t* mem
     /* unlink socket file */
     if (memif_ops->is_master && rx_ctx->memif_socket_args.path[0] != '@') {
         if (mkdir("/run/mcm", 0666) != 0) {
-            if(errno != EEXIST) {
-                perror("Fail to access or create directory (/run/mcm) for MemIF.");
+            if (errno != EEXIST) {
+                ERROR("Fail to access or create directory (/run/mcm) for MemIF.");
                 return -1;
             }
         }

--- a/media-proxy/src/udp_h264_rx_sample.c
+++ b/media-proxy/src/udp_h264_rx_sample.c
@@ -150,7 +150,8 @@ static int udp_server_h264(void* arg)
         ssize_t recv = mudp_recvfrom(socket, buf, sizeof(buf), 0, NULL, NULL);
         // printf("[%s] : recv = %d\n", __FUNCTION__, (int)recv);
         if (recv < 0) {
-            //INFO("%s, mudp_recvfrom fail %d\n", __func__, (int)recv);
+            ERROR("%s, mudp_recvfrom fail %d\n", __func__, (int)recv);
+            free(rtp_header);
             return 0;
         }
         if (s->check_first_new_NALU == true) {
@@ -160,10 +161,9 @@ static int udp_server_h264(void* arg)
                 s->new_NALU = 1;
                 // printf("First Mark = %d\n", mark);
                 s->check_first_new_NALU = false;
-                return 0;
-            } else {
-                return 0;
             }
+            free(rtp_header);
+            return 0;
         }
 
         if (s->fragments_bunch == true) {


### PR DESCRIPTION
High impact Coverity scan fixes that include:

- Buffer not NULL terminated, change `strncpy` method to safe equivalent `strlcpy`.
- Leaks of memory/pointers to system resources (CWE-404) fixed.
- Fixed functions with missing return values in some branches.
- Fixed the uses of an uninitialized variables (CWE-457)
- Minor other improvements and fixes