### PR TITLE
Run basic implementation of AF_XDP/eBPF

### DIFF
--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -136,7 +136,7 @@ RUN apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
        ca-certificates libbsd0 libnuma1 libjson-c5 libpcap0.8 libsdl2-2.0-0 libsdl2-ttf-2.0-0 \
        libssl3 zlib1g libelf1 libcap-ng0 libatomic1 librdmacm1 systemtap sudo \
-       librte-net-mlx4-22 librte-net-mlx5-22 ethtool && \
+       librte-net-mlx4-22 librte-net-mlx5-22 libfdt1 ethtool && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 2110 vfio && \

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -24,6 +24,7 @@ ARG JPEGXS_DIR="/opt/jpegxs"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ="Europe/Warsaw"
 ENV PATH="${PREFIX_DIR}/bin:/root/.local/bin:/root/bin:/root/usr/bin:$PATH"
+ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib/x86_64-linux-gnu/pkgconfig
 
 SHELL ["/bin/bash", "-ex", "-o", "pipefail", "-c"]
 # Install package dependencies
@@ -35,7 +36,7 @@ RUN apt-get update --fix-missing && \
         libnuma-dev libjson-c-dev libpcap-dev libgtest-dev \
         libsdl2-dev libsdl2-ttf-dev libssl-dev ca-certificates \
         m4 clang llvm zlib1g-dev libelf-dev libcap-ng-dev \
-        gcc-multilib systemtap-sdt-dev librdmacm-dev && \
+        gcc-multilib systemtap-sdt-dev librdmacm-dev libfdt-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -52,19 +53,22 @@ RUN git config --global user.email "milosz.linkiewicz@intel.com" && \
     git -C ${JPEGXS_DIR} checkout ${JPEGXS_VER} && \
     git am ${MTL_DIR}/patches/dpdk/${DPDK_VER}/*.patch
 
-RUN meson setup build && \
-    ninja -C build && \
-    meson install -C build && \
-    DESTDIR="${PREFIX_DIR}" meson install -C build
-
 # Build the xdp-tools project
 WORKDIR ${XDP_DIR}
 RUN ./configure && \
     make && \
     make install && \
     DESTDIR="${PREFIX_DIR}" make install && \
+    make -C "${XDP_DIR}/lib/libbpf/src" && \
     make -C "${XDP_DIR}/lib/libbpf/src" install && \
     DESTDIR="${PREFIX_DIR}" make -C "${XDP_DIR}/lib/libbpf/src" install
+
+# Build the DPDK
+WORKDIR ${DPDK_DIR}
+RUN meson setup build && \
+    ninja -C build && \
+    meson install -C build && \
+    DESTDIR="${PREFIX_DIR}" meson install -C build
 
 # Build MTL
 WORKDIR ${MTL_DIR}
@@ -97,10 +101,10 @@ WORKDIR ${MCM_DIR}
 COPY . ${MCM_DIR}
 RUN INSTALL_PREFIX="${PREFIX_DIR}/usr/local" ./build.sh && \
     cp "${MTL_DIR}/build/manager/MtlManager" "${PREFIX_DIR}/usr/local/bin/" && \
+    cp -fR "/usr/local/lib/bpf/"* "${PREFIX_DIR}/usr/local/lib/bpf/" && \
     rm -rf "${PREFIX_DIR}/usr/lib64/"*.a && \
     rm -rf "${PREFIX_DIR}/usr/include" && \
     rm -rf "${PREFIX_DIR}/usr/local/share" && \
-    rm -rf "${PREFIX_DIR}/usr/local/lib/bpf" && \
     rm -rf "${PREFIX_DIR}/usr/local/lib/lib"*.a && \
     rm -rf "${PREFIX_DIR}/usr/local/lib/x86_64-linux-gnu/"*.a && \
     rm -rf "${PREFIX_DIR}/usr/local/bin/dpdk-"* && \

--- a/media-proxy/README.md
+++ b/media-proxy/README.md
@@ -42,7 +42,7 @@ Notice that the device must have a pre-assigned IP address. The `--ip` parameter
 
 > [!CAUTION]
 > `MtlManager` from the Media-Transport-Library `manager` subdirectory must be running.
-> Only a device physical function with a preconfigured IP address can be used for the `native_af_xdp` mode.
+> Only a device physical function with a pre-configured IP address can be used for the `native_af_xdp` mode.
 
 ### Docker
 The Media Proxy can be run as a docker container.

--- a/media-proxy/README.md
+++ b/media-proxy/README.md
@@ -37,12 +37,12 @@ Usage: media_proxy [OPTION]
 
 #### Run media-proxy using `native_af_xdp`
 
-To use media-proxy with native `af_xdp/ebpf` device name should be provided with prefix `native_af_xdp:`, for example `media-proxy --dev native_af_xdp:ens259f0np0`.
+To use media-proxy with the native `af_xdp/ebpf` device a device name should be provided with the `native_af_xdp:` prefix, for example `media-proxy --dev native_af_xdp:ens259f0np0`.
 Notice that device must have a preassigned IP address and `--ip` parameter will not work.
 
 > [!CAUTION]
-> `MtlManager`, from Media-Transport-Library `manager` subdirectory, must be running
-> Only device physical function with preconfigured IP address can be used for `native_af_xdp` mode.
+> `MtlManager` from the Media-Transport-Library `manager` subdirectory must be running.
+> Only a device physical function with a preconfigured IP address can be used for the `native_af_xdp` mode.
 
 ### Docker
 The Media Proxy can be run as a docker container.

--- a/media-proxy/README.md
+++ b/media-proxy/README.md
@@ -35,6 +35,15 @@ Usage: media_proxy [OPTION]
 -t, --tcp=port_number   Port number for TCP socket controller (defaults: 8002).
 ```
 
+#### Run media-proxy using `native_af_xdp`
+
+To use media-proxy with native `af_xdp/ebpf` device name should be provided with prefix `native_af_xdp:`, for example `media-proxy --dev native_af_xdp:ens259f0np0`.
+Notice that device must have a preassigned IP address and `--ip` parameter will not work.
+
+> [!CAUTION]
+> `MtlManager`, from Media-Transport-Library `manager` subdirectory, must be running
+> Only device physical function with preconfigured IP address can be used for `native_af_xdp` mode.
+
 ### Docker
 The Media Proxy can be run as a docker container.
 Since Media Proxy depends on the MTL library, so you need to [setup MTL](https://github.com/OpenVisualCloud/Media-Transport-Library/blob/main/doc/run.md) on the host first.

--- a/media-proxy/README.md
+++ b/media-proxy/README.md
@@ -38,7 +38,7 @@ Usage: media_proxy [OPTION]
 #### Run media-proxy using `native_af_xdp`
 
 To use media-proxy with the native `af_xdp/ebpf` device a device name should be provided with the `native_af_xdp:` prefix, for example `media-proxy --dev native_af_xdp:ens259f0np0`.
-Notice that device must have a preassigned IP address and `--ip` parameter will not work.
+Notice that the device must have a pre-assigned IP address. The `--ip` parameter is not applied in this mode.
 
 > [!CAUTION]
 > `MtlManager` from the Media-Transport-Library `manager` subdirectory must be running.

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -225,14 +225,21 @@ void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_in
     st_param->log_level = MTL_LOG_LEVEL_DEBUG;
     st_param->priv = NULL;
     st_param->ptp_get_time_fn = NULL;
-    st_param->rx_queues_cnt[MTL_PORT_P] = 128;
-    st_param->tx_queues_cnt[MTL_PORT_P] = 128;
+    // Native af_xdp have only 62 queues available
+    if(st_param->pmd[MTL_PORT_P] == MTL_PMD_NATIVE_AF_XDP) {
+      st_param->rx_queues_cnt[MTL_PORT_P] = 62;
+      st_param->tx_queues_cnt[MTL_PORT_P] = 62;
+    } else {
+      st_param->rx_queues_cnt[MTL_PORT_P] = 128;
+      st_param->tx_queues_cnt[MTL_PORT_P] = 128;
+    }
     st_param->lcores = NULL;
     st_param->memzone_max = 9000;
 
     INFO("ProxyContext: ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* st_param)");
     INFO("num_ports : '%d'", st_param->num_ports);
     INFO("port      : '%s'", st_param->port[MTL_PORT_P]);
+    INFO("port pmd  : '%d'", int(st_param->pmd[MTL_PORT_P]));
     INFO("sip_addr  : '%s'", getDataPlaneAddress().c_str());
     INFO("flags:    : '%ld'", st_param->flags);
     INFO("log_level : %d", st_param->log_level);

--- a/tests/single-node-sample-apps/README.md
+++ b/tests/single-node-sample-apps/README.md
@@ -31,7 +31,7 @@ sudo ./test.sh <test-option> <pf-bdf> <input-file> <duration> <frames_number> <w
    * `memif` – use a memif direct connection
    * `st20` – use an ST20 connection via media proxy
    * `st22` – use an ST22 connection via media proxy
-   * `af_xdp` - use native_af_xdp connection for media proxy. MtlManager required.
+   * `af_xdp` - use a native_af_xdp connection for media proxy. MtlManager is required to be available in $PATH.
 
 * `pf-bdf` – NIC PF bus device function, default `0000:32:00.1`. VFs will be created on top of this PF.
 * `input-file` – input video file path
@@ -116,3 +116,12 @@ TBD
 sudo ./test.sh st22 0000:32:00.1 video.yuv 30 300 640 360 60 yuv422p10le
 ```
 TBD
+
+## Run test – af_xdp
+
+### Prerequisites
+1. Build and install MtlManager from [MTL repository](https://github.com/OpenVisualCloud/Media-Transport-Library/tree/main/manager).
+
+```bash
+sudo ./test.sh af_xdp 0000:32:00.1 video.yuv 30 300 640 360 60 yuv422p10le
+```

--- a/tests/single-node-sample-apps/README.md
+++ b/tests/single-node-sample-apps/README.md
@@ -31,6 +31,7 @@ sudo ./test.sh <test-option> <pf-bdf> <input-file> <duration> <frames_number> <w
    * `memif` – use a memif direct connection
    * `st20` – use an ST20 connection via media proxy
    * `st22` – use an ST22 connection via media proxy
+   * `af_xdp` - use native_af_xdp connection for media proxy. MtlManager required.
 
 * `pf-bdf` – NIC PF bus device function, default `0000:32:00.1`. VFs will be created on top of this PF.
 * `input-file` – input video file path

--- a/tests/single-node-sample-apps/test.sh
+++ b/tests/single-node-sample-apps/test.sh
@@ -375,10 +375,6 @@ do
 
     case $test_option in
         af_xdp)
-            if [ -n "$debug" ]; then
-                error "Work in progress."
-                exit 0
-            fi
             run_test_af_xdp_rx
             run_test_af_xdp_tx
             ;;

--- a/tests/single-node-sample-apps/test.sh
+++ b/tests/single-node-sample-apps/test.sh
@@ -6,6 +6,7 @@
 # Directories
 script_dir="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
 . "${script_dir}/test_memif.sh"
+. "${script_dir}/test_af_xdp.sh"
 bin_dir="$script_dir/../../out/bin"
 out_dir="$script_dir/out"
 
@@ -31,6 +32,7 @@ pixel_format="${9:-yuv422p10le}"
 wait_interval=$((duration + 5))
 
 # Stdout/stderr forwarded output file names
+mtl_manager_out="$out_dir/out_mtl_manager.txt"
 tx_media_proxy_out="$out_dir/out_tx_media_proxy.txt"
 rx_media_proxy_out="$out_dir/out_rx_media_proxy.txt"
 sender_app_out="$out_dir/out_sender_app.txt"
@@ -372,6 +374,14 @@ do
     mkdir -p "$out_dir"
 
     case $test_option in
+        af_xdp)
+            if [ -n "$debug" ]; then
+                error "Work in progress."
+                exit 0
+            fi
+            run_test_af_xdp_rx
+            run_test_af_xdp_tx
+            ;;
         memif)
             run_test_memif
             run_test_memif_tx

--- a/tests/single-node-sample-apps/test_af_xdp.sh
+++ b/tests/single-node-sample-apps/test_af_xdp.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+
+function run_test_af_xdp_rx()
+{
+    return 0
+
+    iface_name="$($nicctl list all | grep $nic_pf | cut -f6)"
+    iface_ip="$(ip -json a show $iface_name | jq '.[0].addr_info[0].local' -r)"
+    ip_last_octet="$(echo $iface_ip | cut -d'.' -f4)"
+    iface_new_ip="$(echo $iface_ip | cut -d'.' -f1-3).$((ip_last_octet+1))"
+
+    mkdir -p "$out_dir"
+
+    info "Connection type: af_xdp af_xdp_rx"
+    info "iface_name: $iface_name"
+    info "iface_ip: $iface_ip"
+    info "iface_new_ip: $iface_new_ip"
+
+    info "Starting MtlManager"
+    local mtl_manager_cmd="MtlManager"
+    run_in_background "$mtl_manager_cmd" "$mtl_manager_out"
+    mtl_manager_pid=$!
+
+    sleep 1
+
+    info "Starting Tx side media_proxy"
+    local tx_media_proxy_cmd="media_proxy -d $tx_vf_bdf -i $iface_new_ip -t 8002"
+    info "tx_media_proxy_cmd=$tx_media_proxy_cmd"
+    run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
+    tx_media_proxy_pid=$!
+
+    sleep 1
+
+    info "Starting Rx side media_proxy"
+    local rx_media_proxy_cmd="media_proxy -d native_af_xdp:$iface_name -i $iface_ip -t 8003"
+    info "rx_media_proxy_cmd=$rx_media_proxy_cmd"
+    run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
+    rx_media_proxy_pid=$!
+
+    sleep 1
+
+    info "Starting recver_app"
+    export MCM_MEDIA_PROXY_PORT=8003
+    local recver_app_cmd="recver_app -r $iface_new_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
+    info "recver_app_cmd=$recver_app_cmd"
+    run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
+    recver_app_pid=$!
+
+    sleep 1
+
+    info "Starting sender_app"
+    export MCM_MEDIA_PROXY_PORT=8002
+    local sender_app_cmd="sender_app -s $iface_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
+    info "sender_app_cmd=$sender_app_cmd"
+    run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
+    sender_app_pid=$!
+
+    wait_completion "$wait_interval"
+    local timeout=$?
+
+    sleep 1
+
+    shutdown_apps
+    kill "$mtl_manager_pid" &>/dev/null
+
+    sleep 1
+
+    check_results
+    local error=$?
+
+    info "Cleanup"
+    cleanup
+
+    return $(($error || $timeout))
+}
+
+function run_test_af_xdp_tx()
+{
+    iface_name="$($nicctl list all | grep $nic_pf | cut -f6)"
+    iface_ip="$(ip -json a show $iface_name | jq '.[0].addr_info[0].local' -r)"
+    ip_last_octet="$(echo $iface_ip | cut -d'.' -f4)"
+    iface_new_ip="$(echo $iface_ip | cut -d'.' -f1-3).$((ip_last_octet+1))"
+
+    mkdir -p "$out_dir"
+
+    info "Connection type: af_xdp af_xdp_tx"
+    info "iface_name: $iface_name"
+    info "iface_ip: $iface_ip"
+    info "iface_new_ip: $iface_new_ip"
+
+    info "Starting MtlManager"
+    local mtl_manager_cmd="MtlManager"
+    run_in_background "$mtl_manager_cmd" "$mtl_manager_out"
+    mtl_manager_pid=$!
+
+    sleep 1
+
+    info "Starting Tx side media_proxy"
+    local tx_media_proxy_cmd="media_proxy -d native_af_xdp:$iface_name -i $iface_ip -t 8002"
+    info "tx_media_proxy_cmd=$tx_media_proxy_cmd"
+    run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
+    tx_media_proxy_pid=$!
+
+    sleep 1
+
+    info "Starting Rx side media_proxy"
+    local rx_media_proxy_cmd="media_proxy -d $rx_vf_bdf -i $iface_new_ip -t 8003"
+    info "rx_media_proxy_cmd=$rx_media_proxy_cmd"
+    run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
+    rx_media_proxy_pid=$!
+
+    sleep 1
+
+    info "Starting recver_app"
+    export MCM_MEDIA_PROXY_PORT=8003
+    local recver_app_cmd="recver_app -r $iface_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
+    info "recver_app_cmd=$recver_app_cmd"
+    run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
+    recver_app_pid=$!
+
+    sleep 1
+
+    info "Starting sender_app"
+    export MCM_MEDIA_PROXY_PORT=8002
+    local sender_app_cmd="sender_app -s $iface_new_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
+    info "sender_app_cmd=$sender_app_cmd"
+    run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
+    sender_app_pid=$!
+
+    wait_completion "$wait_interval"
+    local timeout=$?
+
+    sleep 1
+
+    shutdown_apps
+    kill "$mtl_manager_pid" &>/dev/null
+
+    sleep 1
+
+    check_results
+    local error=$?
+
+    info "Cleanup"
+    cleanup
+
+    return $(($error || $timeout))
+}

--- a/tests/single-node-sample-apps/test_af_xdp.sh
+++ b/tests/single-node-sample-apps/test_af_xdp.sh
@@ -5,8 +5,6 @@
 
 function run_test_af_xdp_rx()
 {
-    return 0
-
     iface_name="$($nicctl list all | grep $nic_pf | cut -f6)"
     iface_ip="$(ip -json a show $iface_name | jq '.[0].addr_info[0].local' -r)"
     ip_last_octet="$(echo $iface_ip | cut -d'.' -f4)"


### PR DESCRIPTION
Run basic implementation of AF_XDP/eBPF using mtl native functions and MtlManager. The enablement of `native_af_xdp` for interfaces used in media-proxy workloads required minor impact changes in Dockerfile build sequence as well as adjustments to proxy_context.cc

Biggest issue was encountered for number of queues that are predefined and hardcoded in media-proxy. Current approach treats ax_xdp as alternative case and uses value `62` instead of `128`  for `rx_queues_cnt` and `tx_queues_cnt`.

Test scripts are partially developed and currently not enabled. After confirmed one node deployment possibility I will adjust and enable them.