### PR TITLE
Fix integer overflow in mcm_send_buffer_udp

### DIFF
--- a/sdk/src/udp_impl.c
+++ b/sdk/src/udp_impl.c
@@ -131,12 +131,14 @@ int mcm_send_buffer_udp(void* conn_ctx, mcm_buffer* buf)
     while (len > 0) {
         n = sendto(ctx->sockfd, data, len, MSG_CONFIRM,
             (const struct sockaddr*)&ctx->rx_addr, sizeof(ctx->rx_addr));
-        if (n == -1) {
+
+        if (n < 0) {
             log_error("Fail to send out data.");
             ret = -1;
             break;
+        } else if (len < n) {
+            n = len;
         }
-
         len -= n;
         data += n;
     }


### PR DESCRIPTION
Fix integer overflow in `mcm_send_buffer_udp`

Additional value check was added.