### PR TITLE
FFmpeg fix for default yuv422p10le pixel format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ out
 
 # for debug dump
 dump_*
+.vscode/
+media-proxy/protos/controller.grpc.pb.cc
+media-proxy/protos/controller.grpc.pb.h
+media-proxy/protos/controller.pb.cc
+media-proxy/protos/controller.pb.h

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,16 @@ out
 
 # for debug dump
 dump_*
-.vscode/
+
+# for gRPC protos
 media-proxy/protos/controller.grpc.pb.cc
 media-proxy/protos/controller.grpc.pb.h
 media-proxy/protos/controller.pb.cc
 media-proxy/protos/controller.pb.h
+
+# for VS Code settings
+.vscode/c_cpp_properties.json
+.vscode/settings.json
+
+# For FFmpeg plugin
+ffmpeg-plugin/FFmpeg/

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -9,4 +9,10 @@ SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
 # Read proxy variables from env to pass them to the builder
 BUILD_ARGUMENTS=$(compgen -e | sed -nE '/_(proxy|PROXY)$/{s/^/--build-arg /;p}')
 
-docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} -f "${SCRIPT_DIR}/ffmpeg-plugin/Dockerfile" $@ "${SCRIPT_DIR}"
+IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY:-docker.io}"
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/ffmpeg:${IMAGE_TAG}" -f "${SCRIPT_DIR}/ffmpeg-plugin/Dockerfile" $@ "${SCRIPT_DIR}"
+docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/sdk:${IMAGE_TAG}" -f "${SCRIPT_DIR}/sdk/Dockerfile" $@ "${SCRIPT_DIR}"
+docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/media-proxy:${IMAGE_TAG}" -f "${SCRIPT_DIR}/media-proxy/Dockerfile" $@ "${SCRIPT_DIR}"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+
+set -eo pipefail
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+
+# Read proxy variables from env to pass them to the builder
+BUILD_ARGUMENTS=$(compgen -e | sed -nE '/_(proxy|PROXY)$/{s/^/--build-arg /;p}')
+
+docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} -f "${SCRIPT_DIR}/ffmpeg-plugin/Dockerfile" $@ "${SCRIPT_DIR}"

--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -37,10 +37,11 @@ ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® MCM FFmpeg" \
-      org.opencontainers.image.description="Intel® MCM FFmpeg with MCM-Muxer and MCM-Demuxer Ubuntu 22.04 Docker Release Image" \
+LABEL org.opencontainers.image.title="Intel® Media Communication Mesh FFmpeg" \
+      org.opencontainers.image.description="Intel® Media Communication Mesh FFmpeg with MCM-Muxer and MCM-Demuxer plugins. Ubuntu 22.04 Docker Release Image." \
       org.opencontainers.image.version="1.0.0" \
-      org.opencontainers.image.vendor="Intel"
+      org.opencontainers.image.vendor="Intel Corporation" \
+      org.opencontainers.image.licenses="BSD 3-Clause License"
 
 ARG HOME="/home/${USER}"
 ARG MCM_DIR=/opt/mcm

--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -3,7 +3,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2 as builder
+ARG IMAGE_CACHE_REGISTRY=docker.io
+ARG IMAGE_NAME=library/ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
+
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
@@ -12,12 +15,11 @@ ARG MCM_DIR=/opt/mcm
 ARG PREFIX_DIR="/usr/local"
 
 SHELL ["/bin/bash", "-exc"]
-# To be removed after fixes are merged: sudo
 RUN apt-get update && \
     apt-get full-upgrade -y && \
     apt-get install --no-install-recommends -y \
         sudo \
-        apt-utils build-essential make cmake git ca-certificates pkg-config nasm libbsd-dev && \
+        apt-utils build-essential make cmake git ca-certificates pkg-config nasm libbsd-dev libx264-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -27,10 +29,12 @@ RUN ./build.sh
 
 WORKDIR ${MCM_DIR}/ffmpeg-plugin
 RUN ./clone-and-patch-ffmpeg.sh && \
-    ./configure-ffmpeg.sh && \
+    ./configure-ffmpeg.sh --enable-libx264 --enable-gpl && \
     ./build-ffmpeg.sh
 
-FROM ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
+ARG IMAGE_CACHE_REGISTRY
+ARG IMAGE_NAME
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
 LABEL org.opencontainers.image.title="Intel® MCM FFmpeg" \
@@ -51,7 +55,7 @@ SHELL ["/bin/bash", "-exc"]
 RUN apt-get update && \
     apt-get full-upgrade -y && \
     apt-get install --no-install-recommends -y \
-        libbsd0 vim net-tools ca-certificates sudo && \
+        libbsd0 vim net-tools ca-certificates sudo libx264-163 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 2110 vfio && \

--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1
+
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+FROM ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2 as builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Warsaw
+
+ARG MCM_DIR=/opt/mcm
+ARG PREFIX_DIR="/usr/local"
+
+SHELL ["/bin/bash", "-exc"]
+# To be removed after fixes are merged: sudo
+RUN apt-get update && \
+    apt-get full-upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        sudo \
+        apt-utils build-essential make cmake git ca-certificates pkg-config nasm libbsd-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . ${MCM_DIR}
+WORKDIR ${MCM_DIR}/sdk
+RUN ./build.sh
+
+WORKDIR ${MCM_DIR}/ffmpeg-plugin
+RUN ./clone-and-patch-ffmpeg.sh && \
+    ./configure-ffmpeg.sh && \
+    ./build-ffmpeg.sh
+
+FROM ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
+
+LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL org.opencontainers.image.title="Intel® MCM FFmpeg" \
+      org.opencontainers.image.description="Intel® MCM FFmpeg with MCM-Muxer and MCM-Demuxer Ubuntu 22.04 Docker Release Image" \
+      org.opencontainers.image.version="1.0.0" \
+      org.opencontainers.image.vendor="Intel"
+
+ARG HOME="/home/${USER}"
+ARG MCM_DIR=/opt/mcm
+ARG PREFIX_DIR="/usr/local"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Warsaw
+ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
+
+SHELL ["/bin/bash", "-exc"]
+RUN apt-get update && \
+    apt-get full-upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        libbsd0 vim net-tools ca-certificates sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 2110 vfio && \
+    useradd -m -s /bin/bash -G vfio -u 1002 mcm && \
+    usermod -aG sudo mcm
+
+COPY --chown=mcm --from=builder ${MCM_DIR}/sdk/out/samples /opt/mcm/
+COPY --chown=mcm --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
+
+RUN ldconfig
+
+USER mcm
+WORKDIR /opt/mcm/
+
+CMD ["ffmpeg"]

--- a/ffmpeg-plugin/README.md
+++ b/ffmpeg-plugin/README.md
@@ -39,7 +39,7 @@ TBD
    ```
 1. Start FFmpeg to receive frames from MCM and stream to a remote machine via UDP
    ```
-   sudo MCM_MEDIA_PROXY_PORT=8002 ffmpeg -re -f mcm -frame_rate 24 -video_size nhd -pixel_format yuv420p -protocol_type auto -payload_type st20 -ip_addr 192.168.96.1 -port 9001 -i - -vcodec mpeg4 -f mpegts udp://<remote-ip>:<remote-port>
+   sudo MCM_MEDIA_PROXY_PORT=8002 ffmpeg -re -f mcm -frame_rate 24 -video_size nhd -pixel_format yuv422p10le -protocol_type auto -payload_type st20 -ip_addr 192.168.96.1 -port 9001 -i - -vcodec mpeg4 -f mpegts udp://<remote-ip>:<remote-port>
    ```
 
 ### Sender side setup
@@ -49,7 +49,7 @@ TBD
    ```
 1. Start FFmpeg to stream a video file to the receiver via MCM
    ```
-   sudo MCM_MEDIA_PROXY_PORT=8001 ffmpeg -i <video-file-path> -f mcm -frame_rate 24 -video_size nhd -pixel_format yuv420p -protocol_type auto -payload_type st20 -ip_addr 192.168.96.2 -port 9001 -
+   sudo MCM_MEDIA_PROXY_PORT=8001 ffmpeg -i <video-file-path> -f mcm -frame_rate 24 -video_size nhd -pixel_format yuv422p10le -protocol_type auto -payload_type st20 -ip_addr 192.168.96.2 -port 9001 -
    ```
 
 ### VLC player setup

--- a/ffmpeg-plugin/README.md
+++ b/ffmpeg-plugin/README.md
@@ -58,3 +58,29 @@ On the remote machine start the VLC player and open a network stream from the ne
 udp://@:1234
 ```
 
+## Known Issues
+
+### Shared libraries error:
+FFmpeg build was successful but trying to run `ffmpeg` results in shared libraries error:
+```
+root@my-machine:~# ffmpeg
+
+ffmpeg: error while loading shared libraries: libavfilter.so.9: cannot open shared object file: No such file or directory
+```
+
+**Resolution:**
+Try running ffmpeg or exporting the `LD_LIBRARY_PATH` in your shell session by pointing to the `/usr/local/lib` folder. Examples:
+```
+root@my-machine:~# LD_LIBRARY_PATH=/usr/local/lib ffmpeg
+
+ffmpeg version n6.1.1-152-ge821e6c21d Copyright (c) 2000-2023 the FFmpeg developers
+  built with gcc 11 (Ubuntu 11.4.0-1ubuntu1~22.04)
+```
+Using export:
+```
+root@my-machine:~# export LD_LIBRARY_PATH=/usr/local/lib
+root@my-machine:~# ffmpeg
+
+ffmpeg version n6.1.1-152-ge821e6c21d Copyright (c) 2000-2023 the FFmpeg developers
+  built with gcc 11 (Ubuntu 11.4.0-1ubuntu1~22.04)
+```

--- a/ffmpeg-plugin/configure-ffmpeg.sh
+++ b/ffmpeg-plugin/configure-ffmpeg.sh
@@ -12,7 +12,7 @@ pkg-config --exists --print-errors libmcm_dp
 # copy source files to allow the configure tool to find them
 #cp -f ../mcm_* ./libavdevice/
 
-./configure --enable-shared --enable-mcm
+./configure --enable-shared --enable-mcm $@
 cd ..
 
 echo "FFmpeg MCM plugin configuration completed"

--- a/ffmpeg-plugin/mcm_rx.c
+++ b/ffmpeg-plugin/mcm_rx.c
@@ -36,9 +36,6 @@ static int getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height,
         case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY) */
             size = pixels * 2;
             break;
-        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
-            size = pixels * 2 * 2;
-            break;
         case PIX_FMT_RGB8:
             size = pixels * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
             break;
@@ -46,8 +43,11 @@ static int getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height,
 none-RFC4175 formats like I420/NV12. When this input/output format is set, the frame is identical to
 transport frame without conversion. The frame should not have lines padding) */
         case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
-        default:
             size = pixels * 3 / 2;
+            break;
+        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
+        default:
+            size = pixels * 2 * 2;
             break;
     }
     if (interlaced) size /= 2; /* if all fmt support interlace? */
@@ -127,11 +127,11 @@ static int mcm_read_header(AVFormatContext* avctx)
         param.payload_args.video_args.fps     = param.fps = av_q2d(s->frame_rate);
 
         switch (s->pixel_format) {
-        case AV_PIX_FMT_YUV422P10LE:
-            param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
         case AV_PIX_FMT_YUV420P:
-        default:
             param.pix_fmt = PIX_FMT_NV12;
+        case AV_PIX_FMT_YUV422P10LE:
+        default:
+            param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
         }
 
         param.payload_args.video_args.pix_fmt = param.pix_fmt;
@@ -223,7 +223,7 @@ static const AVOption mcm_rx_options[] = {
     { "payload_type", "set payload type", OFFSET(payload_type), AV_OPT_TYPE_STRING, {.str = "st20"}, .flags = DEC },
     { "protocol_type", "set protocol type", OFFSET(protocol_type), AV_OPT_TYPE_STRING, {.str = "auto"}, .flags = DEC },
     { "video_size", "set video frame size given a string such as 640x480 or hd720", OFFSET(width), AV_OPT_TYPE_IMAGE_SIZE, {.str = "1920x1080"}, 0, 0, DEC },
-    { "pixel_format", "set video pixel format", OFFSET(pixel_format), AV_OPT_TYPE_PIXEL_FMT, {.i64 = AV_PIX_FMT_YUV420P}, AV_PIX_FMT_NONE, INT_MAX, DEC },
+    { "pixel_format", "set video pixel format", OFFSET(pixel_format), AV_OPT_TYPE_PIXEL_FMT, {.i64 = AV_PIX_FMT_YUV422P10LE}, AV_PIX_FMT_NONE, INT_MAX, DEC },
     { "frame_rate", "set video frame rate", OFFSET(frame_rate), AV_OPT_TYPE_VIDEO_RATE, {.str = "25"}, 0, INT_MAX, DEC },
     { "socket_name", "set memif socket name", OFFSET(socket_name), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = DEC },
     { "interface_id", "set interface ID", OFFSET(interface_id), AV_OPT_TYPE_INT, {.i64 = 0}, -1, INT_MAX, DEC },

--- a/ffmpeg-plugin/mcm_rx.c
+++ b/ffmpeg-plugin/mcm_rx.c
@@ -25,7 +25,34 @@ typedef struct McmDemuxerContext {
 
     mcm_conn_context *rx_handle;
     bool first_frame;
+    int frame_size;
 } McmDemuxerContext;
+
+static int getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, bool interlaced)
+{
+    size_t size = 0;
+    size_t pixels = (size_t)(width*height);
+    switch (fmt) {
+        case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY) */
+            size = pixels * 2;
+            break;
+        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
+            size = pixels * 2 * 2;
+            break;
+        case PIX_FMT_RGB8:
+            size = pixels * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
+            break;
+/* Customized YUV 420 8bit, set transport format as ST20_FMT_YUV_420_8BIT. For direct transport of
+none-RFC4175 formats like I420/NV12. When this input/output format is set, the frame is identical to
+transport frame without conversion. The frame should not have lines padding) */
+        case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
+        default:
+            size = pixels * 3 / 2;
+            break;
+    }
+    if (interlaced) size /= 2; /* if all fmt support interlace? */
+    return (int)size;
+}
 
 static int mcm_read_header(AVFormatContext* avctx)
 {
@@ -100,6 +127,8 @@ static int mcm_read_header(AVFormatContext* avctx)
         param.payload_args.video_args.fps     = param.fps = av_q2d(s->frame_rate);
 
         switch (s->pixel_format) {
+        case AV_PIX_FMT_YUV422P10LE:
+            param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
         case AV_PIX_FMT_YUV420P:
         default:
             param.pix_fmt = PIX_FMT_NV12;
@@ -110,6 +139,12 @@ static int mcm_read_header(AVFormatContext* avctx)
     }
 
     param.type = is_rx;
+
+    s->frame_size = getFrameSize(param.pix_fmt, s->width, s->height, false);
+    if (s->frame_size <= 0) {
+        av_log(avctx, AV_LOG_ERROR, "calculate frame size failed\n");
+        return AVERROR(EIO);
+    }
 
     s->rx_handle = mcm_create_connection(&param);
     if (!s->rx_handle) {
@@ -144,7 +179,6 @@ static int mcm_read_packet(AVFormatContext* avctx, AVPacket* pkt)
     mcm_buffer *buf = NULL;
     int timeout = s->first_frame ? -1 : 1000;
     int err = 0;
-    int frame_size;
     int ret;
 
     s->first_frame = false;
@@ -158,12 +192,10 @@ static int mcm_read_packet(AVFormatContext* avctx, AVPacket* pkt)
         return AVERROR(EIO);
     }
 
-    frame_size = (s->width * s->height * 3)/2;
-
-    if ((ret = av_new_packet(pkt, frame_size)) < 0)
+    if ((ret = av_new_packet(pkt, s->frame_size)) < 0)
         return ret;
 
-    memcpy(pkt->data, buf->data, frame_size);
+    memcpy(pkt->data, buf->data, s->frame_size);
 
     pkt->pts = pkt->dts = AV_NOPTS_VALUE;
 
@@ -172,7 +204,7 @@ static int mcm_read_packet(AVFormatContext* avctx, AVPacket* pkt)
         return AVERROR(EIO);
     }
 
-    return frame_size;
+    return s->frame_size;
 }
 
 static int mcm_read_close(AVFormatContext* avctx)

--- a/ffmpeg-plugin/mcm_tx.c
+++ b/ffmpeg-plugin/mcm_tx.c
@@ -161,7 +161,7 @@ static const AVOption mcm_tx_options[] = {
     { "payload_type", "set payload type", OFFSET(payload_type), AV_OPT_TYPE_STRING, {.str = "st20"}, .flags = ENC },
     { "protocol_type", "set protocol type", OFFSET(protocol_type), AV_OPT_TYPE_STRING, {.str = "auto"}, .flags = ENC },
     { "video_size", "set video frame size given a string such as 640x480 or hd720", OFFSET(width), AV_OPT_TYPE_IMAGE_SIZE, {.str = "1920x1080"}, 0, 0, ENC },
-    { "pixel_format", "set video pixel format", OFFSET(pixel_format), AV_OPT_TYPE_PIXEL_FMT, {.i64 = AV_PIX_FMT_NONE}, -1, INT_MAX, ENC },
+    { "pixel_format", "set video pixel format", OFFSET(pixel_format), AV_OPT_TYPE_PIXEL_FMT, {.i64 = AV_PIX_FMT_YUV422P10LE}, AV_PIX_FMT_NONE, INT_MAX, ENC },
     { "frame_rate", "set video frame rate", OFFSET(frame_rate), AV_OPT_TYPE_VIDEO_RATE, {.str = "25"}, 0, INT_MAX, ENC },
     { "socket_name", "set memif socket name", OFFSET(socket_name), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC },
     { "interface_id", "set interface ID", OFFSET(interface_id), AV_OPT_TYPE_INT, {.i64 = 0}, -1, INT_MAX, ENC },

--- a/ffmpeg-plugin/mcm_tx.c
+++ b/ffmpeg-plugin/mcm_tx.c
@@ -97,6 +97,8 @@ static int mcm_write_header(AVFormatContext* avctx)
         param.payload_args.video_args.fps     = param.fps = av_q2d(s->frame_rate);
 
         switch (s->pixel_format) {
+        case AV_PIX_FMT_YUV422P10LE:
+            param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
         case AV_PIX_FMT_YUV420P:
         default:
             param.pix_fmt = PIX_FMT_NV12;

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -1,112 +1,126 @@
+# syntax=docker/dockerfile:1
 
-# SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
-#
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM ubuntu:22.04@sha256:e6173d4dc55e76b87c4af8db8821b1feae4146dd47341e4d431118c7dd060a74 as builder
-LABEL maintainer="qiang.han@intel.com"
+ARG IMAGE_CACHE_REGISTRY=docker.io
+ARG IMAGE_NAME=library/ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
 
-ARG USER=ubuntu
-ARG UID=1000
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as builder
+
+ARG PREFIX_DIR="/usr/local"
+# ARG PREFIX_DIR="/opt/install"
+ARG DPDK_VER="23.11"
+ARG GPRC_VER="v1.58.0"
+ARG MCM_DIR="/opt/mcm"
+ARG MTL_DIR="/opt/mtl"
+ARG DPDK_DIR="/opt/dpdk"
+ARG XDP_DIR="/opt/xdp"
+ARG GRPC_DIR="/opt/grpc"
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV TZ="Europe/Warsaw"
+ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
 
 SHELL ["/bin/bash", "-ex", "-o", "pipefail", "-c"]
 # Install package dependencies
 RUN apt-get update --fix-missing && \
     apt-get full-upgrade -y && \
-    apt-get install --no-install-recommends -y apt-utils \
-    software-properties-common ca-certificates \
-    libtool autoconf automake pkg-config \
-    sudo jq \
-    python3 python3-pip \
-    cmake nasm \
-    build-essential gcc meson \
-    libnuma-dev libjson-c-dev libpcap-dev libgtest-dev \
-    libsdl2-dev libsdl2-ttf-dev libssl-dev nlohmann-json3-dev \
-    libbsd-dev \
-    python3-pyelftools libgrpc++-dev protobuf-compiler \
-    curl git git-lfs \
-    vim openssh-server clang-format \
-    gdb psmisc && \
+    apt-get install --no-install-recommends -y \
+        sudo \
+        nasm cmake libbsd-dev git build-essential \
+        meson python3 python3-pyelftools pkg-config \
+        libnuma-dev libjson-c-dev libpcap-dev libgtest-dev \
+        libsdl2-dev libsdl2-ttf-dev libssl-dev ca-certificates \
+        m4 clang llvm zlib1g-dev libelf-dev libcap-ng-dev \
+        libcap2-bin gcc-multilib systemtap-sdt-dev librdmacm-dev && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    useradd -l -m -s /bin/bash -u ${UID} ${USER}
+    rm -rf /var/lib/apt/lists/*
 
-ARG PREFIX_DIR="/usr/local"
-ARG HOME="/home/${USER}"
-
-ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
-
-ARG MCM_DIR=/opt/mcm
-ARG MTL_DIR=/opt/mtl
-ARG DPDK_DIR=/opt/dpdk
-ENV DPDK_VER=23.11
-
-# Build DPDK/IMTL
+# Clone MTL, DPDK and xdp-tools repo
 WORKDIR ${DPDK_DIR}
-RUN git clone --depth 1 --branch main https://github.com/OpenVisualCloud/Media-Transport-Library.git ${MTL_DIR} && \
-    git clone --depth 1 --branch v${DPDK_VER} https://github.com/DPDK/dpdk.git . && \
-    find ${MTL_DIR}/patches/dpdk/${DPDK_VER}/ -maxdepth 1 -name '*.patch' -print0 | sort -z | xargs -t -0 -n 1 patch -d ${DPDK_DIR} -p1 -i && \
-    meson build && \
-    ninja -C build && \
-    ninja -C build install && \
+RUN git config --global user.email "you@intel.com" && \
+    git config --global user.name "Your Name" && \
+    git clone --branch main https://github.com/OpenVisualCloud/Media-Transport-Library ${MTL_DIR} && \
+    git clone --branch v${DPDK_VER} https://github.com/DPDK/dpdk.git ${DPDK_DIR} && \
+    git clone --recurse-submodules https://github.com/xdp-project/xdp-tools.git ${XDP_DIR} && \
+    git clone --branch ${GPRC_VER} --recurse-submodules --depth 1 --shallow-submodules https://github.com/grpc/grpc ${GRPC_DIR} && \
+    git am ${MTL_DIR}/patches/dpdk/${DPDK_VER}/*.patch && \
+    meson setup build && \
+    meson install -C build && \
+    DESTDIR="${PREFIX_DIR}" meson install -C build && \
     pkg-config --cflags libdpdk && \
     pkg-config --libs libdpdk && \
     pkg-config --modversion libdpdk
 
+# Build the xdp-tools project
+WORKDIR ${XDP_DIR}
+RUN ./configure && \
+    make && \
+    make install && \
+    DESTDIR="${PREFIX_DIR}" make install
+WORKDIR ${XDP_DIR}/lib/libbpf/src
+RUN make install && \
+    DESTDIR="${PREFIX_DIR}" make install
+
 # Build IMTL
 WORKDIR ${MTL_DIR}
-RUN ./build.sh
+RUN ./build.sh && \
+    DESTDIR="${PREFIX_DIR}" meson install -C build
 
 # gRPC
-ARG GPRC_VERSION="v1.58.0"
-RUN git clone --recurse-submodules -b ${GPRC_VERSION} --depth 1 --shallow-submodules https://github.com/grpc/grpc /tmp/grpc
-WORKDIR /tmp/grpc/cmake/build
-RUN cmake -DgRPC_INSTALL=ON \
-        -DgRPC_BUILD_TESTS=OFF \
-        -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR} \
-        ../.. && \
+WORKDIR ${GRPC_DIR}/cmake/build
+RUN cmake -DgRPC_BUILD_TESTS=OFF -DgRPC_INSTALL=ON \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}" ../.. && \
     make -j `nproc` && \
     make install && \
-    rm -rf /tmp/*
+    cmake -DgRPC_BUILD_TESTS=ON -DgRPC_INSTALL=ON \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}" ../.. && \
+    make -j `nproc` grpc_cli
 
 # Build MCM
-RUN git clone --depth 1 --branch main https://github.com/OpenVisualCloud/Media-Communications-Mesh.git ${MCM_DIR}
-WORKDIR $MCM_DIR
-RUN ./build.sh
+WORKDIR ${MCM_DIR}
+COPY . ${MCM_DIR}
+RUN CMAKE_PREFIX_PATH="${PREFIX_DIR}" INSTALL_PREFIX="${PREFIX_DIR}" ./build.sh
 
-# Re-build container for optimised runtime environment using clean Ubuntu release
-FROM ubuntu:22.04@sha256:e6173d4dc55e76b87c4af8db8821b1feae4146dd47341e4d431118c7dd060a74
-LABEL maintainer="qiang.han@intel.com"
+ARG IMAGE_CACHE_REGISTRY
+ARG IMAGE_NAME
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
+LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL org.opencontainers.image.title="Intel® MCM Media Proxy" \
+      org.opencontainers.image.description="Intel® Media Communications Mesh Media Proxy Ubuntu 22.04 Docker Container Release Image" \
+      org.opencontainers.image.version="0.5.0" \
+      org.opencontainers.image.vendor="Intel"
+
+ARG MCM_DIR="/opt/mcm"
+ARG GRPC_DIR="/opt/grpc"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
 
-ARG USER=ubuntu
-ARG UID=1000
-# Set default environment variables for the user
-ARG PREFIX_DIR="/usr/local"
-SHELL ["/bin/bash", "-c"]
+ENV KAHAWAI_CFG_PATH="/usr/local/etc/imtl.json"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
+
+SHELL ["/bin/bash", "-exc"]
 RUN apt-get update --fix-missing && \
     apt-get full-upgrade -y && \
     apt-get install -y --no-install-recommends \
-        libsdl2-2.0-0 libsdl2-ttf-2.0-0 libnuma1 libjson-c5 libpcap0.8 libssl3 libatomic1 libbsd0 \
-        sleepenh net-tools sudo jq && \
+       apt-transport-https software-properties-common ca-certificates \
+       libbsd0 libnuma1 libjson-c5 libpcap0.8 libsdl2-2.0-0 libsdl2-ttf-2.0-0 libssl3 \
+       zlib1g libelf1 libcap-ng0 libatomic1 librdmacm1 systemtap \
+       vim net-tools sudo  && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -l -m -s /bin/bash -u ${UID} ${USER}
+    groupadd -g 2110 vfio && \
+    useradd -m -s /bin/bash -G vfio -u 1002 mcm && \
+    usermod -aG sudo mcm
 
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+COPY --from=builder /usr/lib64 /usr/lib64
 
 RUN ldconfig
-
-# Expose correct default ports to allow quick publishing
-# EXPOSE 8001 8002
-
-USER ${USER}
-
+EXPOSE 8001 8002
 CMD ["media_proxy"]
 
-# Add a health check command to check if a specific program is running
-HEALTHCHECK --interval=30s --timeout=3s \
-  CMD ps aux | grep "media_proxy" || exit 1
+HEALTHCHECK --interval=30s --timeout=5s CMD ps aux | grep "media_proxy" || exit 1

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -88,10 +88,11 @@ ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® MCM Media Proxy" \
-      org.opencontainers.image.description="Intel® Media Communications Mesh Media Proxy Ubuntu 22.04 Docker Container Release Image" \
+LABEL org.opencontainers.image.title="Intel® Media Communication Mesh Media Proxy" \
+      org.opencontainers.image.description="Intel® Media Communications Mesh Media Proxy application. Ubuntu 22.04 Docker Container Release Image" \
       org.opencontainers.image.version="0.5.0" \
-      org.opencontainers.image.vendor="Intel"
+      org.opencontainers.image.vendor="Intel Corporation" \
+      org.opencontainers.image.licenses="BSD 3-Clause License"
 
 ARG MCM_DIR="/opt/mcm"
 ARG GRPC_DIR="/opt/grpc"

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,78 +1,68 @@
+# syntax=docker/dockerfile:1
+
 # SPDX-FileCopyrightText: Copyright (c) 2023 Intel Corporation
-#
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Use the specific version of ubuntu image
-FROM ubuntu:22.04@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f as builder
+ARG IMAGE_CACHE_REGISTRY=docker.io
+ARG IMAGE_NAME=library/ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
 
-# Set the maintainer label
-LABEL maintainer="qiang.han@intel.com"
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as builder
 
-# Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Warsaw
 
-# Update and install package dependencies in a single RUN command to reduce layer size
-RUN apt-get update && apt-get full-upgrade -y && \
-    apt-get install --no-install-recommends -y apt-utils sudo build-essential cmake git ca-certificates curl libbsd-dev && \
+ARG MCM_DIR=/opt/mcm
+ARG PREFIX_DIR="/usr/local"
+
+SHELL ["/bin/bash", "-exc"]
+RUN apt-get update && \
+    apt-get full-upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        apt-utils build-essential make cmake git ca-certificates pkg-config nasm libbsd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Create a non-root user
-ARG USER=docker
-ARG UID=1000
-RUN useradd -l -m -s /bin/bash -u ${UID} ${USER}
-
-# Set default environment variables for the user
-ARG PREFIX_DIR="/usr/local"
-ARG HOME="/home/${USER}"
-ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
-
-# Set the MCM directory
-ARG MCM_DIR=/opt/mcm
-
-# Clone the MCM repository and build the application
-RUN git clone --depth 1 --branch main https://github.com/OpenVisualCloud/Media-Communications-Mesh.git ${MCM_DIR}
-WORKDIR $MCM_DIR/sdk
+COPY . ${MCM_DIR}
+WORKDIR ${MCM_DIR}/sdk
 RUN ./build.sh
 
-## Re-build container for optimised runtime environment using clean Ubuntu release
-FROM ubuntu:22.04@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
+ARG IMAGE_CACHE_REGISTRY
+ARG IMAGE_NAME
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
-# Set the maintainer label
-LABEL maintainer="qiang.han@intel.com"
+LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL org.opencontainers.image.title="Intel® MCM SDK" \
+      org.opencontainers.image.description="Intel® MCM SDK with recv and sender applications Ubuntu 22.04 Docker Release Image" \
+      org.opencontainers.image.version="1.0.0" \
+      org.opencontainers.image.vendor="Intel"
 
-# Set environment variables
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Update and install package dependencies in a single RUN command to reduce layer size
-RUN apt-get update && apt-get full-upgrade -y && \
-    apt-get install --no-install-recommends -y libbsd0 && \
-    apt-get install --no-install-recommends -y sleepenh net-tools && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-ARG USER=docker
-ARG UID=1000
-RUN useradd -l -m -s /bin/bash -u ${UID} ${USER}
-
-# Set default environment variables for the user
-ARG PREFIX_DIR="/usr/local"
 ARG HOME="/home/${USER}"
-ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
-
-# Set the MCM directory
 ARG MCM_DIR=/opt/mcm
+ARG PREFIX_DIR="/usr/local"
 
-# Copy the application build from the builder stage
-COPY --from=builder $MCM_DIR/sdk/out/samples /opt/mcm/sdk/out/samples
-COPY --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Warsaw
+ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
+
+SHELL ["/bin/bash", "-exc"]
+RUN apt-get update && \
+    apt-get full-upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        libbsd0 vim net-tools ca-certificates sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 2110 vfio && \
+    useradd -m -s /bin/bash -G vfio -u 1002 mcm && \
+    usermod -aG sudo mcm
+
+COPY --chown=mcm --from=builder ${MCM_DIR}/sdk/out/samples /opt/mcm/
+COPY --chown=mcm --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
+COPY --chown=mcm --from=builder ${MCM_DIR}/sdk/out/samples /usr/local/bin/
 
 RUN ldconfig
 
-USER ${USER}
+USER mcm
+WORKDIR /opt/mcm/
 
-# Set the working directory
-WORKDIR /opt/mcm/sdk/out/samples
-
-# Set the default command to run the application
 CMD ["./recver_app"]

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -31,10 +31,11 @@ ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® MCM SDK" \
-      org.opencontainers.image.description="Intel® MCM SDK with recv and sender applications Ubuntu 22.04 Docker Release Image" \
+LABEL org.opencontainers.image.title="Intel® Media Communication Mesh SDK" \
+      org.opencontainers.image.description="Intel® Media Communication Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image" \
       org.opencontainers.image.version="1.0.0" \
-      org.opencontainers.image.vendor="Intel"
+      org.opencontainers.image.vendor="Intel Corporation" \
+      org.opencontainers.image.licenses="BSD 3-Clause License"
 
 ARG HOME="/home/${USER}"
 ARG MCM_DIR=/opt/mcm

--- a/sdk/samples/CMakeLists.txt
+++ b/sdk/samples/CMakeLists.txt
@@ -9,12 +9,11 @@ project(McmDPSdk_Samples VERSION 0.1.0
         )
 
 set(CMAKE_C_STANDARD 11)
-set(MTL_LIB mtl)
 
 add_executable(sender_app sender_app.c)
 target_include_directories(sender_app PRIVATE ../include)
-target_link_libraries(sender_app PRIVATE ${MTL_LIB} mcm_dp)
+target_link_libraries(sender_app PRIVATE mcm_dp)
 
 add_executable(recver_app recver_app.c)
 target_include_directories(recver_app PRIVATE ../include)
-target_link_libraries(recver_app PRIVATE ${MTL_LIB} mcm_dp)
+target_link_libraries(recver_app PRIVATE mcm_dp)

--- a/sdk/samples/recver_app.c
+++ b/sdk/samples/recver_app.c
@@ -154,15 +154,14 @@ int main(int argc, char** argv)
         { "socketpath", required_argument, NULL, 'k' },
         { "master", required_argument, NULL, 'm' },
         { "interfaceid", required_argument, NULL, 'd' },
-        { "dumpfile", required_argument, NULL, 's' },
-        { "file_input", required_argument, NULL, 'b' },
+        { "dumpfile", required_argument, NULL, 'b' },
         { "pix_fmt", required_argument, NULL, 'x' },
         { 0 }
     };
 
     /* infinite loop, to be broken when we are done parsing options */
     while (1) {
-        opt = getopt_long(argc, argv, "Hw:h:f:r:p:o:t:s:k:m:d:", longopts, 0);
+        opt = getopt_long(argc, argv, "Hw:h:f:r:i:s:p:o:t:s:k:m:d:b:", longopts, 0);
         if (opt == -1) {
             break;
         }
@@ -363,7 +362,7 @@ int main(int argc, char** argv)
 
         if (strncmp(payload_type, "rtsp", sizeof(payload_type)) != 0) {
             if (dump_fp) {
-                fwrite(buf->data, buf->len, 1, dump_fp);
+                fwrite(buf->data, frm_size, 1, dump_fp);
             } else {
                 // Following code are mainly for test purpose, it requires the sender side to
                 // pre-set the first several bytes

--- a/sdk/samples/recver_app.c
+++ b/sdk/samples/recver_app.c
@@ -14,7 +14,6 @@
 #include <time.h>
 #include <unistd.h>
 #include "mcm_dp.h"
-#include <mtl/st_pipeline_api.h>
 
 #define DEFAULT_RECV_IP "127.0.0.1"
 #define DEFAULT_RECV_PORT "9001"
@@ -87,17 +86,30 @@ void usage(FILE* fp, const char* path)
     fprintf(fp, "\n");
 }
 
-uint32_t getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height) {
-    if (fmt == PIX_FMT_YUV422P) {
-        return st_frame_size(ST_FRAME_FMT_UYVY, width, height, false); // yuv422p10be (1920*1080*2.5) ST20_FMT_YUV_422_8BIT
-    } else if (fmt == PIX_FMT_YUV422P_10BIT_LE) {
-        return st_frame_size(ST_FRAME_FMT_YUV422PLANAR10LE , width, height, false); // yuv422p10be (1920*1080*2.5) ST20_FMT_YUV_422_8BIT
-    } else if (fmt == PIX_FMT_YUV444M) {
-        return st_frame_size(ST_FRAME_FMT_YUV444RFC4175PG4BE10, width, height, false); // yuv422p10be (1920*1080*2.5) ST20_FMT_YUV_422_8BIT
-    } else if (fmt == PIX_FMT_RGB8) {
-        return st_frame_size(ST_FRAME_FMT_RGB8, width, height, false); // yuv422p10be (1920*1080*2.5) ST20_FMT_YUV_422_8BIT
+size_t getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, bool interlaced)
+{
+    size_t size = 0;
+    size_t pixels = (size_t)(width*height);
+    switch (fmt) {
+        case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY) */
+            size = pixels * 2;
+            break;
+        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
+            size = pixels * 2 * 2;
+            break;
+        case PIX_FMT_RGB8:
+            size = pixels * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
+            break;
+/* Customized YUV 420 8bit, set transport format as ST20_FMT_YUV_420_8BIT. For direct transport of
+none-RFC4175 formats like I420/NV12. When this input/output format is set, the frame is identical to
+transport frame without conversion. The frame should not have lines padding) */
+        case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
+        default:
+            size = pixels * 3 / 2;
+            break;
     }
-    return width*height*3/2; // PIX_FMT_NV12
+    if (interlaced) size /= 2; /* if all fmt support interlace? */
+    return size;
 }
 
 int main(int argc, char** argv)
@@ -304,7 +316,7 @@ int main(int argc, char** argv)
 
     uint32_t frame_count = 0;
     // uint32_t frm_size = width * height * 3 / 2; //TODO:assume it's NV12
-    uint32_t frm_size = getFrameSize(PIX_FMT_YUV422P_10BIT_LE, width, height);
+    uint32_t frm_size = getFrameSize(PIX_FMT_YUV422P_10BIT_LE, width, height, false);
 
     const uint32_t fps_interval = 30;
     double fps = 0.0;

--- a/sdk/samples/sender_app.c
+++ b/sdk/samples/sender_app.c
@@ -200,7 +200,7 @@ int main(int argc, char** argv)
         { "send_port", required_argument, NULL, 'p' },
         { "protocol", required_argument, NULL, 'o' },
         { "number", required_argument, NULL, 'n' },
-        { "file", required_argument, NULL, 'i' },
+        { "file", required_argument, NULL, 'b' },
         { "type", required_argument, NULL, 't' },
         { "socketpath", required_argument, NULL, 'k' },
         { "master", required_argument, NULL, 'm' },
@@ -212,7 +212,7 @@ int main(int argc, char** argv)
 
     /* infinite loop, to be broken when we are done parsing options */
     while (1) {
-        opt = getopt_long(argc, argv, "Hw:h:f:s:p:o:n:i:t:k:m:d:l:x:", longopts, 0);
+        opt = getopt_long(argc, argv, "Hw:h:f:s:p:o:n:r:i:t:k:m:d:l:x:b:", longopts, 0);
         if (opt == -1) {
             break;
         }
@@ -402,6 +402,7 @@ int main(int argc, char** argv)
         printf("INFO: buf->metadata.seq_num = %d\n", buf->metadata.seq_num);
         printf("INFO: buf->metadata.timestamp = %d\n", buf->metadata.timestamp);
         printf("INFO: buf->len = %ld\n", buf->len);
+        buf->len = frame_size;
 
         if (input_fp == NULL) {
             gen_test_data(buf, frame_count);


### PR DESCRIPTION
FFmpeg fix for default yuv422p10le pixel format:

Follow-up change to recent, introduced in NAB2024, adjusted and merged changes to media-proxy. Main
change was introduction of RFC4175 compliant (aka. st2110-20 format) frame FMT PIX_FMT_YUV422P_10BIT_LE, which is now default output format for media-proxy.

Above requires adjustments to `FFmpeg` by introducing `getFrameSize()` method for `mcm_rx.c` part of implementation. For making this MTL independent, method was implemented as is in the code instead of being included for the framework.

Updated README.md to include possible shared libraries error where `ffmpeg` tries to load libraries from wrong path by default.