### PR TITLE
Cumulative Pre-Release Fixes Dockerfile oriented.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: 'Harden Runner'
-      uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
       with:
         egress-policy: audit
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 90
     steps:
     - name: 'Harden Runner'
-      uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
       with:
         egress-policy: audit
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Harden Runner'
-        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,7 +13,7 @@ jobs:
       name: Checkout code
       steps:
         - name: Harden Runner
-          uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+          uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
           with:
             egress-policy: audit
         - name: Checkout code

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: 'Harden Runner'
-      uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
       with:
         egress-policy: audit
 
@@ -77,7 +77,9 @@ jobs:
         key: ${{ steps.grpc-cache-restore.outputs.cache-primary-key }}
 
     - name: 'Install gRPC'
-      run: sudo cmake --install "${GRPC_DIR}/cmake/build"
+      run: |
+        sudo cmake --install "${GRPC_DIR}/cmake/build" && \
+        rm -rf "${GRPC_DIR}"
 
     - name: 'Build MCM SDK and Media Proxy'
       run: ./build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,20 @@
 [![BSD 3-Clause][license-img]][license]
 
 ## Table of Contents
-- [Introduction](#introduction)
-- [Media Proxy](#media-proxy)
-- [MCM SDK](#mcm-sdk)
-- [Getting Started](#getting-started)
-- [Usage](#usage)
-- [Known Issues](#known-issues)
-- [Support](#support)
+- [ Media Communications Mesh](#-media-communications-mesh)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Media Proxy](#media-proxy)
+    - [Key Features](#key-features)
+    - [MemIF](#memif)
+  - [MCM SDK](#mcm-sdk)
+  - [Getting Started](#getting-started)
+    - [Prerequisites](#prerequisites)
+    - [Basic Installation](#basic-installation)
+  - [Usage](#usage)
+  - [Known Issues](#known-issues)
+  - [Support](#support)
+  - [Note](#note)
 
 ## Introduction
 
@@ -45,6 +52,7 @@ Detailed information about MCM SDK can be found in [sdk](sdk) directory.
 ## Getting Started
 
 ### Prerequisites
+
 - Linux server (Intel Xeon processor recommended)
 - Network Interface Card (NIC) compatible with DPDK
 - Docker installed
@@ -60,22 +68,22 @@ Detailed information about MCM SDK can be found in [sdk](sdk) directory.
    $ git clone https://github.com/OpenVisualCloud/Media-Communications-Mesh.git
    ```
 
-2. Navigate to the Media Proxy directory
+2. **Navigate to the Media-Communications-Mesh directory**
     ```sh
     $ cd Media-Communications-Mesh
     ```
 
-3. Build the Media Proxy binary (run on Host)
+3. **Build the Media Proxy binary (run on Host)**
     ```sh
     $ ./build.sh
     ```
 
-4. Build the Media Proxy Docker image (run in Container)
+4. **Build the Media Proxy Docker image (run in Container)**
     ```sh
-    $ docker build -t media-proxy ./media-proxy
+    $ ./build_docker.sh
     ```
 
-By following these instructions, you'll be able to perform the basic installation of the Media Communications Mesh application.
+By following these instructions, you'll be able to perform the basic build and installation of the Media Communications Mesh application.
 
 ## Usage
 
@@ -105,6 +113,7 @@ Usage: media_proxy [OPTION]
 ```
 
 ## Known Issues
+
 - There is one bug with default docker.io package installation (version 20.10.25-0ubuntu1~22.04.2) with Ubuntu 22.04.3 LTS. The [`USER` command](https://github.com/moby/moby/issues/46355) and [`chown` command](https://github.com/moby/moby/issues/46161) don't work as expected. It's preferred to install docker-ce package following [instruction from docker community](https://docs.docker.com/engine/install/ubuntu/).
 
 - The Authentication function of the Media Proxy interfaces is currently missing. This feature is still under development, and the current implementation is weak in defending against network attacks.
@@ -122,6 +131,7 @@ Before submitting an issue, please check the existing documentation and discussi
 We are here to help, so don't hesitate to reach out if you need assistance.
 
 ## Note
+
 This project is under development.
 All source code and features on the main branch are for the purpose of testing or evaluation and not production ready.
 

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,21 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 #!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+
+set -eo pipefail
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/common.sh"
 
 # Set build type. ("Debug" or "Release")
 BUILD_TYPE="${BUILD_TYPE:-Release}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 
-cmake -B out -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .
-cmake --build out -j
+cmake -B "${SCRIPT_DIR}/out" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+    "${SCRIPT_DIR}"
+cmake --build "${SCRIPT_DIR}/out" -j
 
 # Install
-sudo cmake --install out
+run_as_root_user cmake --install "${SCRIPT_DIR}/out"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -5,6 +5,7 @@
 
 set -eo pipefail
 SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/common.sh"
 
 # Read proxy variables from env to pass them to the builder
 BUILD_ARGUMENTS=$(compgen -e | sed -nE '/_(proxy|PROXY)$/{s/^/--build-arg /;p}')

--- a/common.sh
+++ b/common.sh
@@ -143,7 +143,6 @@ function print_logo()
     logo_string="$(cat <<- EOF
 	.-----------------------------------------------------------.
 	|        *          .                    ..        .    *   |
-	|                      .             .     . :  .   .    .  |
 	|       .                         .   .  .  .   .           |
 	|                                    . .  *:. . .           |
 	|                             .  .   . .. .         .       |
@@ -156,10 +155,9 @@ function print_logo()
 	|        .  .  .    . ^                                     |
 	|       .  .. :.    . |             .               .       |
 	|.   ... .            |                                     |
-	| :.  . .   *.        |     .               .               |
-	| *.              We are here.                              |
+	| :.  . .   *.    We are here.              .               |
 	|   .               .             *.                        |
-	.---------------------------------------ascii-author-unknown.
+	.©-Intel-Corporation--------------------ascii-author-unknown.
 	=                                                           =
 	=        88                                  88             =
 	=        ""                ,d                88             =
@@ -169,9 +167,7 @@ function print_logo()
 	=        88  88       88   88    8PP"""""""  88             =
 	=        88  88       88   88,   "8b,   ,aa  88             =
 	=        88  88       88   "Y888  '"Ybbd8"'  88             =
-	=============================================================
-	=    Intel Technology Poland  2024:                         =
-	=            Network & Edge Group Visual Solutions          =
+	=                                                           =
 	=============================================================
 		EOF
     )"
@@ -216,8 +212,8 @@ function print_logo_sequence()
 
 function print_logo_anim()
 {
-    local number_of_sequences="${1:-2}"
-    local wait_between_frames="${2:-0}"
+    local number_of_sequences="${1:-3}"
+    local wait_between_frames="${2:-0.025}"
     clear
     for (( pt=0; pt<${number_of_sequences}; pt++ ))
     do

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+
+function message() {
+    local type=$1
+    shift
+    echo -e "$type: $*" >&2
+}
+
+function prompt() {
+    local PomptHBlue='\e[38;05;33m';
+    local PomptTBlue='\e[38;05;45m';
+    message "${PomptHBlue}INFO${PomptTBlue}" "$*\e[m"
+}
+
+function error() {
+    local ErrorHRed='\e[38;05;1m'
+    local PomptTBlue='\e[38;05;45m';
+    message "${ErrorHRed}ERROR${PomptTBlue}" "$*\e[m"
+}
+
+function warning() {
+    local WarningHPurple='\e[38;05;61m';
+    local PomptTBlue='\e[38;05;45m';
+    message "${WarningHPurple}WARN${PomptTBlue}" "$*\e[m"
+}
+
+function get_user_input_confirm() {
+    local confirm_default="${1:-0}"
+    shift
+    local confirm=""
+    local PomptHBlue='\e[38;05;33m';
+    local PomptTBlue='\e[38;05;45m';
+
+    prompt "$@"
+    echo -en "${PomptHBlue}CHOOSE:  YES / NO   (Y/N) [default: " >&2
+    [[ "$confirm_default" == "1" ]] && echo -en 'YES]: \e[m' >&2 || echo -en 'NO]: \e[m' >&2
+    read confirm
+    if [[ -z "$confirm" ]]
+    then
+        confirm="$confirm_default"
+    else
+        ( [[ $confirm == [yY] ]] || [[ $confirm == [yY][eE][sS] ]] ) && confirm="1" || confirm="0"
+    fi
+    echo "${confirm}"
+}
+
+function get_user_input_def_yes() {
+    get_user_input_confirm 1 "$@"
+}
+
+function get_user_input_def_no() {
+    get_user_input_confirm 0 "$@"
+}
+
+function get_filename() {
+    local path=$1
+    echo ${path##*/}
+}
+
+function get_dirname() {
+    local path=$1
+    echo "${path%/*}/"
+}
+
+function get_extension() {
+    local filename=$(get_filename $1)
+    echo "${filename#*.}"
+}
+
+function get_basename() {
+    local filename=$(get_filename $1)
+    echo "${filename%%.*}"
+}
+
+# Takes ID as first param and full path to output file as second for creating benchmark specific output file
+#  input: [path]/[file_base].[extension]
+# output: [path]/[file_base][id].[extension]
+function get_filepath_add_sufix() {
+    local file_sufix="${1}"
+    local file_path="${2}"
+    local dir_path=$(get_dirname "${filepath}")
+    local file_base=$(get_basename "${filepath}")
+    local file_ext=$(get_extension "${filepath}")
+    echo "${dir_path}${file_base}${sufix}.${file_ext}"
+}
+
+function run_as_root_user()
+{
+    CMD_TO_EVALUATE="$@"
+    if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+        eval "${CMD_TO_EVALUATE[@]}"
+    else
+        eval "sudo ${CMD_TO_EVALUATE[@]}" || echo 'Must be run as root. No sudo found.'
+    fi
+}
+
+function github_api_call() {
+    url=$1
+    shift
+    GITHUB_API_URL=https://api.github.com
+    INPUT_OWNER=$(echo "${url#"${GITHUB_API_URL}/repos/"}" | cut -f1 -d'/')
+    INPUT_REPO=$(echo "${url#"${GITHUB_API_URL}/repos/"}" | cut -f2 -d'/')
+    API_SUBPATH="${url#"${GITHUB_API_URL}/repos/${INPUT_OWNER}/${INPUT_REPO}/"}"
+    if [ -z "${INPUT_GITHUB_TOKEN}" ]; then
+        echo >&2 "Set the INPUT_GITHUB_TOKEN env variable first."
+        return
+    fi
+
+    echo >&2 "GITHUB_API_URL=$GITHUB_API_URL"
+    echo >&2 "INPUT_OWNER=$INPUT_OWNER"
+    echo >&2 "INPUT_REPO=$INPUT_REPO"
+    echo >&2 "API_SUBPATH=$API_SUBPATH"
+    echo >&2 "curl --fail-with-body -sSL \"${GITHUB_API_URL}/repos/${INPUT_OWNER}/${INPUT_REPO}/${API_SUBPATH}\" -H \"Authorization: Bearer ${INPUT_GITHUB_TOKEN}\" -H 'Accept: application/vnd.github.v3+json' -H 'Content-Type: application/json' $*"
+
+    if API_RESPONSE=$(curl --fail-with-body -sSL \
+        "${GITHUB_API_URL}/repos/${INPUT_OWNER}/${INPUT_REPO}/${API_SUBPATH}" \
+        -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+        -H 'Accept: application/vnd.github.v3+json' \
+        -H 'Content-Type: application/json' \
+        "$@")
+    then
+        echo "${API_RESPONSE}"
+    else
+        echo >&2 "GitHub API call failed."
+        echo >&2 "${API_RESPONSE}"
+        return
+    fi
+}
+
+function print_logo()
+{
+    if [[ -z "$blue_code" ]]
+    then
+        local blue_code=( 26 27 20 19 20 20 21 04 27 26 32 12 33 06 39 38 44 45 )
+    fi
+    local IFS
+	local logo_string
+    local colorized_logo_string
+    IFS=$'\n\t'
+    logo_string="$(cat <<- EOF
+	.-----------------------------------------------------------.
+	|        *          .                    ..        .    *   |
+	|                      .             .     . :  .   .    .  |
+	|       .                         .   .  .  .   .           |
+	|                                    . .  *:. . .           |
+	|                             .  .   . .. .         .       |
+	|                    .     . .  . ...    .    .             |
+	|  .              .  .  . .    . .  . .                     |
+	|                   .    .     . ...   ..   .       .       |
+	|            .  .    . *.   . .                             |
+	|                   :.  .           .                       |
+	|            .   .    .    .                                |
+	|        .  .  .    . ^                                     |
+	|       .  .. :.    . |             .               .       |
+	|.   ... .            |                                     |
+	| :.  . .   *.        |     .               .               |
+	| *.              We are here.                              |
+	|   .               .             *.                        |
+	.---------------------------------------ascii-author-unknown.
+	=                                                           =
+	=        88                                  88             =
+	=        ""                ,d                88             =
+	=        88                88                88             =
+	=        88  8b,dPPYba,  MM88MMM  ,adPPYba,  88             =
+	=        88  88P'   '"8a   88    a8P_____88  88             =
+	=        88  88       88   88    8PP"""""""  88             =
+	=        88  88       88   88,   "8b,   ,aa  88             =
+	=        88  88       88   "Y888  '"Ybbd8"'  88             =
+	=============================================================
+	=    Intel Technology Poland  2024:                         =
+	=            Network & Edge Group Visual Solutions          =
+	=============================================================
+		EOF
+    )"
+
+    colorized_logo_string=""
+    for (( i=0; i<${#logo_string}; i++ ))
+    do
+        colorized_logo_string+="\e[38;05;${blue_code[$(( (i-(i/64)*64)/4 ))]}m"
+        colorized_logo_string+="${logo_string:$i:1}"
+    done;
+    colorized_logo_string+='\e[m\n'
+
+    echo -e "$colorized_logo_string" >&2
+}
+
+function print_logo_sequence()
+{
+    local wait_between_frames="${1:-0}"
+    local wait_cmd=""
+    if [ ! "${wait_between_frames}" = "0" ]; then
+        wait_cmd="sleep ${wait_between_frames}"
+    fi
+
+    blue_code_fixed=( 26 27 20 19 20 20 21 04 27 26 32 12 33 06 39 38 44 45 )
+    size=${#blue_code_fixed[@]}
+    for (( move=0; move<size; move++ ))
+    do
+    	blue_code=()
+    	for (( i=move; i<size; i++ ))
+    	do
+    		blue_code+=("${blue_code_fixed[i]}")
+    	done
+    	for (( i=0; i<move; i++ ))
+    	do
+    		blue_code+=("${blue_code_fixed[i]}")
+    	done
+    	echo -en "\e[0;0H"
+    	print_logo
+        ${wait_cmd}
+    done;
+}
+
+function print_logo_anim()
+{
+    local number_of_sequences="${1:-2}"
+    local wait_between_frames="${2:-0}"
+    clear
+    for (( pt=0; pt<${number_of_sequences}; pt++ ))
+    do
+        print_logo_sequence ${wait_between_frames};
+    done
+}

--- a/ffmpeg-plugin/README.md
+++ b/ffmpeg-plugin/README.md
@@ -3,21 +3,25 @@
 ## Build
 
 ### Prerequitites
+
 Install dependencies and build MCM as described in the top level README.md, paragraph "Basic Installation".
 
 ### Build flow
 
 1. Clone the FFmpeg repository and apply MCM patches
+
    ```bash
    ./clone-and-patch-ffmpeg.sh
    ```
 
-1. Run the FFmpeg configuration tool
+2. Run the FFmpeg configuration tool
+
    ```bash
    ./configure-ffmpeg.sh
    ```
 
-1. Build and install FFmpeg with the MCM plugin
+3. Build and install FFmpeg with the MCM plugin
+
    ```bash
    ./build-ffmpeg.sh
    ```
@@ -30,29 +34,33 @@ TBD
 This test run demonstrates sending a video file from the 1st FFmpeg instance to the 2nd FFmpeg instance via MCM and then stream it to a remote machine via UDP.
 
 ### NIC setup
+
 TBD
 
 ### Receiver side setup
+
 1. Start media_proxy
    ```
    sudo media_proxy -d 0000:32:11.1 -i 192.168.96.2 -t 8002
    ```
-1. Start FFmpeg to receive frames from MCM and stream to a remote machine via UDP
+2. Start FFmpeg to receive frames from MCM and stream to a remote machine via UDP
    ```
    sudo MCM_MEDIA_PROXY_PORT=8002 ffmpeg -re -f mcm -frame_rate 24 -video_size nhd -pixel_format yuv422p10le -protocol_type auto -payload_type st20 -ip_addr 192.168.96.1 -port 9001 -i - -vcodec mpeg4 -f mpegts udp://<remote-ip>:<remote-port>
    ```
 
 ### Sender side setup
+
 1. Start media_proxy
    ```
    sudo media_proxy -d 0000:32:11.0 -i 192.168.96.1 -t 8001
    ```
-1. Start FFmpeg to stream a video file to the receiver via MCM
+2. Start FFmpeg to stream a video file to the receiver via MCM
    ```
    sudo MCM_MEDIA_PROXY_PORT=8001 ffmpeg -i <video-file-path> -f mcm -frame_rate 24 -video_size nhd -pixel_format yuv422p10le -protocol_type auto -payload_type st20 -ip_addr 192.168.96.2 -port 9001 -
    ```
 
 ### VLC player setup
+
 On the remote machine start the VLC player and open a network stream from the next URL:
 ```
 udp://@:1234

--- a/ffmpeg-plugin/build-ffmpeg.sh
+++ b/ffmpeg-plugin/build-ffmpeg.sh
@@ -3,13 +3,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2024 Intel Corporation
 
-set -e
+set -eo pipefail
 
-cd FFmpeg
-cp -f ../mcm_* ./libavdevice/
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/../common.sh"
 
-make -j "$(nproc)"
-sudo make install
-cd ..
+cp -f "${SCRIPT_DIR}/mcm_"* "${SCRIPT_DIR}/FFmpeg/libavdevice/"
 
-echo "FFmpeg MCM plugin build completed"
+make -C "${SCRIPT_DIR}/FFmpeg" -j "$(nproc)"
+run_as_root_user make -C "${SCRIPT_DIR}/FFmpeg" install
+
+prompt "FFmpeg MCM plugin build completed."
+prompt "\t${SCRIPT_DIR}/FFmpeg"

--- a/ffmpeg-plugin/clone-and-patch-ffmpeg.sh
+++ b/ffmpeg-plugin/clone-and-patch-ffmpeg.sh
@@ -3,20 +3,18 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2024 Intel Corporation
 
-set -e
+set -eo pipefail
 
-if [ -n "$1" ]; then
-	ffmpeg_ver=$1
-else
-	# default to latest 6.1
-	ffmpeg_ver=6.1
-fi
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/../common.sh"
 
-rm FFmpeg -rf
-git clone https://github.com/FFmpeg/FFmpeg.git
-cd FFmpeg
-git checkout release/"$ffmpeg_ver"
-git apply ../"$ffmpeg_ver"/*.patch
-cd ..
+# First parameter or default to latest 6.1
+ffmpeg_ver="${1:-6.1}"
 
-echo "FFmpeg $ffmpeg_ver cloned and patched successfully"
+rm -rf "${SCRIPT_DIR}/FFmpeg"
+git clone https://github.com/FFmpeg/FFmpeg.git "${SCRIPT_DIR}/FFmpeg"
+git -C "${SCRIPT_DIR}/FFmpeg" checkout release/"${ffmpeg_ver}"
+git -C "${SCRIPT_DIR}/FFmpeg" apply "${SCRIPT_DIR}/${ffmpeg_ver}/"*.patch
+
+prompt "FFmpeg ${ffmpeg_ver} cloned and patched successfully."
+prompt "\t${SCRIPT_DIR}/FFmpeg"

--- a/ffmpeg-plugin/configure-ffmpeg.sh
+++ b/ffmpeg-plugin/configure-ffmpeg.sh
@@ -3,16 +3,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2024 Intel Corporation
 
-set -e
+set -eo pipefail
 
-cd FFmpeg
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-pkg-config --exists --print-errors libmcm_dp
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/../common.sh"
+
+cd "${SCRIPT_DIR}/FFmpeg"
+PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" pkg-config --exists --print-errors libmcm_dp
 
 # copy source files to allow the configure tool to find them
 #cp -f ../mcm_* ./libavdevice/
 
-./configure --enable-shared --enable-mcm $@
-cd ..
+"${SCRIPT_DIR}/FFmpeg/configure" --enable-shared --enable-mcm $@
+cd "${OLDPWD}"
 
-echo "FFmpeg MCM plugin configuration completed"
+prompt "FFmpeg MCM plugin configuration completed."
+prompt "\t${SCRIPT_DIR}/FFmpeg"

--- a/media-proxy/CMakeLists.txt
+++ b/media-proxy/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -27,8 +27,7 @@ SHELL ["/bin/bash", "-ex", "-o", "pipefail", "-c"]
 RUN apt-get update --fix-missing && \
     apt-get full-upgrade -y && \
     apt-get install --no-install-recommends -y \
-        sudo \
-        nasm cmake libbsd-dev git build-essential \
+        sudo nasm cmake libbsd-dev git build-essential \
         meson python3 python3-pyelftools pkg-config \
         libnuma-dev libjson-c-dev libpcap-dev libgtest-dev \
         libsdl2-dev libsdl2-ttf-dev libssl-dev ca-certificates \

--- a/media-proxy/build.sh
+++ b/media-proxy/build.sh
@@ -1,14 +1,21 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 #!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+
+set -eo pipefail
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/../common.sh"
 
 # Set build type. ("Debug" or "Release")
 BUILD_TYPE="${BUILD_TYPE:-Release}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 
-cmake -B out -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .
-cmake --build out -j
+cmake -B "${SCRIPT_DIR}/out" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+    "${SCRIPT_DIR}"
+cmake --build "${SCRIPT_DIR}/out" -j
 
 # Install
-sudo cmake --install out
+run_as_root_user cmake --install "${SCRIPT_DIR}/out"

--- a/media-proxy/include/api_server_grpc.h
+++ b/media-proxy/include/api_server_grpc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/include/api_server_tcp.h
+++ b/media-proxy/include/api_server_tcp.h
@@ -1,8 +1,7 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
- *
  * SPDX-License-Identifier: BSD-3-Clause
- */
+*/
 
 #pragma once
 #include "proxy_context.h"

--- a/media-proxy/include/api_server_tcp.h
+++ b/media-proxy/include/api_server_tcp.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/media-proxy/include/app_platform.h
+++ b/media-proxy/include/app_platform.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/include/mtl.h
+++ b/media-proxy/include/mtl.h
@@ -51,7 +51,7 @@ typedef struct {
     char interface_name[32];
     uint32_t interface_id;
     char socket_path[108];
-    uint32_t msessioncount;
+    uint32_t m_session_count;
 } memif_ops_t;
 
 typedef struct {

--- a/media-proxy/include/mtl.h
+++ b/media-proxy/include/mtl.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/include/proxy_context.h
+++ b/media-proxy/include/proxy_context.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/media-proxy/include/proxy_context.h
+++ b/media-proxy/include/proxy_context.h
@@ -39,14 +39,13 @@ public:
     std::vector<mtl_session_context_t*> mStCtx;
     std::vector<rx_session_context_t*> mRxCtx;
     std::vector<tx_session_context_t*> mTxCtx;
-    std::atomic<std::uint32_t> mSessionCount;
     mtl_handle mDevHandle = NULL;
+
     /*udp pool*/
     mtl_sch_handle schs[SCH_CNT];
     bool schs_ready;
     bool imtl_init_preparing;
     pthread_mutex_t mutex_lock;
-    pthread_mutex_t sessioncount_mutex_lock;
 
     std::string mDevPort;
     std::string mDpAddress;
@@ -94,4 +93,12 @@ public:
     void TxStop(const int32_t session_id);
     void RxStop(const int32_t session_id);
     void Stop();
+
+private:
+    std::atomic<std::uint32_t> mSessionCount;
+    pthread_mutex_t sessions_count_mutex_lock;
+
+    ProxyContext(const ProxyContext&) = delete;
+    ProxyContext& operator=(const ProxyContext&) = delete;
+    uint32_t incrementMSessionCount(bool postIncrement);
 };

--- a/media-proxy/include/proxy_context.h
+++ b/media-proxy/include/proxy_context.h
@@ -1,12 +1,12 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
- *
  * SPDX-License-Identifier: BSD-3-Clause
- */
+*/
 
 #include <atomic>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "controller.grpc.pb.h"
@@ -28,6 +28,7 @@ using controller::TxControlRequest;
 class ProxyContext {
 public:
     std::string mRpcCtrlAddr;
+    int mRpcCtrlPort;
 
     std::string mTcpCtrlAddr;
     int mTcpCtrlPort;
@@ -52,13 +53,13 @@ public:
     std::string mDpPort;
 
     ProxyContext(void);
-    ProxyContext(std::string rpc_addr, std::string tcp_addr);
+    ProxyContext(std::string_view rpc_addr, std::string_view tcp_addr);
 
-    void setRPCListenAddress(std::string addr);
-    void setTCPListenAddress(std::string addr);
-    void setDevicePort(std::string dev);
-    void setDataPlaneAddress(std::string ip);
-    void setDataPlanePort(std::string port);
+    void setRPCListenAddress(std::string_view addr);
+    void setTCPListenAddress(std::string_view addr);
+    void setDevicePort(std::string_view dev);
+    void setDataPlaneAddress(std::string_view ip);
+    void setDataPlanePort(std::string_view port);
 
     std::string getDevicePort(void);
     std::string getDataPlaneAddress(void);

--- a/media-proxy/include/shm_memif.h
+++ b/media-proxy/include/shm_memif.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/include/utils.h
+++ b/media-proxy/include/utils.h
@@ -20,8 +20,10 @@
         printf("\n");                  \
     } while (0)
 
-#define DEBUG(...) \
-    do {           \
+#define DEBUG(...)                     \
+    do {                               \
+        printf("DEBUG: " __VA_ARGS__); \
+        printf("\n");                  \
     } while (0)
 
 #endif

--- a/media-proxy/include/utils.h
+++ b/media-proxy/include/utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/protos/controller.proto
+++ b/media-proxy/protos/controller.proto
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/api_server_grpc.cc
+++ b/media-proxy/src/api_server_grpc.cc
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/api_server_tcp.cc
+++ b/media-proxy/src/api_server_tcp.cc
@@ -234,6 +234,19 @@ void* msg_loop(void* ptr)
         (int)((addr)&0xff), (int)((addr >> 8) & 0xff),
         (int)((addr >> 16) & 0xff), (int)((addr >> 24) & 0xff));
 
+    if(session_id > 0) {
+        for (auto it : proxy_ctx->mStCtx) {
+            if (it->id == session_id) {
+                if (it->type == TX) {
+                    proxy_ctx->TxStop(session_id);
+                } else {
+                    proxy_ctx->RxStop(session_id);
+                }
+                break;
+            }
+        }
+    }
+
     /* Clean-up all sessions. */
     // for (auto it : proxy_ctx->mStCtx) {
     //     if (it->type == TX) {

--- a/media-proxy/src/api_server_tcp.cc
+++ b/media-proxy/src/api_server_tcp.cc
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
 */
 
@@ -247,15 +247,6 @@ void* msg_loop(void* ptr)
         }
     }
 
-    /* Clean-up all sessions. */
-    // for (auto it : proxy_ctx->mStCtx) {
-    //     if (it->type == TX) {
-    //         proxy_ctx->TxStop(it->id);
-    //     } else {
-    //         proxy_ctx->RxStop(it->id);
-    //     }
-    // }
-
     /* close socket and clean up */
     close(conn->sock);
     free(conn);
@@ -267,6 +258,7 @@ void* msg_loop(void* ptr)
 void handleSignals(int sig_num)
 {
     keepRunning = false;
+    exit(0);
 }
 
 void registerSignals()

--- a/media-proxy/src/api_server_tcp.cc
+++ b/media-proxy/src/api_server_tcp.cc
@@ -53,12 +53,12 @@ void* msg_loop(void* ptr)
             break;
         }
 
-        if (strncmp(msg.header.magic_word, "MCM", sizeof(msg.header.magic_word)) != 0) {
-            INFO("Failed to read header MCM.\n");
+        if (msg.header.magic_word != *(uint32_t*)HEADER_MAGIC_WORD) {
+            ERROR("Header Data Mismatch: Incorrect magic word.");
             continue;
         }
-        if (msg.header.version != 0x01) {
-            INFO("Failed to read header version.\n");
+        if (msg.header.version != HEADER_VERSION) {
+            ERROR("Header Data Mismatch: Incorrect version of client.");
             continue;
         }
 

--- a/media-proxy/src/media_proxy.cc
+++ b/media-proxy/src/media_proxy.cc
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/mtl.c
+++ b/media-proxy/src/mtl.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/shm_memif_common.c
+++ b/media-proxy/src/shm_memif_common.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/shm_memif_st20.c
+++ b/media-proxy/src/shm_memif_st20.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/shm_memif_st22.c
+++ b/media-proxy/src/shm_memif_st22.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/shm_memif_st30.c
+++ b/media-proxy/src/shm_memif_st30.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/shm_memif_st40.c
+++ b/media-proxy/src/shm_memif_st40.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/shm_memif_udp.c
+++ b/media-proxy/src/shm_memif_udp.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/src/udp_h264_rx_sample.c
+++ b/media-proxy/src/udp_h264_rx_sample.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/tests/build.sh
+++ b/media-proxy/tests/build.sh
@@ -1,8 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 #!/bin/bash -x
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
 
 # compile tests
 # -DMEMIF_DBG_SHM

--- a/media-proxy/tests/common.h
+++ b/media-proxy/tests/common.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/tests/ffmpeg_test.sh
+++ b/media-proxy/tests/ffmpeg_test.sh
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
-#
+#!/bin/bash -x
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # generate test source

--- a/media-proxy/tests/memif_test_rx.c
+++ b/media-proxy/tests/memif_test_rx.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/media-proxy/tests/memif_test_tx.c
+++ b/media-proxy/tests/memif_test_tx.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 ARG IMAGE_CACHE_REGISTRY=docker.io

--- a/sdk/build.sh
+++ b/sdk/build.sh
@@ -1,14 +1,21 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 #!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+
+set -eo pipefail
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/../common.sh"
 
 # Set build type. ("Debug" or "Release")
 BUILD_TYPE="${BUILD_TYPE:-Release}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 
-cmake -B out -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .
-cmake --build out -j
+cmake -B "${SCRIPT_DIR}/out" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+    "${SCRIPT_DIR}"
+cmake --build "${SCRIPT_DIR}/out" -j
 
 # Install
-sudo cmake --install out
+run_as_root_user cmake --install "${SCRIPT_DIR}/out"

--- a/sdk/cmake/compile_options.cmake
+++ b/sdk/cmake/compile_options.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/sdk/include/logger.h
+++ b/sdk/include/logger.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/include/logger.h
+++ b/sdk/include/logger.h
@@ -26,7 +26,8 @@
           logmsg("DEBUG", fmt, ##__VA_ARGS__); \
       } while (0)
 #else
-  #define log_debug(fmt, ...)  // Define log_debug as empty in release build
+  // Define log_debug as empty in release build
+  #define log_debug(fmt, ...)
 #endif
 
 #define log_warn(fmt, ...)                  \

--- a/sdk/include/mcm_dp.h
+++ b/sdk/include/mcm_dp.h
@@ -24,8 +24,15 @@ extern "C" {
 #define MCM_QUERY_MEMIF_ID 4
 #define MCM_QUERY_MEMIF_PARAM 5
 
+// Media proxy magic_word and version
+// 4 letters can be casted to numerical value in code:
+#ifndef HEADER_MAGIC_WORD
+    #define HEADER_MAGIC_WORD "mcm"
+    #define HEADER_VERSION 0x10
+#endif
+
 typedef struct _msg_header {
-    char magic_word[3];
+    uint32_t magic_word;
     uint8_t version;
 } msg_header;
 

--- a/sdk/include/mcm_dp.h
+++ b/sdk/include/mcm_dp.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/include/media_proxy_ctrl.h
+++ b/sdk/include/media_proxy_ctrl.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/include/memif_impl.h
+++ b/sdk/include/memif_impl.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/include/udp_impl.h
+++ b/sdk/include/udp_impl.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/samples/CMakeLists.txt
+++ b/sdk/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/sdk/samples/recver_app.c
+++ b/sdk/samples/recver_app.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/samples/rtsp_recver_app.c
+++ b/sdk/samples/rtsp_recver_app.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/samples/sender_app.c
+++ b/sdk/samples/sender_app.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/src/mcm_dp.c
+++ b/sdk/src/mcm_dp.c
@@ -140,7 +140,7 @@ mcm_conn_context* mcm_create_connection(mcm_conn_param* param)
         conn_ctx->proto = PROTO_UDP;
         conn_ctx->priv = (void*)p_ctx;
         break;
-    case PROTO_MEMIF:;
+    case PROTO_MEMIF:
         memif_conn_param memif_param = {};
         parse_memif_param(param, &(memif_param.socket_args), &(memif_param.conn_args));
         /* Connect memif connection. */

--- a/sdk/src/mcm_dp.c
+++ b/sdk/src/mcm_dp.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/src/media_proxy_ctrl.c
+++ b/sdk/src/media_proxy_ctrl.c
@@ -87,10 +87,8 @@ int media_proxy_create_session(int sockfd, mcm_conn_param* param, uint32_t* sess
     }
 
     /* intialize message header. */
-    msg.header.magic_word[0] = 'M';
-    msg.header.magic_word[1] = 'C';
-    msg.header.magic_word[2] = 'M';
-    msg.header.version = 0x01;
+    msg.header.magic_word = *(uint32_t*)HEADER_MAGIC_WORD;
+    msg.header.version = HEADER_VERSION;
 
     msg.command.inst = MCM_CREATE_SESSION;
     msg.command.data_len = sizeof(mcm_conn_param);
@@ -137,10 +135,8 @@ int media_proxy_query_interface(int sockfd, uint32_t session_id, mcm_conn_param*
     }
 
     /* intialize message header. */
-    msg.header.magic_word[0] = 'M';
-    msg.header.magic_word[1] = 'C';
-    msg.header.magic_word[2] = 'M';
-    msg.header.version = 0x01;
+    msg.header.magic_word = *(uint32_t*)HEADER_MAGIC_WORD;
+    msg.header.version = HEADER_VERSION;
 
     /* memif parameters */
     msg.command.inst = MCM_QUERY_MEMIF_PARAM;
@@ -190,10 +186,8 @@ void media_proxy_destroy_session(mcm_conn_context* pctx)
     session_id = pctx->session_id;
 
     /* intialize message header. */
-    msg.header.magic_word[0] = 'M';
-    msg.header.magic_word[1] = 'C';
-    msg.header.magic_word[2] = 'M';
-    msg.header.version = 0x01;
+    msg.header.magic_word = *(uint32_t*)HEADER_MAGIC_WORD;
+    msg.header.version = HEADER_VERSION;
 
     msg.command.inst = MCM_DESTROY_SESSION;
     msg.command.data_len = sizeof(session_id);

--- a/sdk/src/media_proxy_ctrl.c
+++ b/sdk/src/media_proxy_ctrl.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/src/memif_impl.c
+++ b/sdk/src/memif_impl.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/src/udp_impl.c
+++ b/sdk/src/udp_impl.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sdk/tests/test_log.c
+++ b/sdk/tests/test_log.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */


### PR DESCRIPTION
### **THIS PR CONTAINS BREAKING CHANGES:**

[Common methods and scripting improved](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/e58edd8ac3ef46d05caddc2d706e2c6bf8b6b6ed) 

Common methods and scripting improved:
- added file `common.sh` in root repository directory with some of commonly used functions.
- added fail on error in every bash script, including pipe fail
- improved scripting by usage of absolute paths instead of relative ones (any directory removal with relative paths can have unexpected behavior)
- fixed bash script files with `#!/bin/bash` not in first line.

Also `build_docker.sh` file was added with basic workflow of building media-proxy Dockerfile with the same approach as mentioned above.
- build docker files using buildx toolkit
- read and pass possible proxy variables from environment

[Markdown and .gitignore files minor fixes](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/d8132eacfe3dde39c598a7496c679beafcbbf5a5) 

Markdown and `.gitignore` files minor fixes
- added proto files generated by `gRPC` to Git-Ignore
- added Microsoft VS-Code configuration files to Git-Ignore
- adjusted markdown files to GitHub standard
- minor fixes in readme text

[Header definition and msg_header simplification](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/08505bf4ff5436be47fd81b395472e0d9a7ada47) 

**THIS COMMIT CONTAINS BREAKING CHANGES:**
Header definition and `msg_header` simplification
- moved `magic_word` declaration outside to top-level include file HEADER_MAGIC_WORD
- changed type definition for magic word from `char` to `uint32_t` as for up to 4 letters this simplifies the flow.
- proposed workflow is compliant with the C++11 and all newer standards.
- casting example: `uint32_t res = *(uint32_t*)"MCM"`

[Debug added and minor code simplifications](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/0618d001069db4440ffe35752b0838dceb8f6605) 

Debug added and minor code simplifications
- added definition for DEBUG printing function
- fixed SDK logger header format issue
- fixed PROTO_MEMIF case - removed `;` after colon.
- extended debug information by adding methods name with variables
- removed infinity loops that could occur when waiting for non null variable like `deviceHandle`

[Partial Migration to C++17 for class ProxyContext](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/0f14002ad4bb38d0ccb0ceb61ccbfe1b031b85c5) 

Partial migration to C++17 for class `ProxyContext`
- changed all std::string copy methods to `std::string_view` (no copy parameter)
- removed old-fashioned ineffective methods for string operations from class file and constructor
- removed try{} catch{} from `ProxyContext` constructor as it could cause undefined behavior. Application should simply fail when main class constructor can not be initialized.
- added simple signal handling for the `TcpServer` for it to close threads when asked.
- redesigned main loop for `TcpServer` in more non-fail oriented way to allow for easy loop break when needed.

[Major Dockerfile changes and IMTL update](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/88e2dc824e090202920a369fe9482bb6c0190ed1) 

Major Dockerfile changes and IMTL update:
Due to workflow and default values changes in the IMTL workflow, the `Dockerfile` had to be adopted. This includes fixes to DPDK drivers build process, IMTL build and usage of XDP repository.

Also minor changes like syntax versioning usage were also included:
`# syntax=docker/dockerfile:1`

[[msg_loop] Thread clean-up on exit](https://github.com/OpenVisualCloud/Media-Communications-Mesh/pull/127/commits/ecf5483be25730d85a3dce336b263e0df60f2e55)

[msg_loop] Thread clean-up on exit.
On msg_loop exit, the thread that is exiting tries to do a cleanup based on session_id (value moved to the method scope so can be reused). This includes going through all `mtl_session_context_t` for running context (server) and checking the id.

Minor updates to common.sh:
- Removed non global text from Intel animated bash logo
- Made the logo little smaller and left only the one-liner description `Intel-Corporation`
- Adjustment to render and animation speed.

To use the animated logo, user should just type in his bash console:
(third line is an example, with all possible params (2), first is number of full sequences and second is a delay between steps:
```bash
. common.sh
print_logo_anim
print_logo_anim 3 0.025
```

[mSessionCount multisession bug fix](https://github.com/OpenVisualCloud/Media-Communications-Mesh/pull/127/commits/c024701a2c0f27f8876a0b6edfbf689040984a1b) 

`mSessionCount` multisession bug fix:
- moved `mSessionCount` and mutex to private part of `ProxyContext` class.
- added method for safe increment of mSessionCount value.
- minor fix to constructor - `mTcpCtrlPort` condition.
- minor name refactor for `memif_ops_t`.
- explicit copy and assign constructor deletion for `ProxyContext`.

Signed-off-by: Milosz Linkiewicz <milosz.linkiewicz@intel.com>
@[Mionsz](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commits?author=Mionsz)

