### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -26,6 +26,8 @@ include(compile_options)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_IPATH ${CMAKE_INSTALL_PREFIX}/include)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
 
 aux_source_directory(${MCMDP_SRC_DIR} sdk_srcs)
 add_library(mcm_dp SHARED ${sdk_srcs})

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MCMDP_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(MCMDP_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(MEMIF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/libmemif)
 set(MCMDP_SAMPLE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/samples)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
 add_subdirectory(${MEMIF_DIR})
 
@@ -26,8 +27,6 @@ include(compile_options)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_IPATH ${CMAKE_INSTALL_PREFIX}/include)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-
 
 aux_source_directory(${MCMDP_SRC_DIR} sdk_srcs)
 add_library(mcm_dp SHARED ${sdk_srcs})


### PR DESCRIPTION
Update CMakeLists.txt append "-fPIC" flag, without that some compilers return error
```
/usr/bin/ld: CMakeFiles/sender_app.dir/sender_app.c.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: CMakeFiles/recver_app.dir/recver_app.c.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIE
collect2: error: ld returned 1 exit status
collect2: error: ld returned 1 exit status
```