### PR TITLE
JPEG XS added and FFmpeg plugin extended

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,5 @@
-# for Python
-__pycache__/
+# .dockerignore
 
-# for compilation
 build
 out/*
 build/*
@@ -10,18 +8,10 @@ ffmpeg-plugin/build/*
 ffmpeg-plugin/out/*
 ffmpeg-plugin/FFmpeg/*
 
-# for debug dump
-dump_*
+.git/*
 
 # for gRPC protos
 media-proxy/protos/controller.grpc.pb.cc
 media-proxy/protos/controller.grpc.pb.h
 media-proxy/protos/controller.pb.cc
 media-proxy/protos/controller.pb.h
-
-# for VS Code settings
-.vscode/c_cpp_properties.json
-.vscode/settings.json
-
-# For FFmpeg plugin
-ffmpeg-plugin/FFmpeg/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -106,9 +106,11 @@ jobs:
     - name: 'Build MCM FFmpeg plugin'
       working-directory: ${{ github.workspace }}/ffmpeg-plugin
       run: |
-        ./clone-and-patch-ffmpeg.sh && \
-        ./configure-ffmpeg.sh && \
-        ./build-ffmpeg.sh
+          git config --global user.email "you@intel.com"
+          git config --global user.name "Your Name"
+          ./clone-and-patch-ffmpeg.sh && \
+          ./configure-ffmpeg.sh && \
+          ./build-ffmpeg.sh
 
     - name: 'Perform CodeQL Analysis'
       uses: github/codeql-action/analyze@2e230e8fe0ad3a14a340ad0815ddb96d599d2aff # v3.25.8

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -106,8 +106,8 @@ jobs:
     - name: 'Build MCM FFmpeg plugin'
       working-directory: ${{ github.workspace }}/ffmpeg-plugin
       run: |
-          git config --global user.email "you@intel.com"
-          git config --global user.name "Your Name"
+          git config --global user.email "milosz.linkiewicz@intel.com"
+          git config --global user.name "Milosz Linkiewicz"
           ./clone-and-patch-ffmpeg.sh && \
           ./configure-ffmpeg.sh && \
           ./build-ffmpeg.sh

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build:
     runs-on: 'ubuntu-22.04'
-    timeout-minutes: 90
+    timeout-minutes: 120
     defaults:
       run:
         shell: bash
@@ -63,10 +63,13 @@ jobs:
     - name: 'Build gRPC'
       if: steps.grpc-cache-restore.outputs.cache-hit != 'true'
       run: |
-        git clone --branch ${GRPC_VERSION} --recurse-submodules --depth 1 --shallow-submodules https://github.com/grpc/grpc "${GRPC_DIR}" && \
-        cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR} \
-          -B "${GRPC_DIR}/cmake/build" -S "${GRPC_DIR}" && \
-        cmake --build "${GRPC_DIR}/cmake/build" -j `nproc`
+          git clone --branch ${GRPC_VERSION} --recurse-submodules --depth 1 --shallow-submodules https://github.com/grpc/grpc "${GRPC_DIR}" && \
+          cmake -DgRPC_INSTALL=ON \
+                -DgRPC_BUILD_TESTS=OFF \
+                -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR} \
+                -B "${GRPC_DIR}/cmake/build"
+                -S "${GRPC_DIR}" && \
+          cmake --build "${GRPC_DIR}/cmake/build" -j `nproc`
 
     - name: 'Save cache for gRPC build'
       if: steps.grpc-cache-restore.outputs.cache-hit != 'true'
@@ -78,8 +81,8 @@ jobs:
 
     - name: 'Install gRPC'
       run: |
-        sudo cmake --install "${GRPC_DIR}/cmake/build" && \
-        rm -rf "${GRPC_DIR}"
+          sudo cmake --install "${GRPC_DIR}/cmake/build" && \
+          rm -rf "${GRPC_DIR}"
 
     - name: 'Build MCM SDK and Media Proxy'
       run: ./build.sh
@@ -87,6 +90,8 @@ jobs:
     - name: 'Build MCM FFmpeg plugin'
       working-directory: ${{ github.workspace }}/ffmpeg-plugin
       run: |
-        ./clone-and-patch-ffmpeg.sh && \
-        ./configure-ffmpeg.sh && \
-        ./build-ffmpeg.sh
+          git config --global user.email "you@intel.com"
+          git config --global user.name "Your Name"
+          ./clone-and-patch-ffmpeg.sh && \
+          ./configure-ffmpeg.sh && \
+          ./build-ffmpeg.sh

--- a/.github/workflows/ubuntu-docker.yml
+++ b/.github/workflows/ubuntu-docker.yml
@@ -1,0 +1,55 @@
+name: Docker Build
+
+on:
+    push:
+      branches: [ "main", "dev" ]
+    pull_request:
+      branches: [ "main", "dev" ]
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build and push SDK sample apps
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          file: sdk/Dockerfile
+          context: .
+          push: false
+          tags: "mcm/sdk:${{ github.sha }}"
+
+      - name: Build and push ffmpeg and plugins
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          file: ffmpeg-plugin/Dockerfile
+          context: .
+          push: false
+          tags: "mcm/ffmpeg:${{ github.sha }}"
+
+      - name: Build and push media proxy application
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          file: media-proxy/Dockerfile
+          context: .
+          push: false
+          tags: "mcm/media-proxy:${{ github.sha }}"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -14,10 +14,10 @@ IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY:-docker.io}"
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 
-docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/ffmpeg:${IMAGE_TAG}" -f "${SCRIPT_DIR}/ffmpeg-plugin/Dockerfile" $@ "${SCRIPT_DIR}"
 docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/sdk:${IMAGE_TAG}" -f "${SCRIPT_DIR}/sdk/Dockerfile" $@ "${SCRIPT_DIR}"
 docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/media-proxy:${IMAGE_TAG}" -f "${SCRIPT_DIR}/media-proxy/Dockerfile" $@ "${SCRIPT_DIR}"
+docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/ffmpeg:${IMAGE_TAG}" -f "${SCRIPT_DIR}/ffmpeg-plugin/Dockerfile" $@ "${SCRIPT_DIR}"
 
-docker tag "${IMAGE_REGISTRY}/ffmpeg:${IMAGE_TAG}" mcm/ffmpeg:latest
-docker tag "${IMAGE_REGISTRY}/sdk:${IMAGE_TAG}" mcm/sample-app:latest
-docker tag "${IMAGE_REGISTRY}/media-proxy:${IMAGE_TAG}" mcm/media-proxy:latest
+docker tag "${IMAGE_REGISTRY}/sdk:${IMAGE_TAG}" "mcm/sample-app:${IMAGE_TAG}"
+docker tag "${IMAGE_REGISTRY}/media-proxy:${IMAGE_TAG}" "mcm/media-proxy:${IMAGE_TAG}"
+docker tag "${IMAGE_REGISTRY}/ffmpeg:${IMAGE_TAG}" "mcm/ffmpeg:${IMAGE_TAG}"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -17,3 +17,7 @@ IMAGE_TAG="${IMAGE_TAG:-latest}"
 docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/ffmpeg:${IMAGE_TAG}" -f "${SCRIPT_DIR}/ffmpeg-plugin/Dockerfile" $@ "${SCRIPT_DIR}"
 docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/sdk:${IMAGE_TAG}" -f "${SCRIPT_DIR}/sdk/Dockerfile" $@ "${SCRIPT_DIR}"
 docker buildx build --progress=plain --network=host ${BUILD_ARGUMENTS} --build-arg IMAGE_CACHE_REGISTRY="${IMAGE_CACHE_REGISTRY}" -t "${IMAGE_REGISTRY}/media-proxy:${IMAGE_TAG}" -f "${SCRIPT_DIR}/media-proxy/Dockerfile" $@ "${SCRIPT_DIR}"
+
+docker tag "${IMAGE_REGISTRY}/ffmpeg:${IMAGE_TAG}" mcm/ffmpeg:latest
+docker tag "${IMAGE_REGISTRY}/sdk:${IMAGE_TAG}" mcm/sample-app:latest
+docker tag "${IMAGE_REGISTRY}/media-proxy:${IMAGE_TAG}" mcm/media-proxy:latest

--- a/deployment/setup.sh
+++ b/deployment/setup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+
+set -eo pipefail
+SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+. "${SCRIPT_DIR}/../common.sh"
+
 # Function to display execution step log
 display_step_info() {
     step_num=$((step_num + 1))

--- a/ffmpeg-plugin/6.1/0001-mcm-add-in-out-dev-support.patch
+++ b/ffmpeg-plugin/6.1/0001-mcm-add-in-out-dev-support.patch
@@ -6,7 +6,7 @@ index 96b181fd21..e5320f8751 100755
    --enable-libvo-amrwbenc  enable AMR-WB encoding via libvo-amrwbenc [no]
    --enable-libvorbis       enable Vorbis en/decoding via libvorbis,
                             native implementation exists [no]
-+  --enable-mcm             enable Media Communication Mesh library [no]
++  --enable-mcm             enable Media Communications Mesh library [no]
    --enable-libvpx          enable VP8 and VP9 de/encoding via libvpx [no]
    --enable-libwebp         enable WebP encoding via libwebp [no]
    --enable-libx264         enable H.264 encoding via x264 [no]

--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -43,11 +43,11 @@ ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® Media Communications Mesh FFmpeg" \
-      org.opencontainers.image.description="Intel® Media Communications Mesh FFmpeg with MCM-Muxer and MCM-Demuxer plugins. Ubuntu 22.04 Docker Release Image." \
-      org.opencontainers.image.version="1.0.0" \
-      org.opencontainers.image.vendor="Intel Corporation" \
-      org.opencontainers.image.licenses="BSD 3-Clause License"
+LABEL org.opencontainers.image.title="Intel® Media Communications Mesh FFmpeg"
+LABEL org.opencontainers.image.description="Intel® Media Communications Mesh FFmpeg with MCM-Muxer and MCM-Demuxer plugins. Ubuntu 22.04 Docker Release Image."
+LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.vendor="Intel Corporation"
+LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
 ARG MCM_DIR=/opt/mcm
 ARG PREFIX_DIR="/install"

--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -12,45 +12,49 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
 
 ARG MCM_DIR=/opt/mcm
-ARG PREFIX_DIR="/usr/local"
+ARG PREFIX_DIR="/install"
 
 SHELL ["/bin/bash", "-exc"]
 RUN apt-get update && \
     apt-get full-upgrade -y && \
     apt-get install --no-install-recommends -y \
-        sudo \
-        apt-utils build-essential make cmake git ca-certificates pkg-config nasm libbsd-dev libx264-dev && \
+        sudo apt-utils build-essential make cmake git ca-certificates pkg-config nasm libbsd-dev libx264-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . ${MCM_DIR}
-WORKDIR ${MCM_DIR}/sdk
-RUN ./build.sh
+WORKDIR ${MCM_DIR}
+RUN git config --global user.email "milosz.linkiewicz@intel.com" && \
+    git config --global user.name "Milosz Linkiewicz" && \
+    ./sdk/build.sh && \
+    INSTALL_PREFIX="${PREFIX_DIR}/usr/local" ./sdk/build.sh && \
+    ./ffmpeg-plugin/clone-and-patch-ffmpeg.sh && \
+    ./ffmpeg-plugin/configure-ffmpeg.sh --enable-libx264 --enable-gpl --prefix="${PREFIX_DIR}/usr/local"
+
+# Build and install JPEG XS
+WORKDIR ${MCM_DIR}/ffmpeg-plugin/build/jpegxs/Build/linux
+RUN ./build.sh release --prefix "${PREFIX_DIR}/usr/local" install
 
 WORKDIR ${MCM_DIR}/ffmpeg-plugin
-RUN ./clone-and-patch-ffmpeg.sh && \
-    ./configure-ffmpeg.sh --enable-libx264 --enable-gpl && \
-    ./build-ffmpeg.sh
+RUN ./build-ffmpeg.sh
 
 ARG IMAGE_CACHE_REGISTRY
 ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® Media Communication Mesh FFmpeg" \
-      org.opencontainers.image.description="Intel® Media Communication Mesh FFmpeg with MCM-Muxer and MCM-Demuxer plugins. Ubuntu 22.04 Docker Release Image." \
+LABEL org.opencontainers.image.title="Intel® Media Communications Mesh FFmpeg" \
+      org.opencontainers.image.description="Intel® Media Communications Mesh FFmpeg with MCM-Muxer and MCM-Demuxer plugins. Ubuntu 22.04 Docker Release Image." \
       org.opencontainers.image.version="1.0.0" \
       org.opencontainers.image.vendor="Intel Corporation" \
       org.opencontainers.image.licenses="BSD 3-Clause License"
 
-ARG HOME="/home/${USER}"
 ARG MCM_DIR=/opt/mcm
-ARG PREFIX_DIR="/usr/local"
+ARG PREFIX_DIR="/install"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
-ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
-ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
+ENV HOME="${MCM_DIR}"
 
 SHELL ["/bin/bash", "-exc"]
 RUN apt-get update && \
@@ -60,15 +64,16 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 2110 vfio && \
-    useradd -m -s /bin/bash -G vfio -u 1002 mcm && \
+    groupadd -g 1001 imtl && \
+    useradd -m -s /bin/bash -G vfio,imtl -u 1002 mcm && \
     usermod -aG sudo mcm
 
-COPY --chown=mcm --from=builder ${MCM_DIR}/sdk/out/samples /opt/mcm/
-COPY --chown=mcm --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
+COPY --chown=1002 --from=builder "${PREFIX_DIR}" /
+COPY --chown=1002 --from=builder "${MCM_DIR}/sdk/build/samples" "${MCM_DIR}"
 
 RUN ldconfig
 
-USER mcm
+# USER 1002
 WORKDIR /opt/mcm/
 
 CMD ["ffmpeg"]

--- a/ffmpeg-plugin/build-ffmpeg.sh
+++ b/ffmpeg-plugin/build-ffmpeg.sh
@@ -6,12 +6,13 @@
 set -eo pipefail
 
 SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+BUILD_DIR="${BUILD_DIR:-${SCRIPT_DIR}/build}"
 . "${SCRIPT_DIR}/../common.sh"
 
-cp -f "${SCRIPT_DIR}/mcm_"* "${SCRIPT_DIR}/FFmpeg/libavdevice/"
+cp -f "${SCRIPT_DIR}/mcm_"* "${BUILD_DIR}/FFmpeg/libavdevice/"
 
-make -C "${SCRIPT_DIR}/FFmpeg" -j "$(nproc)"
-run_as_root_user make -C "${SCRIPT_DIR}/FFmpeg" install
+make -C "${BUILD_DIR}/FFmpeg/" -j "$(nproc)"
+run_as_root_user make -C "${BUILD_DIR}/FFmpeg/" install
 
 prompt "FFmpeg MCM plugin build completed."
-prompt "\t${SCRIPT_DIR}/FFmpeg"
+prompt "\t${BUILD_DIR}/FFmpeg"

--- a/ffmpeg-plugin/clone-and-patch-ffmpeg.sh
+++ b/ffmpeg-plugin/clone-and-patch-ffmpeg.sh
@@ -6,15 +6,32 @@
 set -eo pipefail
 
 SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+BUILD_DIR="${BUILD_DIR:-${SCRIPT_DIR}/build}"
 . "${SCRIPT_DIR}/../common.sh"
 
-# First parameter or default to latest 6.1
-ffmpeg_ver="${1:-6.1}"
+# Default to latest 6.1
+FFMPEG_VER="${FFMPEG_VER:-6.1}"
+# Default to latest 0.9
+JPEGXS_VER="${JPEGXS_VER:-e1030c6c8ee2fb05b76c3fa14cccf8346db7a1fa}"
+JPEGXS_ENABLED="${JPEGXS_ENABLED:-1}"
 
-rm -rf "${SCRIPT_DIR}/FFmpeg"
-git clone https://github.com/FFmpeg/FFmpeg.git "${SCRIPT_DIR}/FFmpeg"
-git -C "${SCRIPT_DIR}/FFmpeg" checkout release/"${ffmpeg_ver}"
-git -C "${SCRIPT_DIR}/FFmpeg" apply "${SCRIPT_DIR}/${ffmpeg_ver}/"*.patch
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
 
-prompt "FFmpeg ${ffmpeg_ver} cloned and patched successfully."
-prompt "\t${SCRIPT_DIR}/FFmpeg"
+# Clone FFmpeg:
+git clone --branch "release/${FFMPEG_VER}" --depth 1 https://github.com/FFmpeg/FFmpeg.git "${BUILD_DIR}/FFmpeg"
+
+# Clone JPEG XS if JPEGXS_VER is set, else skip:
+if [ "$JPEGXS_ENABLED" == "1" ]; then
+    git clone https://github.com/OpenVisualCloud/SVT-JPEG-XS "${BUILD_DIR}/jpegxs"
+    git -C "${BUILD_DIR}/jpegxs" checkout "${JPEGXS_VER}"
+    git -C "${BUILD_DIR}/FFmpeg" am --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0001-Enable-JPEG-XS-codec-type.patch
+    git -C "${BUILD_DIR}/FFmpeg" am --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0002-Allow-JPEG-XS-to-be-stored-in-mp4-mkv-container.patch
+    git -C "${BUILD_DIR}/FFmpeg" am --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0003-svt-jpegxs-encoder-support.patch
+    git -C "${BUILD_DIR}/FFmpeg" am --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0004-svt-jpegxs-decoder-support.patch
+fi
+
+git -C "${BUILD_DIR}/FFmpeg" apply "${SCRIPT_DIR}/${FFMPEG_VER}/"*.patch
+
+prompt "FFmpeg ${FFMPEG_VER} cloned and patched successfully."
+prompt "\t${BUILD_DIR}/FFmpeg"

--- a/ffmpeg-plugin/mcm_rx.c
+++ b/ffmpeg-plugin/mcm_rx.c
@@ -45,6 +45,9 @@ transport frame without conversion. The frame should not have lines padding) */
         case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
             size = pixels * 3 / 2;
             break;
+        case PIX_FMT_YUV444P_10BIT_LE:
+            size = pixels * 2 * 3;
+            break;
         case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
         default:
             size = pixels * 2 * 2;
@@ -87,6 +90,7 @@ static int mcm_read_header(AVFormatContext* avctx)
         param.payload_type = PAYLOAD_TYPE_ST20_VIDEO;
     } else if (strcmp(s->payload_type, "st22") == 0) {
         param.payload_type = PAYLOAD_TYPE_ST22_VIDEO;
+        param.payload_codec = PAYLOAD_CODEC_JPEGXS;
     } else if (strcmp(s->payload_type, "st30") == 0) {
         param.payload_type = PAYLOAD_TYPE_ST30_AUDIO;
     } else if (strcmp(s->payload_type, "st40") == 0) {
@@ -127,11 +131,22 @@ static int mcm_read_header(AVFormatContext* avctx)
         param.payload_args.video_args.fps     = param.fps = av_q2d(s->frame_rate);
 
         switch (s->pixel_format) {
-        case AV_PIX_FMT_YUV420P:
+        case AV_PIX_FMT_NV12:
             param.pix_fmt = PIX_FMT_NV12;
+            break;
+        case AV_PIX_FMT_YUV422P:
+            param.pix_fmt = PIX_FMT_YUV422P;
+            break;
+        case AV_PIX_FMT_YUV444P10LE:
+            param.pix_fmt = PIX_FMT_YUV444P_10BIT_LE;
+            break;
+        case AV_PIX_FMT_RGB24:
+            param.pix_fmt = PIX_FMT_RGB8;
+            break;
         case AV_PIX_FMT_YUV422P10LE:
         default:
             param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
+            break;
         }
 
         param.payload_args.video_args.pix_fmt = param.pix_fmt;
@@ -240,7 +255,7 @@ static const AVClass mcm_demuxer_class = {
 
 AVInputFormat ff_mcm_demuxer = {
         .name = "mcm",
-        .long_name = NULL_IF_CONFIG_SMALL("Media Communication Mesh"),
+        .long_name = NULL_IF_CONFIG_SMALL("Media Communications Mesh"),
         .priv_data_size = sizeof(McmDemuxerContext),
         .read_header = mcm_read_header,
         .read_packet = mcm_read_packet,

--- a/ffmpeg-plugin/mcm_rx.c
+++ b/ffmpeg-plugin/mcm_rx.c
@@ -146,7 +146,6 @@ static int mcm_read_header(AVFormatContext* avctx)
         case AV_PIX_FMT_YUV422P10LE:
         default:
             param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
-            break;
         }
 
         param.payload_args.video_args.pix_fmt = param.pix_fmt;

--- a/ffmpeg-plugin/mcm_tx.c
+++ b/ffmpeg-plugin/mcm_tx.c
@@ -57,6 +57,7 @@ static int mcm_write_header(AVFormatContext* avctx)
         param.payload_type = PAYLOAD_TYPE_ST20_VIDEO;
     } else if (strcmp(s->payload_type, "st22") == 0) {
         param.payload_type = PAYLOAD_TYPE_ST22_VIDEO;
+        param.payload_codec = PAYLOAD_CODEC_JPEGXS;
     } else if (strcmp(s->payload_type, "st30") == 0) {
         param.payload_type = PAYLOAD_TYPE_ST30_AUDIO;
     } else if (strcmp(s->payload_type, "st40") == 0) {
@@ -97,11 +98,22 @@ static int mcm_write_header(AVFormatContext* avctx)
         param.payload_args.video_args.fps     = param.fps = av_q2d(s->frame_rate);
 
         switch (s->pixel_format) {
-        case AV_PIX_FMT_YUV422P10LE:
-            param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
-        case AV_PIX_FMT_YUV420P:
-        default:
+        case AV_PIX_FMT_NV12:
             param.pix_fmt = PIX_FMT_NV12;
+            break;
+        case AV_PIX_FMT_YUV422P:
+            param.pix_fmt = PIX_FMT_YUV422P;
+            break;
+        case AV_PIX_FMT_YUV444P10LE:
+            param.pix_fmt = PIX_FMT_YUV444P_10BIT_LE;
+            break;
+        case AV_PIX_FMT_RGB24:
+            param.pix_fmt = PIX_FMT_RGB8;
+            break;
+        case AV_PIX_FMT_YUV422P10LE:
+        default:
+            param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
+            break;
         }
 
         param.payload_args.video_args.pix_fmt = param.pix_fmt;
@@ -178,7 +190,7 @@ static const AVClass mcm_muxer_class = {
 
 const FFOutputFormat ff_mcm_muxer = {
     .p.name = "mcm",
-    .p.long_name = NULL_IF_CONFIG_SMALL("Media Communication Mesh"),
+    .p.long_name = NULL_IF_CONFIG_SMALL("Media Communications Mesh"),
     .priv_data_size = sizeof(McmMuxerContext),
     .write_header = mcm_write_header,
     .write_packet = mcm_write_packet,

--- a/ffmpeg-plugin/mcm_tx.c
+++ b/ffmpeg-plugin/mcm_tx.c
@@ -113,7 +113,6 @@ static int mcm_write_header(AVFormatContext* avctx)
         case AV_PIX_FMT_YUV422P10LE:
         default:
             param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
-            break;
         }
 
         param.payload_args.video_args.pix_fmt = param.pix_fmt;

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -8,15 +8,18 @@ ARG IMAGE_NAME=library/ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d
 
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as builder
 
-ARG PREFIX_DIR="/usr/local"
-# ARG PREFIX_DIR="/opt/install"
-ARG DPDK_VER="23.11"
-ARG GPRC_VER="v1.58.0"
+ARG PREFIX_DIR="/install"
 ARG MCM_DIR="/opt/mcm"
+ARG MTL_VER="9d87d0da3466bd88cdf3336844643882d272460b"
 ARG MTL_DIR="/opt/mtl"
+ARG DPDK_VER="23.11"
 ARG DPDK_DIR="/opt/dpdk"
 ARG XDP_DIR="/opt/xdp"
+ARG GPRC_VER="v1.58.0"
 ARG GRPC_DIR="/opt/grpc"
+# JPEGXS_VER Release v0.9
+ARG JPEGXS_VER="e1030c6c8ee2fb05b76c3fa14cccf8346db7a1fa"
+ARG JPEGXS_DIR="/opt/jpegxs"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ="Europe/Warsaw"
@@ -27,8 +30,8 @@ SHELL ["/bin/bash", "-ex", "-o", "pipefail", "-c"]
 RUN apt-get update --fix-missing && \
     apt-get full-upgrade -y && \
     apt-get install --no-install-recommends -y \
-        sudo nasm cmake libbsd-dev git build-essential \
-        meson python3 python3-pyelftools pkg-config \
+        nasm cmake libbsd-dev git build-essential sudo \
+        meson python3-dev python3-pyelftools pkg-config \
         libnuma-dev libjson-c-dev libpcap-dev libgtest-dev \
         libsdl2-dev libsdl2-ttf-dev libssl-dev ca-certificates \
         m4 clang llvm zlib1g-dev libelf-dev libcap-ng-dev \
@@ -38,29 +41,30 @@ RUN apt-get update --fix-missing && \
 
 # Clone MTL, DPDK and xdp-tools repo
 WORKDIR ${DPDK_DIR}
-RUN git config --global user.email "you@intel.com" && \
-    git config --global user.name "Your Name" && \
+RUN git config --global user.email "milosz.linkiewicz@intel.com" && \
+    git config --global user.name "Milosz Linkiewicz" && \
     git clone --branch main https://github.com/OpenVisualCloud/Media-Transport-Library ${MTL_DIR} && \
-    git clone --branch v${DPDK_VER} https://github.com/DPDK/dpdk.git ${DPDK_DIR} && \
+    git -C ${MTL_DIR} checkout ${MTL_VER} && \
+    git clone --branch v${DPDK_VER} --depth 1 https://github.com/DPDK/dpdk.git ${DPDK_DIR} && \
     git clone --recurse-submodules https://github.com/xdp-project/xdp-tools.git ${XDP_DIR} && \
     git clone --branch ${GPRC_VER} --recurse-submodules --depth 1 --shallow-submodules https://github.com/grpc/grpc ${GRPC_DIR} && \
-    git am ${MTL_DIR}/patches/dpdk/${DPDK_VER}/*.patch && \
-    meson setup build && \
+    git clone https://github.com/OpenVisualCloud/SVT-JPEG-XS ${JPEGXS_DIR} && \
+    git -C ${JPEGXS_DIR} checkout ${JPEGXS_VER} && \
+    git am ${MTL_DIR}/patches/dpdk/${DPDK_VER}/*.patch
+
+RUN meson setup build && \
+    ninja -C build && \
     meson install -C build && \
-    DESTDIR="${PREFIX_DIR}" meson install -C build && \
-    pkg-config --cflags libdpdk && \
-    pkg-config --libs libdpdk && \
-    pkg-config --modversion libdpdk
+    DESTDIR="${PREFIX_DIR}" meson install -C build
 
 # Build the xdp-tools project
 WORKDIR ${XDP_DIR}
 RUN ./configure && \
     make && \
     make install && \
-    DESTDIR="${PREFIX_DIR}" make install
-WORKDIR ${XDP_DIR}/lib/libbpf/src
-RUN make install && \
-    DESTDIR="${PREFIX_DIR}" make install
+    DESTDIR="${PREFIX_DIR}" make install && \
+    make -C "${XDP_DIR}/lib/libbpf/src" install && \
+    DESTDIR="${PREFIX_DIR}" make -C "${XDP_DIR}/lib/libbpf/src" install
 
 # Build IMTL
 WORKDIR ${MTL_DIR}
@@ -69,27 +73,44 @@ RUN ./build.sh && \
 
 # gRPC
 WORKDIR ${GRPC_DIR}/cmake/build
-RUN cmake -DgRPC_BUILD_TESTS=OFF -DgRPC_INSTALL=ON \
-        -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}" ../.. && \
+RUN cmake -DgRPC_BUILD_TESTS=OFF -DgRPC_INSTALL=ON ../.. && \
     make -j `nproc` && \
     make install && \
-    cmake -DgRPC_BUILD_TESTS=ON -DgRPC_INSTALL=ON \
-        -DCMAKE_INSTALL_PREFIX="${PREFIX_DIR}" ../.. && \
-    make -j `nproc` grpc_cli
+    cmake -DgRPC_BUILD_TESTS=ON -DgRPC_INSTALL=ON ../.. && \
+    make -j `nproc` grpc_cli && \
+    cp grpc_cli "${PREFIX_DIR}/usr/local/bin/"
+
+# Build and install JPEG XS
+WORKDIR ${JPEGXS_DIR}/Build/linux
+RUN ./build.sh release install && \
+    ./build.sh release --prefix "${PREFIX_DIR}/usr/local" install
+
+# Build and install JPEG XS imtl plugin
+WORKDIR ${JPEGXS_DIR}/imtl-plugin
+RUN ./build.sh build-only && \
+    DESTDIR="${PREFIX_DIR}" meson install --no-rebuild -C build && \
+    mkdir -p /install/usr/local/etc/ && \
+    cp ${JPEGXS_DIR}/imtl-plugin/kahawai.json /install/usr/local/etc/jpegxs.json
 
 # Build MCM
 WORKDIR ${MCM_DIR}
 COPY . ${MCM_DIR}
-RUN CMAKE_PREFIX_PATH="${PREFIX_DIR}" INSTALL_PREFIX="${PREFIX_DIR}" ./build.sh
+RUN INSTALL_PREFIX="${PREFIX_DIR}/usr/local" ./build.sh && \
+    setcap 'cap_ipc_lock+ep cap_ipc_owner+ep' /install/usr/local/bin/media_proxy && \
+    setcap 'cap_net_bind_service+ep cap_net_broadcast+ep cap_net_raw+ep' /install/usr/local/bin/media_proxy && \
+    rm -rf "${PREFIX_DIR}/usr/local/lib/lib"*.a && \
+    rm -rf "${PREFIX_DIR}/usr/local/bin/dpdk-test"* && \
+    rm -rf "${PREFIX_DIR}/usr/local/bin/"*_plugin && \
+    rm -rf "${PREFIX_DIR}/usr/local/share"
 
 ARG IMAGE_CACHE_REGISTRY
 ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® Media Communication Mesh Media Proxy" \
+LABEL org.opencontainers.image.title="Intel® Media Communications Mesh Media Proxy" \
       org.opencontainers.image.description="Intel® Media Communications Mesh Media Proxy application. Ubuntu 22.04 Docker Container Release Image" \
-      org.opencontainers.image.version="0.5.0" \
+      org.opencontainers.image.version="1.0.0" \
       org.opencontainers.image.vendor="Intel Corporation" \
       org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -98,28 +119,27 @@ ARG GRPC_DIR="/opt/grpc"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
 
-ENV KAHAWAI_CFG_PATH="/usr/local/etc/imtl.json"
+ENV KAHAWAI_CFG_PATH="/usr/local/etc/jpegxs.json"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
 
 SHELL ["/bin/bash", "-exc"]
 RUN apt-get update --fix-missing && \
     apt-get full-upgrade -y && \
     apt-get install -y --no-install-recommends \
-       apt-transport-https software-properties-common ca-certificates \
-       libbsd0 libnuma1 libjson-c5 libpcap0.8 libsdl2-2.0-0 libsdl2-ttf-2.0-0 libssl3 \
-       zlib1g libelf1 libcap-ng0 libatomic1 librdmacm1 systemtap \
-       vim net-tools sudo  && \
+       ca-certificates libbsd0 libnuma1 libjson-c5 libpcap0.8 libsdl2-2.0-0 libsdl2-ttf-2.0-0 \
+       libssl3 zlib1g libelf1 libcap-ng0 libatomic1 librdmacm1 systemtap vim sudo \
+       pciutils librte-net-mlx4-22 librte-net-mlx5-22 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 2110 vfio && \
-    useradd -m -s /bin/bash -G vfio -u 1002 mcm && \
+    groupadd -g 1001 imtl && \
+    useradd -m -s /bin/bash -G vfio,imtl -u 1002 mcm && \
     usermod -aG sudo mcm
 
-COPY --from=builder /usr/local /usr/local
-COPY --from=builder /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
-COPY --from=builder /usr/lib64 /usr/lib64
+COPY --chown=mcm --from=builder /install /
 
 RUN ldconfig
+
 EXPOSE 8001 8002
 CMD ["media_proxy"]
 

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -108,11 +108,11 @@ ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® Media Communications Mesh Media Proxy" \
-      org.opencontainers.image.description="Intel® Media Communications Mesh Media Proxy application. Ubuntu 22.04 Docker Container Release Image" \
-      org.opencontainers.image.version="1.0.0" \
-      org.opencontainers.image.vendor="Intel Corporation" \
-      org.opencontainers.image.licenses="BSD 3-Clause License"
+LABEL org.opencontainers.image.title="Intel® Media Communications Mesh Media Proxy"
+LABEL org.opencontainers.image.description="Intel® Media Communications Mesh Media Proxy application. Ubuntu 22.04 Docker Container Release Image"
+LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.vendor="Intel Corporation"
+LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
 ARG MCM_DIR="/opt/mcm"
 ARG GRPC_DIR="/opt/grpc"

--- a/media-proxy/include/mtl.h
+++ b/media-proxy/include/mtl.h
@@ -69,6 +69,10 @@ typedef struct {
     size_t frame_size; /* Size (Bytes) of single frame. */
     uint32_t fb_count; /* Frame buffer count. */
 
+    uint32_t width;
+    uint32_t height;
+    enum st_frame_fmt output_fmt;
+
 #if defined(ZERO_COPY)
     uint8_t* source_begin;
     uint8_t* source_end;

--- a/media-proxy/include/proxy_context.h
+++ b/media-proxy/include/proxy_context.h
@@ -101,4 +101,5 @@ private:
     ProxyContext(const ProxyContext&) = delete;
     ProxyContext& operator=(const ProxyContext&) = delete;
     uint32_t incrementMSessionCount(bool postIncrement);
+    st_frame_fmt getStFrameFmt(video_pixel_format fmt);
 };

--- a/media-proxy/include/proxy_context.h
+++ b/media-proxy/include/proxy_context.h
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
 */
 
+#ifndef __PROXY_CONTEXT_H
+#define __PROXY_CONTEXT_H
+
 #include <atomic>
 #include <iostream>
 #include <string>
@@ -12,6 +15,12 @@
 #include "controller.grpc.pb.h"
 #include "mtl.h"
 #include <mcm_dp.h>
+
+// Based on mtl/app/src/fmt.h
+#ifndef ST_APP_PAYLOAD_TYPE_VIDEO
+#define ST_APP_PAYLOAD_TYPE_VIDEO (112)
+#define ST_APP_PAYLOAD_TYPE_ST22 (114)
+#endif
 
 using controller::MemIFOps;
 using controller::RxControlRequest;
@@ -103,3 +112,5 @@ private:
     uint32_t incrementMSessionCount(bool postIncrement);
     st_frame_fmt getStFrameFmt(video_pixel_format fmt);
 };
+
+#endif // __PROXY_CONTEXT_H

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -121,7 +121,6 @@ st_frame_fmt ProxyContext::getStFrameFmt(video_pixel_format mcm_frame_fmt)
         case PIX_FMT_YUV422P_10BIT_LE:
         default:
             mtl_frame_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
-            break;
     }
     return mtl_frame_fmt;
 }

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -102,6 +102,30 @@ uint32_t ProxyContext::incrementMSessionCount(bool postIncrement=true)
     return retValue;
 }
 
+st_frame_fmt ProxyContext::getStFrameFmt(video_pixel_format mcm_frame_fmt)
+{
+    st_frame_fmt mtl_frame_fmt;
+    switch(mcm_frame_fmt) {
+        case PIX_FMT_NV12:
+            mtl_frame_fmt = ST_FRAME_FMT_YUV420CUSTOM8;
+            break;
+        case PIX_FMT_YUV422P:
+            mtl_frame_fmt = ST_FRAME_FMT_YUV422PLANAR8;
+            break;
+        case PIX_FMT_YUV444P_10BIT_LE:
+            mtl_frame_fmt = ST_FRAME_FMT_YUV444PLANAR10LE;
+            break;
+        case PIX_FMT_RGB8:
+            mtl_frame_fmt = ST_FRAME_FMT_RGB8;
+            break;
+        case PIX_FMT_YUV422P_10BIT_LE:
+        default:
+            mtl_frame_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
+            break;
+    }
+    return mtl_frame_fmt;
+}
+
 void ProxyContext::ParseStInitParam(const TxControlRequest* request, struct mtl_init_params* st_param)
 {
     StInit init = request->st_init();
@@ -345,7 +369,7 @@ void ProxyContext::ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx
     strlcpy(ops_rx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops_rx->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops_rx->port.payload_type = 112;
+        ops_rx->port.payload_type = 96;
     } else {
         ops_rx->port.payload_type = request->payload_type_nr;
     }
@@ -353,10 +377,8 @@ void ProxyContext::ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx
     ops_rx->width = request->width;
     ops_rx->height = request->height;
     ops_rx->fps = st_frame_rate_to_st_fps((double)request->fps);
-    // ops_rx->transport_fmt = ST20_FMT_YUV_422_10BIT;
-    // ops_rx->output_fmt = ST_FRAME_FMT_YUV422RFC4175PG2BE10;
     ops_rx->transport_fmt = ST20_FMT_YUV_422_10BIT;
-    ops_rx->output_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
+    ops_rx->output_fmt = getStFrameFmt(request->pix_fmt);
     ops_rx->device = ST_PLUGIN_DEVICE_AUTO;
     ops_rx->framebuff_cnt = 4;
 
@@ -417,7 +439,7 @@ void ProxyContext::ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx
     ops_tx->port.udp_src_port[MTL_PORT_P] = atoi(request->local_addr.port);
     ops_tx->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops_tx->port.payload_type = 112;
+        ops_tx->port.payload_type = 96;
     } else {
         ops_tx->port.payload_type = request->payload_type_nr;
     }
@@ -425,9 +447,7 @@ void ProxyContext::ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx
     ops_tx->width = request->width;
     ops_tx->height = request->height;
     ops_tx->fps = st_frame_rate_to_st_fps((double)request->fps);
-    // ops_tx->transport_fmt = ST20_FMT_YUV_422_10BIT;
-    // ops_tx->input_fmt = ST_FRAME_FMT_YUV422RFC4175PG2BE10;
-    ops_tx->input_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
+    ops_tx->input_fmt = getStFrameFmt(request->pix_fmt);
     ops_tx->transport_fmt = ST20_FMT_YUV_422_10BIT;
     ops_tx->device = ST_PLUGIN_DEVICE_AUTO;
     ops_tx->framebuff_cnt = 4;
@@ -466,7 +486,7 @@ void ProxyContext::ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx
     ops->port.udp_src_port[MTL_PORT_P] = atoi(request->local_addr.port);
     ops->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops->port.payload_type = 114;
+        ops->port.payload_type = 99;
     } else {
         ops->port.payload_type = request->payload_type_nr;
     }
@@ -474,7 +494,7 @@ void ProxyContext::ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx
     ops->width = request->width;
     ops->height = request->height;
     ops->fps = st_frame_rate_to_st_fps((double)request->fps);
-    ops->input_fmt = ST_FRAME_FMT_YUV422PLANAR10LE; //ST_FRAME_FMT_YUV422PLANAR8;
+    ops->input_fmt = getStFrameFmt(request->pix_fmt);
     ops->device = ST_PLUGIN_DEVICE_AUTO;
     ops->framebuff_cnt = 4;
     ops->pack_type = ST22_PACK_CODESTREAM;
@@ -518,7 +538,7 @@ void ProxyContext::ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx
     strlcpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops->port.payload_type = 114;
+        ops->port.payload_type = 99;
     } else {
         ops->port.payload_type = request->payload_type_nr;
     }
@@ -526,7 +546,7 @@ void ProxyContext::ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx
     ops->width = request->width;
     ops->height = request->height;
     ops->fps = st_frame_rate_to_st_fps((double)request->fps);
-    ops->output_fmt = ST_FRAME_FMT_YUV422PLANAR10LE; //ST_FRAME_FMT_YUV422PLANAR8;
+    ops->output_fmt = getStFrameFmt(request->pix_fmt);
     ops->device = ST_PLUGIN_DEVICE_AUTO;
     ops->framebuff_cnt = 4;
     ops->pack_type = ST22_PACK_CODESTREAM;

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -219,12 +219,10 @@ void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_in
     st_param->pmd[MTL_PORT_P] = mtl_pmd_by_port_name(st_param->port[MTL_PORT_P]);
     st_param->num_ports = 1;
     st_param->flags = MTL_FLAG_BIND_NUMA;
-    st_param->flags |= MTL_FLAG_SHARED_RX_QUEUE;
-    st_param->flags |= MTL_FLAG_SHARED_TX_QUEUE;
+    st_param->flags |= MTL_FLAG_TX_VIDEO_MIGRATE;
+    st_param->flags |= MTL_FLAG_RX_VIDEO_MIGRATE;
     st_param->flags |= request->payload_mtl_flags_mask;
     st_param->pacing = (st21_tx_pacing_way) request->payload_mtl_pacing;
-    // st_param->flags |= MTL_FLAG_TX_VIDEO_MIGRATE;
-    // st_param->flags |= MTL_FLAG_RX_VIDEO_MIGRATE;
     st_param->log_level = MTL_LOG_LEVEL_DEBUG;
     st_param->priv = NULL;
     st_param->ptp_get_time_fn = NULL;
@@ -721,10 +719,9 @@ int ProxyContext::RxStart(const RxControlRequest* request)
 
     if (mDevHandle == NULL) {
         struct mtl_init_params st_param = {};
-        ParseStInitParam(request, &st_param);
-
         /* set default parameters */
-        st_param.flags = MTL_FLAG_BIND_NUMA;
+        st_param.flags |= MTL_FLAG_BIND_NUMA;
+        ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);
         if (mDevHandle == NULL) {
@@ -765,11 +762,9 @@ int ProxyContext::TxStart(const TxControlRequest* request)
 
     if (mDevHandle == NULL) {
         struct mtl_init_params st_param = {};
-
-        ParseStInitParam(request, &st_param);
-
         /* set default parameters */
         st_param.flags = MTL_FLAG_BIND_NUMA;
+        ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);
         if (mDevHandle == NULL) {
@@ -815,7 +810,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         struct mtl_init_params st_param = { 0 };
 
         /* set default parameters */
-        // st_param.flags = MTL_FLAG_BIND_NUMA;
+        st_param.flags = MTL_FLAG_BIND_NUMA;
         ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);
@@ -965,7 +960,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         struct mtl_init_params st_param = { 0 };
 
         /* set default parameters */
-        // st_param.flags = MTL_FLAG_BIND_NUMA;
+        st_param.flags = MTL_FLAG_BIND_NUMA;
         ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -367,7 +367,7 @@ void ProxyContext::ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx
     strlcpy(ops_rx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops_rx->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops_rx->port.payload_type = 96;
+        ops_rx->port.payload_type = ST_APP_PAYLOAD_TYPE_VIDEO;
     } else {
         ops_rx->port.payload_type = request->payload_type_nr;
     }
@@ -437,7 +437,7 @@ void ProxyContext::ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx
     ops_tx->port.udp_src_port[MTL_PORT_P] = atoi(request->local_addr.port);
     ops_tx->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops_tx->port.payload_type = 96;
+        ops_tx->port.payload_type = ST_APP_PAYLOAD_TYPE_VIDEO;
     } else {
         ops_tx->port.payload_type = request->payload_type_nr;
     }
@@ -484,7 +484,7 @@ void ProxyContext::ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx
     ops->port.udp_src_port[MTL_PORT_P] = atoi(request->local_addr.port);
     ops->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops->port.payload_type = 99;
+        ops->port.payload_type = ST_APP_PAYLOAD_TYPE_ST22;
     } else {
         ops->port.payload_type = request->payload_type_nr;
     }
@@ -536,7 +536,7 @@ void ProxyContext::ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx
     strlcpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->port.num_port = 1;
     if(request->payload_type_nr == 0 ) {
-        ops->port.payload_type = 99;
+        ops->port.payload_type = ST_APP_PAYLOAD_TYPE_ST22;
     } else {
         ops->port.payload_type = request->payload_type_nr;
     }
@@ -720,7 +720,6 @@ int ProxyContext::RxStart(const RxControlRequest* request)
     if (mDevHandle == NULL) {
         struct mtl_init_params st_param = {};
         /* set default parameters */
-        st_param.flags |= MTL_FLAG_BIND_NUMA;
         ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);
@@ -763,7 +762,6 @@ int ProxyContext::TxStart(const TxControlRequest* request)
     if (mDevHandle == NULL) {
         struct mtl_init_params st_param = {};
         /* set default parameters */
-        st_param.flags = MTL_FLAG_BIND_NUMA;
         ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);
@@ -810,7 +808,6 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         struct mtl_init_params st_param = { 0 };
 
         /* set default parameters */
-        st_param.flags = MTL_FLAG_BIND_NUMA;
         ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);
@@ -960,7 +957,6 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         struct mtl_init_params st_param = { 0 };
 
         /* set default parameters */
-        st_param.flags = MTL_FLAG_BIND_NUMA;
         ParseStInitParam(request, &st_param);
 
         mDevHandle = inst_init(&st_param);

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -31,11 +31,11 @@ ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® Media Communications Mesh SDK" \
-      org.opencontainers.image.description="Intel® Media Communications Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image" \
-      org.opencontainers.image.version="1.0.0" \
-      org.opencontainers.image.vendor="Intel Corporation" \
-      org.opencontainers.image.licenses="BSD 3-Clause License"
+LABEL org.opencontainers.image.title="Intel® Media Communications Mesh SDK"
+LABEL org.opencontainers.image.description="Intel® Media Communications Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image"
+LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.vendor="Intel Corporation"
+LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
 
 ARG MCM_DIR="/opt/mcm"

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
 
 ARG MCM_DIR=/opt/mcm
-ARG PREFIX_DIR="/usr/local"
+ARG PREFIX_DIR="/install"
 
 SHELL ["/bin/bash", "-exc"]
 RUN apt-get update && \
@@ -24,29 +24,31 @@ RUN apt-get update && \
 
 COPY . ${MCM_DIR}
 WORKDIR ${MCM_DIR}/sdk
-RUN ./build.sh
+RUN INSTALL_PREFIX="${PREFIX_DIR}/usr/local" ./build.sh
 
 ARG IMAGE_CACHE_REGISTRY
 ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
 LABEL maintainer="milosz.linkiewicz@intel.com"
-LABEL org.opencontainers.image.title="Intel® Media Communication Mesh SDK" \
-      org.opencontainers.image.description="Intel® Media Communication Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image" \
+LABEL org.opencontainers.image.title="Intel® Media Communications Mesh SDK" \
+      org.opencontainers.image.description="Intel® Media Communications Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image" \
       org.opencontainers.image.version="1.0.0" \
       org.opencontainers.image.vendor="Intel Corporation" \
       org.opencontainers.image.licenses="BSD 3-Clause License"
 
-ARG HOME="/home/${USER}"
-ARG MCM_DIR=/opt/mcm
-ARG PREFIX_DIR="/usr/local"
 
+ARG MCM_DIR="/opt/mcm"
+ARG PREFIX_DIR="/install"
+
+ENV HOME="${MCM_DIR}"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
-ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
+ENV PATH="/usr/local/bin:$HOME/.local/bin:$PATH"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
 
 SHELL ["/bin/bash", "-exc"]
+WORKDIR "/opt/mcm/"
 RUN apt-get update && \
     apt-get full-upgrade -y && \
     apt-get install --no-install-recommends -y \
@@ -54,16 +56,15 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 2110 vfio && \
-    useradd -m -s /bin/bash -G vfio -u 1002 mcm && \
+    groupadd -g 1001 imtl && \
+    useradd -m -s /bin/bash -G vfio,imtl -u 1002 mcm && \
     usermod -aG sudo mcm
 
-COPY --chown=mcm --from=builder ${MCM_DIR}/sdk/out/samples /opt/mcm/
-COPY --chown=mcm --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
-COPY --chown=mcm --from=builder ${MCM_DIR}/sdk/out/samples /usr/local/bin/
+COPY --chown=1002 --from=builder "${PREFIX_DIR}" /
+COPY --chown=1002 --from=builder "${MCM_DIR}/sdk/build/samples" "${MCM_DIR}"
 
 RUN ldconfig
 
-USER mcm
-WORKDIR /opt/mcm/
+# USER mcm
 
 CMD ["./recver_app"]

--- a/sdk/build.sh
+++ b/sdk/build.sh
@@ -11,11 +11,11 @@ SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 
-cmake -B "${SCRIPT_DIR}/out" \
+cmake -B "${SCRIPT_DIR}/build" \
     -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     "${SCRIPT_DIR}"
-cmake --build "${SCRIPT_DIR}/out" -j
+cmake --build "${SCRIPT_DIR}/build" -j
 
 # Install
-run_as_root_user cmake --install "${SCRIPT_DIR}/out"
+run_as_root_user cmake --install "${SCRIPT_DIR}/build"

--- a/sdk/include/mcm_dp.h
+++ b/sdk/include/mcm_dp.h
@@ -103,9 +103,9 @@ typedef enum {
     PIX_FMT_YUV422P,
     /* YUV 4:2:2 10bit planar le */
     PIX_FMT_YUV422P_10BIT_LE,
-    /* YUV 4:4:4 */
-    PIX_FMT_YUV444M,
-    /* RGB */
+    /* YUV 4:4:4 10bit planar le */
+    PIX_FMT_YUV444P_10BIT_LE,
+    /* RGB 8bit packed RGB,RGB,...*/
     PIX_FMT_RGB8,
 } video_pixel_format;
 

--- a/sdk/samples/recver_app.c
+++ b/sdk/samples/recver_app.c
@@ -109,7 +109,6 @@ transport frame without conversion. The frame should not have lines padding) */
         case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
         default:
             size = pixels * 2 * 2;
-            break;
     }
     if (interlaced) size /= 2; /* if all fmt support interlace? */
     return (int)size;

--- a/sdk/samples/sender_app.c
+++ b/sdk/samples/sender_app.c
@@ -87,16 +87,13 @@ void usage(FILE* fp, const char* path)
     fprintf(fp, "\n");
 }
 
-size_t getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, bool interlaced)
+static int getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, bool interlaced)
 {
     size_t size = 0;
     size_t pixels = (size_t)(width*height);
     switch (fmt) {
         case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY) */
             size = pixels * 2;
-            break;
-        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
-            size = pixels * 2 * 2;
             break;
         case PIX_FMT_RGB8:
             size = pixels * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
@@ -105,12 +102,18 @@ size_t getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, boo
 none-RFC4175 formats like I420/NV12. When this input/output format is set, the frame is identical to
 transport frame without conversion. The frame should not have lines padding) */
         case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
-        default:
             size = pixels * 3 / 2;
+            break;
+        case PIX_FMT_YUV444P_10BIT_LE:
+            size = pixels * 2 * 3;
+            break;
+        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
+        default:
+            size = pixels * 2 * 2;
             break;
     }
     if (interlaced) size /= 2; /* if all fmt support interlace? */
-    return size;
+    return (int)size;
 }
 
 int read_test_data(FILE* fp, mcm_buffer* buf, uint32_t frame_size, bool loop)
@@ -179,7 +182,7 @@ int main(int argc, char** argv)
     uint32_t width = DEFAULT_FRAME_WIDTH;
     uint32_t height = DEFAULT_FRAME_HEIGHT;
     double vid_fps = DEFAULT_FPS;
-    video_pixel_format pix_fmt = PIX_FMT_YUV422P_10BIT_LE; //PIX_FMT_YUV444M;
+    video_pixel_format pix_fmt = PIX_FMT_YUV422P_10BIT_LE;;
     uint32_t frame_size = 0;
 
     mcm_conn_context* dp_ctx = NULL;
@@ -272,8 +275,8 @@ int main(int argc, char** argv)
                 pix_fmt = PIX_FMT_YUV422P;
             } else if (strncmp(pix_fmt_string, "yuv422p10le", sizeof(pix_fmt_string)) == 0) {
                 pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
-            } else if (strncmp(pix_fmt_string, "yuv444m", sizeof(pix_fmt_string)) == 0){
-                pix_fmt = PIX_FMT_YUV444M;
+            } else if (strncmp(pix_fmt_string, "yuv444p10le", sizeof(pix_fmt_string)) == 0){
+                pix_fmt = PIX_FMT_YUV444P_10BIT_LE;
             } else if (strncmp(pix_fmt_string, "rgb8", sizeof(pix_fmt_string)) == 0){
                 pix_fmt = PIX_FMT_RGB8;
             } else {

--- a/sdk/samples/sender_app.c
+++ b/sdk/samples/sender_app.c
@@ -89,28 +89,26 @@ void usage(FILE* fp, const char* path)
 
 static int getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, bool interlaced)
 {
-    size_t size = 0;
-    size_t pixels = (size_t)(width*height);
+    size_t size = (size_t)(width*height);
     switch (fmt) {
         case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY) */
-            size = pixels * 2;
+            size = size * 2;
             break;
         case PIX_FMT_RGB8:
-            size = pixels * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
+            size = size * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
             break;
 /* Customized YUV 420 8bit, set transport format as ST20_FMT_YUV_420_8BIT. For direct transport of
 none-RFC4175 formats like I420/NV12. When this input/output format is set, the frame is identical to
 transport frame without conversion. The frame should not have lines padding) */
         case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
-            size = pixels * 3 / 2;
+            size = size * 3 / 2;
             break;
         case PIX_FMT_YUV444P_10BIT_LE:
-            size = pixels * 2 * 3;
+            size = size * 2 * 3;
             break;
         case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
         default:
-            size = pixels * 2 * 2;
-            break;
+            size = size * 2 * 2;
     }
     if (interlaced) size /= 2; /* if all fmt support interlace? */
     return (int)size;
@@ -182,7 +180,7 @@ int main(int argc, char** argv)
     uint32_t width = DEFAULT_FRAME_WIDTH;
     uint32_t height = DEFAULT_FRAME_HEIGHT;
     double vid_fps = DEFAULT_FPS;
-    video_pixel_format pix_fmt = PIX_FMT_YUV422P_10BIT_LE;;
+    video_pixel_format pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
     uint32_t frame_size = 0;
 
     mcm_conn_context* dp_ctx = NULL;


### PR DESCRIPTION
[Input/Output FMT pixel format made configurable.](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/d985a0b3c52e450bbce713a48a4dc370a5aaba2a) 


Output FMT pixel format made configurable.
- FMT pixel format removed `PIX_FMT_YUV444M` in favor of `PIX_FMT_YUV444P_10BIT_LE`. There is minimum support for any YUV_444M (YUV_444 8BIT Planar).
- Corrections have been made in source code and `getFrameSize()` methods inside the code - refactor.
- `ProxyContext` Class have now an private method for `getStFrameFmt()`. This allows to move from MCM FMT `enum` to iMTL FMT `enum` for output/input purposes. This function cover all available formats after YUV444M removal.
- rx_session_context_t have been extended by additional parameters including output_fmt for making this parameter configurable
- removed big chunk of code as the null pointer is never possible to reach as parameter is passed always by reference
- build and setup scripts with minor fix

**Signed-off-by:** Milosz Linkiewicz <milosz.linkiewicz@intel.com> [Mionsz](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commits?author=Mionsz)

[JPEG XS added and FFmpeg plugin extended](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/08c216ae00d8407be7f38849e18bdf0803e9702a) 

JPEG XS added and FFmpeg plugin extended:
- JPEG XS plugin build workflow added inside media-proxy image build
- FFmpeg plugin all available MCM pixel_formats have been added
- FFmpeg plugin now can send/receive data in st22 encoded format.
- payload_codec is still hardcoded
- payload id number is now made 96 and 99 by default instead 112 and 114

**Signed-off-by:** Milosz Linkiewicz <milosz.linkiewicz@intel.com> [Mionsz](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commits?author=Mionsz)

[Media Proxy docker image minimal rruntime-size](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/903143035c945f64ba3aa33228bd075dd7ca4dc1) 

Media Proxy docker image minimal runtime-size
- removed all unused during runtime files and libraries
- added `.dockerignore` to the repository for docker context not to load local build results
- moved `FFmpeg` build output to out/FFmpeg in root GitHub directory structure for jpeg xs plugin build prepaaration process.
- naming convention fixed as valid form should be Media Communications Mesh in plural.
- docker container can now be graduated to initial version of 1.0.0

**Signed-off-by:** Milosz Linkiewicz <milosz.linkiewicz@intel.com> [Mionsz](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commits?author=Mionsz)

[Test Docker Buildx Action Added](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commit/288be3c9504527f3daabfce22dc696d423086cbf) 

Docker GitHub Action: Buildx build.

Simple setup of Docker buildx build envrionment with multiplatform build engine based on QEMUI

Simple build steps added for all Docker images in MCM repository:
- mcm/sdk -- simple application based on sdk
- mcm/ffmepg -- ffmpeg with mcm-mux, mcm-demux and JPEG XS library integrated
- mcm/media-proxy -- main application Docker image with JPEG XS library on iMTL/mcm side as st2110-22 - tested and works just by changing st20 to st22 on startup.

Will be developed further if we intend to do so. This is brings us really close to running tests and validation based on containers. What is important I have manage to make media-proxy image very slim. It was ~3.0Gb now it is 494Mb

**Signed-off-by:** Milosz Linkiewicz <milosz.linkiewicz@intel.com> [Mionsz](https://github.com/OpenVisualCloud/Media-Communications-Mesh/commits?author=Mionsz)
