### PR TITLE
Remove metadata from sent buffer

### DIFF
--- a/sdk/samples/recver_app.c
+++ b/sdk/samples/recver_app.c
@@ -353,8 +353,6 @@ int main(int argc, char** argv)
             }
             break;
         }
-        printf("INFO: buf->metadata.seq_num   = %u\n", buf->metadata.seq_num);
-        printf("INFO: buf->metadata.timestamp = %u\n", buf->metadata.timestamp);
         printf("INFO: buf->len = %ld frame size = %u\n", buf->len, frm_size);
 
         clock_gettime(CLOCK_REALTIME, &ts_recv);

--- a/tests/single-node-sample-apps/test.sh
+++ b/tests/single-node-sample-apps/test.sh
@@ -294,7 +294,7 @@ function run_test_stXX() {
     recver_app_pid=$!
 
     info "Waiting for recver_app to connect to Rx media_proxy"
-    wait_text 10 $recver_app_out "Success connect to MCM media-proxy"
+    wait_text 50 $recver_app_out "Success connect to MCM media-proxy"
     local recver_app_timeout=$?
     [ $recver_app_timeout -eq 0 ] && info "Connection established"
 
@@ -305,7 +305,7 @@ function run_test_stXX() {
     sender_app_pid=$!
 
     info "Waiting for sender_app to connect to Tx media_proxy"
-    wait_text 10 $sender_app_out "Success connect to MCM media-proxy"
+    wait_text 100 $sender_app_out "Success connect to MCM media-proxy"
     local sender_app_timeout=$?
     [ $sender_app_timeout -eq 0 ] && info "Connection established"
 


### PR DESCRIPTION
Video data was overwritten with metadata, which resulted in not enough data being sent