### PR TITLE
Dockerfiles adjustments to meet Trivy requirements.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,13 +4,17 @@ build
 out/*
 build/*
 
+sdk/out/*
+sdk/build/*
+
 ffmpeg-plugin/build/*
 ffmpeg-plugin/out/*
 ffmpeg-plugin/FFmpeg/*
-
 .git/*
 
 # for gRPC protos
+media-proxy/out/*
+media-proxy/build/*
 media-proxy/protos/controller.grpc.pb.cc
 media-proxy/protos/controller.grpc.pb.h
 media-proxy/protos/controller.pb.cc

--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -6,7 +6,7 @@
 ARG IMAGE_CACHE_REGISTRY=docker.io
 ARG IMAGE_NAME=library/ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
 
-FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as builder
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
@@ -68,12 +68,18 @@ RUN apt-get update && \
     useradd -m -s /bin/bash -G vfio,imtl -u 1002 mcm && \
     usermod -aG sudo mcm
 
-COPY --chown=1002 --from=builder "${PREFIX_DIR}" /
-COPY --chown=1002 --from=builder "${MCM_DIR}/sdk/build/samples" "${MCM_DIR}"
+COPY --chown=mcm --from=builder "${PREFIX_DIR}" /
+COPY --chown=mcm --chmod=755 --from=builder "${MCM_DIR}/sdk/build/samples/recver_app" "${MCM_DIR}/recver_app"
+COPY --chown=mcm --chmod=755 --from=builder "${MCM_DIR}/sdk/build/samples/sender_app" "${MCM_DIR}/sender_app"
 
 RUN ldconfig
 
-# USER 1002
+USER mcm
 WORKDIR /opt/mcm/
+EXPOSE 8001/tcp 8002/tcp
 
-CMD ["ffmpeg"]
+CMD ["--help"]
+SHELL ["/bin/bash", "-c"]
+ENTRYPOINT ["/usr/local/bin/ffmpeg"]
+
+HEALTHCHECK --interval=30s --timeout=5s CMD ps aux | grep "ffmpeg" || exit 1

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -6,7 +6,7 @@
 ARG IMAGE_CACHE_REGISTRY=docker.io
 ARG IMAGE_NAME=library/ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
 
-FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as builder
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} AS builder
 
 ARG PREFIX_DIR="/install"
 ARG MCM_DIR="/opt/mcm"
@@ -21,9 +21,9 @@ ARG GRPC_DIR="/opt/grpc"
 ARG JPEGXS_VER="e1030c6c8ee2fb05b76c3fa14cccf8346db7a1fa"
 ARG JPEGXS_DIR="/opt/jpegxs"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ="Europe/Warsaw"
-ENV PATH="${PREFIX_DIR}/bin:$HOME/.local/bin:$HOME/bin:$HOME/usr/bin:$PATH"
+ENV PATH="${PREFIX_DIR}/bin:/root/.local/bin:/root/bin:/root/usr/bin:$PATH"
 
 SHELL ["/bin/bash", "-ex", "-o", "pipefail", "-c"]
 # Install package dependencies
@@ -35,7 +35,7 @@ RUN apt-get update --fix-missing && \
         libnuma-dev libjson-c-dev libpcap-dev libgtest-dev \
         libsdl2-dev libsdl2-ttf-dev libssl-dev ca-certificates \
         m4 clang llvm zlib1g-dev libelf-dev libcap-ng-dev \
-        libcap2-bin gcc-multilib systemtap-sdt-dev librdmacm-dev && \
+        gcc-multilib systemtap-sdt-dev librdmacm-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -96,8 +96,6 @@ RUN ./build.sh build-only && \
 WORKDIR ${MCM_DIR}
 COPY . ${MCM_DIR}
 RUN INSTALL_PREFIX="${PREFIX_DIR}/usr/local" ./build.sh && \
-    setcap 'cap_ipc_lock+ep cap_ipc_owner+ep' /install/usr/local/bin/media_proxy && \
-    setcap 'cap_net_bind_service+ep cap_net_broadcast+ep cap_net_raw+ep' /install/usr/local/bin/media_proxy && \
     rm -rf "${PREFIX_DIR}/usr/local/lib/lib"*.a && \
     rm -rf "${PREFIX_DIR}/usr/local/bin/dpdk-test"* && \
     rm -rf "${PREFIX_DIR}/usr/local/bin/"*_plugin && \
@@ -139,8 +137,13 @@ RUN apt-get update --fix-missing && \
 COPY --chown=mcm --from=builder /install /
 
 RUN ldconfig
+USER mcm
+WORKDIR /opt/mcm/
 
-EXPOSE 8001 8002
-CMD ["media_proxy"]
+EXPOSE 8001/tcp 8002/tcp
+
+CMD ["--help"]
+SHELL ["/bin/bash", "-c"]
+ENTRYPOINT ["/usr/local/bin/media_proxy"]
 
 HEALTHCHECK --interval=30s --timeout=5s CMD ps aux | grep "media_proxy" || exit 1

--- a/sdk/3rdparty/libmemif/CMakeLists.txt
+++ b/sdk/3rdparty/libmemif/CMakeLists.txt
@@ -74,6 +74,7 @@ endforeach()
 #   OUTPUT_STRIP_TRAILING_WHITESPACE
 # )
 set(VER "v24.06-rc2stable-256-g55457075d")
+message(STATUS "Memif library version: ${VER}")
 string(REGEX REPLACE "v(.*)-([0-9]+)-(g[0-9a-f]+)" "\\1;\\2;\\3" VER ${VER})
 list(GET VER 0 tag)
 list(GET VER 1 commit_num)

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -6,7 +6,7 @@
 ARG IMAGE_CACHE_REGISTRY=docker.io
 ARG IMAGE_NAME=library/ubuntu:22.04@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
 
-FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as builder
+FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
@@ -44,7 +44,7 @@ ARG PREFIX_DIR="/install"
 ENV HOME="${MCM_DIR}"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
-ENV PATH="/usr/local/bin:$HOME/.local/bin:$PATH"
+ENV PATH="/usr/local/bin:/home/mcm/.local/bin:/root/.local/bin:$PATH"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
 
 SHELL ["/bin/bash", "-exc"]
@@ -61,10 +61,15 @@ RUN apt-get update && \
     usermod -aG sudo mcm
 
 COPY --chown=1002 --from=builder "${PREFIX_DIR}" /
-COPY --chown=1002 --from=builder "${MCM_DIR}/sdk/build/samples" "${MCM_DIR}"
+COPY --chown=1002 --chmod=755 --from=builder "${MCM_DIR}/sdk/build/samples/recver_app" "${MCM_DIR}/recver_app"
+COPY --chown=1002 --chmod=755 --from=builder "${MCM_DIR}/sdk/build/samples/sender_app" "${MCM_DIR}/sender_app"
 
 RUN ldconfig
+WORKDIR /opt/mcm/
+EXPOSE 8001/tcp 8002/tcp
 
-# USER mcm
+USER mcm
 
-CMD ["./recver_app"]
+CMD ["--help"]
+SHELL ["/bin/bash", "-c"]
+ENTRYPOINT ["${MCM_DIR}/recver_app"]


### PR DESCRIPTION
Dockerfile adjustments to meet high standards of Trivy scan based report:
- exposed used port 8001 and 8002
- default user set to  mcm
- entrypoint, cmd and shell are now valid
- minor .Dockerignore and Dockerfile adjustments