### PR TITLE
Cleanup ffmpeg plugin build scripts

### DIFF
--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -31,10 +31,6 @@ RUN git config --global user.email "intel@intel.com" && \
     ./ffmpeg-plugin/clone-and-patch-ffmpeg.sh && \
     ./ffmpeg-plugin/configure-ffmpeg.sh --enable-libx264 --enable-gpl --prefix="${PREFIX_DIR}/usr/local"
 
-# Build and install JPEG XS
-WORKDIR ${MCM_DIR}/ffmpeg-plugin/build/jpegxs/Build/linux
-RUN ./build.sh release --prefix "${PREFIX_DIR}/usr/local" install
-
 WORKDIR ${MCM_DIR}/ffmpeg-plugin
 RUN ./build-ffmpeg.sh
 

--- a/ffmpeg-plugin/clone-and-patch-ffmpeg.sh
+++ b/ffmpeg-plugin/clone-and-patch-ffmpeg.sh
@@ -11,25 +11,12 @@ BUILD_DIR="${BUILD_DIR:-${SCRIPT_DIR}/build}"
 
 # Default to latest 6.1
 FFMPEG_VER="${FFMPEG_VER:-6.1}"
-# Default to latest 0.9
-JPEGXS_VER="${JPEGXS_VER:-e1030c6c8ee2fb05b76c3fa14cccf8346db7a1fa}"
-JPEGXS_ENABLED="${JPEGXS_ENABLED:-1}"
 
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 
 # Clone FFmpeg:
 git clone --branch "release/${FFMPEG_VER}" --depth 1 https://github.com/FFmpeg/FFmpeg.git "${BUILD_DIR}/FFmpeg"
-
-# Clone JPEG XS if JPEGXS_VER is set, else skip:
-if [ "$JPEGXS_ENABLED" == "1" ]; then
-    git clone https://github.com/OpenVisualCloud/SVT-JPEG-XS "${BUILD_DIR}/jpegxs"
-    git -C "${BUILD_DIR}/jpegxs" checkout "${JPEGXS_VER}"
-    git -C "${BUILD_DIR}/FFmpeg" apply --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0001-Enable-JPEG-XS-codec-type.patch
-    git -C "${BUILD_DIR}/FFmpeg" apply --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0002-Allow-JPEG-XS-to-be-stored-in-mp4-mkv-container.patch
-    git -C "${BUILD_DIR}/FFmpeg" apply --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0003-svt-jpegxs-encoder-support.patch
-    git -C "${BUILD_DIR}/FFmpeg" apply --whitespace=fix ${BUILD_DIR}/jpegxs/ffmpeg-plugin/0004-svt-jpegxs-decoder-support.patch
-fi
 
 git -C "${BUILD_DIR}/FFmpeg" apply --whitespace=fix "${SCRIPT_DIR}/${FFMPEG_VER}/"*.patch
 

--- a/ffmpeg-plugin/configure-ffmpeg.sh
+++ b/ffmpeg-plugin/configure-ffmpeg.sh
@@ -9,24 +9,13 @@ SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
 BUILD_DIR="${BUILD_DIR:-${SCRIPT_DIR}/build}"
 . "${SCRIPT_DIR}/../common.sh"
 
-JPEGXS_FLAGS=( )
-JPEGXS_ENABLED="${JPEGXS_ENABLED:-1}"
-
-if [ "$JPEGXS_ENABLED" == "1" ]
-then
-    pushd "${BUILD_DIR}/jpegxs/Build/linux"
-    run_as_root_user ./build.sh release install
-    JPEGXS_FLAGS+=( "--enable-libsvtjpegxs" )
-    popd
-fi
-
 pushd "${BUILD_DIR}/FFmpeg"
 PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" pkg-config --exists --print-errors libmcm_dp
 
 # copy source files to allow the configure tool to find them
 #cp -f ../mcm_* ./libavdevice/
 
-"${BUILD_DIR}/FFmpeg/configure" --enable-shared --enable-mcm ${JPEGXS_FLAGS[@]} $@
+"${BUILD_DIR}/FFmpeg/configure" --enable-shared --enable-mcm $@
 popd
 
 prompt "FFmpeg MCM plugin configuration completed."


### PR DESCRIPTION
Remove  jpeg xs patch application to ffmpeg because:
1. Jpeg xs is not required as direct ffmpeg-plugin,
2. Jpeg xs is used internally by MTL (kahawai.json), call stack: FFMPEG -> MCM -> MTL -> JPEG-XS