### PR TITLE
Fix segfault in MCM FFmpeg plugin occurred in memcpy

### DIFF
--- a/ffmpeg-plugin/mcm_rx.c
+++ b/ffmpeg-plugin/mcm_rx.c
@@ -209,7 +209,7 @@ static int mcm_read_packet(AVFormatContext* avctx, AVPacket* pkt)
     if ((ret = av_new_packet(pkt, s->frame_size)) < 0)
         return ret;
 
-    memcpy(pkt->data, buf->data, s->frame_size);
+    memcpy(pkt->data, buf->data, FFMIN(s->frame_size, buf->len));
 
     pkt->pts = pkt->dts = AV_NOPTS_VALUE;
 


### PR DESCRIPTION
In mcm_read_packet() the length of the buffer received from media_proxy can be smaller than the configured frame size. Passing the size argument to memcpy() being larger than the source buffer size can lead to a segmentation fault.

This commit fixes this issue by passing the size argument to memcpy() as the lowest value between the configured frame size and the actual Rx buffer length.