### PR TITLE
Fix audio buffer size + Rework of PCM16/24 support

### DIFF
--- a/ffmpeg-plugin/6.1/0001-mcm-add-in-out-dev-support.patch
+++ b/ffmpeg-plugin/6.1/0001-mcm-add-in-out-dev-support.patch
@@ -1,16 +1,16 @@
-From fbb0700ea7bd9b055ae9e43746a7751be88a8955 Mon Sep 17 00:00:00 2001
+From 496a92977701bd5f665afe6b8171208457418585 Mon Sep 17 00:00:00 2001
 From: Konstantin Ilichev <konstantin.ilichev@intel.com>
-Date: Wed, 21 Aug 2024 14:55:08 +0000
+Date: Fri, 6 Sep 2024 18:33:01 +0000
 Subject: [PATCH] Enable FFmpeg support in MCM
 
 ---
- configure                | 9 +++++++++
- libavdevice/Makefile     | 5 +++++
- libavdevice/alldevices.c | 5 +++++
- 3 files changed, 19 insertions(+)
+ configure                | 10 ++++++++++
+ libavdevice/Makefile     |  6 ++++++
+ libavdevice/alldevices.c |  6 ++++++
+ 3 files changed, 22 insertions(+)
 
 diff --git a/configure b/configure
-index 5af693c954..60caa4ebdf 100755
+index ff11033a01..96c17b34c7 100755
 --- a/configure
 +++ b/configure
 @@ -285,6 +285,7 @@ External library support:
@@ -29,19 +29,20 @@ index 5af693c954..60caa4ebdf 100755
      libaom
      libaribcaption
      libass
-@@ -3567,6 +3569,11 @@ xwma_demuxer_select="riffdec"
+@@ -3568,6 +3570,12 @@ xwma_demuxer_select="riffdec"
  android_camera_indev_deps="android camera2ndk mediandk pthreads"
  alsa_indev_deps="alsa"
  alsa_outdev_deps="alsa"
 +mcm_indev_deps="libmcm_dp"
 +mcm_outdev_deps="libmcm_dp"
-+mcm_audio_indev_deps="libmcm_dp"
-+mcm_audio_outdev_deps="libmcm_dp"
++mcm_audio_pcm16_indev_deps="libmcm_dp"
++mcm_audio_pcm24_indev_deps="libmcm_dp"
 +mcm_audio_pcm16_outdev_deps="libmcm_dp"
++mcm_audio_pcm24_outdev_deps="libmcm_dp"
  avfoundation_indev_deps="avfoundation corevideo coremedia pthreads"
  avfoundation_indev_suggest="coregraphics applicationservices"
  avfoundation_indev_extralibs="-framework Foundation"
-@@ -6692,6 +6699,8 @@ enabled libaribb24        && { check_pkg_config libaribb24 "aribb24 > 1.0.3" "ar
+@@ -6693,6 +6701,8 @@ enabled libaribb24        && { check_pkg_config libaribb24 "aribb24 > 1.0.3" "ar
  enabled libaribcaption    && require_pkg_config libaribcaption "libaribcaption >= 1.1.1" "aribcaption/aribcaption.h" aribcc_context_alloc
  enabled lv2               && require_pkg_config lv2 lilv-0 "lilv/lilv.h" lilv_world_new
  enabled libiec61883       && require libiec61883 libiec61883/iec61883.h iec61883_cmp_connect -lraw1394 -lavc1394 -lrom1394 -liec61883
@@ -51,34 +52,36 @@ index 5af693c954..60caa4ebdf 100755
  enabled libbluray         && require_pkg_config libbluray libbluray libbluray/bluray.h bd_open
  enabled libbs2b           && require_pkg_config libbs2b libbs2b bs2b.h bs2b_open
 diff --git a/libavdevice/Makefile b/libavdevice/Makefile
-index c30449201d..62bda757c3 100644
+index c30449201d..1d7c0d1a10 100644
 --- a/libavdevice/Makefile
 +++ b/libavdevice/Makefile
-@@ -20,6 +20,11 @@ OBJS-$(CONFIG_AUDIOTOOLBOX_OUTDEV)       += audiotoolbox.o
+@@ -20,6 +20,12 @@ OBJS-$(CONFIG_AUDIOTOOLBOX_OUTDEV)       += audiotoolbox.o
  OBJS-$(CONFIG_AVFOUNDATION_INDEV)        += avfoundation.o
  OBJS-$(CONFIG_BKTR_INDEV)                += bktr.o
  OBJS-$(CONFIG_CACA_OUTDEV)               += caca.o
 +OBJS-$(CONFIG_MCM_INDEV)                 += mcm_video_rx.o mcm_common.o
 +OBJS-$(CONFIG_MCM_OUTDEV)                += mcm_video_tx.o mcm_common.o
-+OBJS-$(CONFIG_MCM_AUDIO_INDEV)           += mcm_audio_rx.o mcm_common.o
-+OBJS-$(CONFIG_MCM_AUDIO_OUTDEV)          += mcm_audio_tx.o mcm_common.o
++OBJS-$(CONFIG_MCM_AUDIO_PCM16_INDEV)     += mcm_audio_rx.o mcm_common.o
++OBJS-$(CONFIG_MCM_AUDIO_PCM24_INDEV)     += mcm_audio_rx.o mcm_common.o
 +OBJS-$(CONFIG_MCM_AUDIO_PCM16_OUTDEV)    += mcm_audio_tx.o mcm_common.o
++OBJS-$(CONFIG_MCM_AUDIO_PCM24_OUTDEV)    += mcm_audio_tx.o mcm_common.o
  OBJS-$(CONFIG_DECKLINK_OUTDEV)           += decklink_enc.o decklink_enc_c.o decklink_common.o
  OBJS-$(CONFIG_DECKLINK_INDEV)            += decklink_dec.o decklink_dec_c.o decklink_common.o
  OBJS-$(CONFIG_DSHOW_INDEV)               += dshow_crossbar.o dshow.o dshow_enummediatypes.o \
 diff --git a/libavdevice/alldevices.c b/libavdevice/alldevices.c
-index 8a90fcb5d7..fe0eabdd67 100644
+index 8a90fcb5d7..40c25ff009 100644
 --- a/libavdevice/alldevices.c
 +++ b/libavdevice/alldevices.c
-@@ -25,6 +25,11 @@
+@@ -25,6 +25,12 @@
  /* devices */
  extern const AVInputFormat  ff_alsa_demuxer;
  extern const FFOutputFormat ff_alsa_muxer;
 +extern const AVInputFormat  ff_mcm_demuxer;
 +extern const FFOutputFormat ff_mcm_muxer;
-+extern const AVInputFormat  ff_mcm_audio_demuxer;
-+extern const FFOutputFormat ff_mcm_audio_muxer;
++extern const AVInputFormat  ff_mcm_audio_pcm16_demuxer;
++extern const AVInputFormat  ff_mcm_audio_pcm24_demuxer;
 +extern const FFOutputFormat ff_mcm_audio_pcm16_muxer;
++extern const FFOutputFormat ff_mcm_audio_pcm24_muxer;
  extern const AVInputFormat  ff_android_camera_demuxer;
  extern const FFOutputFormat ff_audiotoolbox_muxer;
  extern const AVInputFormat  ff_avfoundation_demuxer;

--- a/ffmpeg-plugin/7.0/0001-mcm-add-in-out-dev-support.patch
+++ b/ffmpeg-plugin/7.0/0001-mcm-add-in-out-dev-support.patch
@@ -1,16 +1,16 @@
-From 0b5b445454655f3bbe326fef865a418a2de03f08 Mon Sep 17 00:00:00 2001
-From: Tomasz Szumski <tomasz.szumski@intel.com>
-Date: Thu, 29 Aug 2024 09:12:42 +0200
+From 8e3a267c09b6f270ca1411f5c9f4e7fb0e1af8cb Mon Sep 17 00:00:00 2001
+From: Konstantin Ilichev <konstantin.ilichev@intel.com>
+Date: Fri, 6 Sep 2024 20:33:36 +0000
 Subject: [PATCH] Enable FFmpeg support in MCM
 
 ---
- configure                | 9 +++++++++
- libavdevice/Makefile     | 5 +++++
- libavdevice/alldevices.c | 5 +++++
- 3 files changed, 19 insertions(+)
+ configure                | 10 ++++++++++
+ libavdevice/Makefile     |  6 ++++++
+ libavdevice/alldevices.c |  6 ++++++
+ 3 files changed, 22 insertions(+)
 
 diff --git a/configure b/configure
-index bde796d03a..f9eb340f7a 100755
+index 20d4e4b615..9fdac37877 100755
 --- a/configure
 +++ b/configure
 @@ -290,6 +290,7 @@ External library support:
@@ -21,7 +21,7 @@ index bde796d03a..f9eb340f7a 100755
    --enable-libvpx          enable VP8 and VP9 de/encoding via libvpx [no]
    --enable-libwebp         enable WebP encoding via libwebp [no]
    --enable-libx264         enable H.264 encoding via x264 [no]
-@@ -1903,6 +1904,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1902,6 +1903,7 @@ EXTERNAL_LIBRARY_LIST="
      jni
      ladspa
      lcms2
@@ -29,19 +29,20 @@ index bde796d03a..f9eb340f7a 100755
      libaom
      libaribcaption
      libass
-@@ -3665,6 +3667,11 @@ xwma_demuxer_select="riffdec"
+@@ -3662,6 +3664,12 @@ xwma_demuxer_select="riffdec"
  android_camera_indev_deps="android camera2ndk mediandk pthreads"
  alsa_indev_deps="alsa"
  alsa_outdev_deps="alsa"
 +mcm_indev_deps="libmcm_dp"
 +mcm_outdev_deps="libmcm_dp"
-+mcm_audio_indev_deps="libmcm_dp"
-+mcm_audio_outdev_deps="libmcm_dp"
++mcm_audio_pcm16_indev_deps="libmcm_dp"
++mcm_audio_pcm24_indev_deps="libmcm_dp"
 +mcm_audio_pcm16_outdev_deps="libmcm_dp"
++mcm_audio_pcm24_outdev_deps="libmcm_dp"
  avfoundation_indev_deps="avfoundation corevideo coremedia pthreads"
  avfoundation_indev_suggest="coregraphics applicationservices"
  avfoundation_indev_extralibs="-framework Foundation"
-@@ -6834,6 +6841,8 @@ enabled libaribb24        && { check_pkg_config libaribb24 "aribb24 > 1.0.3" "ar
+@@ -6831,6 +6839,8 @@ enabled libaribb24        && { check_pkg_config libaribb24 "aribb24 > 1.0.3" "ar
  enabled libaribcaption    && require_pkg_config libaribcaption "libaribcaption >= 1.1.1" "aribcaption/aribcaption.h" aribcc_context_alloc
  enabled lv2               && require_pkg_config lv2 lilv-0 "lilv/lilv.h" lilv_world_new
  enabled libiec61883       && require libiec61883 libiec61883/iec61883.h iec61883_cmp_connect -lraw1394 -lavc1394 -lrom1394 -liec61883
@@ -51,37 +52,39 @@ index bde796d03a..f9eb340f7a 100755
  enabled libbluray         && require_pkg_config libbluray libbluray libbluray/bluray.h bd_open
  enabled libbs2b           && require_pkg_config libbs2b libbs2b bs2b.h bs2b_open
 diff --git a/libavdevice/Makefile b/libavdevice/Makefile
-index c30449201d..62bda757c3 100644
+index c30449201d..1d7c0d1a10 100644
 --- a/libavdevice/Makefile
 +++ b/libavdevice/Makefile
-@@ -20,6 +20,11 @@ OBJS-$(CONFIG_AUDIOTOOLBOX_OUTDEV)       += audiotoolbox.o
+@@ -20,6 +20,12 @@ OBJS-$(CONFIG_AUDIOTOOLBOX_OUTDEV)       += audiotoolbox.o
  OBJS-$(CONFIG_AVFOUNDATION_INDEV)        += avfoundation.o
  OBJS-$(CONFIG_BKTR_INDEV)                += bktr.o
  OBJS-$(CONFIG_CACA_OUTDEV)               += caca.o
 +OBJS-$(CONFIG_MCM_INDEV)                 += mcm_video_rx.o mcm_common.o
 +OBJS-$(CONFIG_MCM_OUTDEV)                += mcm_video_tx.o mcm_common.o
-+OBJS-$(CONFIG_MCM_AUDIO_INDEV)           += mcm_audio_rx.o mcm_common.o
-+OBJS-$(CONFIG_MCM_AUDIO_OUTDEV)          += mcm_audio_tx.o mcm_common.o
++OBJS-$(CONFIG_MCM_AUDIO_PCM16_INDEV)     += mcm_audio_rx.o mcm_common.o
++OBJS-$(CONFIG_MCM_AUDIO_PCM24_INDEV)     += mcm_audio_rx.o mcm_common.o
 +OBJS-$(CONFIG_MCM_AUDIO_PCM16_OUTDEV)    += mcm_audio_tx.o mcm_common.o
++OBJS-$(CONFIG_MCM_AUDIO_PCM24_OUTDEV)    += mcm_audio_tx.o mcm_common.o
  OBJS-$(CONFIG_DECKLINK_OUTDEV)           += decklink_enc.o decklink_enc_c.o decklink_common.o
  OBJS-$(CONFIG_DECKLINK_INDEV)            += decklink_dec.o decklink_dec_c.o decklink_common.o
  OBJS-$(CONFIG_DSHOW_INDEV)               += dshow_crossbar.o dshow.o dshow_enummediatypes.o \
 diff --git a/libavdevice/alldevices.c b/libavdevice/alldevices.c
-index 9b9a9146c7..a95f68850c 100644
+index 9b9a9146c7..364c918cda 100644
 --- a/libavdevice/alldevices.c
 +++ b/libavdevice/alldevices.c
-@@ -29,6 +29,11 @@ FF_VISIBILITY_PUSH_HIDDEN
+@@ -29,6 +29,12 @@ FF_VISIBILITY_PUSH_HIDDEN
  /* devices */
  extern const FFInputFormat  ff_alsa_demuxer;
  extern const FFOutputFormat ff_alsa_muxer;
 +extern const FFInputFormat  ff_mcm_demuxer;
 +extern const FFOutputFormat ff_mcm_muxer;
-+extern const FFInputFormat  ff_mcm_audio_demuxer;
-+extern const FFOutputFormat ff_mcm_audio_muxer;
++extern const FFInputFormat  ff_mcm_audio_pcm16_demuxer;
++extern const FFInputFormat  ff_mcm_audio_pcm24_demuxer;
 +extern const FFOutputFormat ff_mcm_audio_pcm16_muxer;
++extern const FFOutputFormat ff_mcm_audio_pcm24_muxer;
  extern const FFInputFormat  ff_android_camera_demuxer;
  extern const FFOutputFormat ff_audiotoolbox_muxer;
  extern const FFInputFormat  ff_avfoundation_demuxer;
 -- 
-2.45.1.windows.1
+2.34.1
 

--- a/ffmpeg-plugin/README.md
+++ b/ffmpeg-plugin/README.md
@@ -106,27 +106,22 @@ udp://@:1234
 
 The table below shows a proper way to configure the sender and the receiver depending on the audio PCM encoding format
 
-| Audio encoding | Sender configuration | Receiver configuration |
-| --- | --- | --- |
-| PCM 24-bit | Output device `mcm_audio` | Input device `mcm_audio` and argument `-pcm_fmt pcm24`
-| PCM 16-bit | Output device `mcm_audio_pcm16` | Input device `mcm_audio` and argument `-pcm_fmt pcm16`
+| Audio encoding | Sender configuration            | Receiver configuration         |
+| -------------- | ------------------------------- | ------------------------------ |
+| PCM 16-bit     | Output device `mcm_audio_pcm16` | Input device `mcm_audio_pcm16` |
+| PCM 24-bit     | Output device `mcm_audio_pcm24` | Input device `mcm_audio_pcm24` |
 
 The next arguments are supported to configure an audio transmission
 
-| Argument      | Type    | Description                                                                                                                                                                            | Default   |
-| ------------- | :-----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------: |
-| `channels`    | Integer | Number of audio channels (`1`, `2`, etc.)                                                                                                                                              | `2`       |
-| `sample_rate` | Integer | Audio sample rate (`44100`, `48000`, or `96000`)                                                                                                                                       | `48000`   |
+| Argument      | Type    | Description                                                                                                                                                                                       | Default   |
+| ------------- | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------: |
+| `channels`    | Integer | Number of audio channels (`1`, `2`, etc.)                                                                                                                                                         | `2`       |
+| `sample_rate` | Integer | Audio sample rate (`44100`, `48000`, or `96000`)                                                                                                                                                  | `48000`   |
 | `ptime`       | String  | Audio packet time according to ST2110-30. For 48000 and 96000 sampling: `"1ms"`, `"125us"`, `"250us"`, `"333us"`, `"4ms"`, or `"80us"`. For 44100 sampling: `"1.09ms"`, `"0.14ms"`, or `"0.09ms"` | `"1ms"`   |
-| `pcm_fmt`     | String  | PCM audio format (`"pcm24"` or `"pcm16"`)                                                                                                                                              | `"pcm24"` |
 
-## Example – Run audio transmission
+## Example – Run audio transmission, PCM 24-bit
 
-This example demonstrates sending an audio file from the 1st FFmpeg instance to the 2nd FFmpeg instance via MCM.
-
-There are two options of configuration:
-* **Option A** for PCM 24-bit encoded audio
-* **Option B** for PCM 16-bit encoded audio
+This example demonstrates sending a PCM 24-bit encoded audio file from the 1st FFmpeg instance to the 2nd FFmpeg instance via MCM.
 
 ### NIC setup
 
@@ -140,27 +135,11 @@ TBD
    ```
 2. Start FFmpeg to receive packets from MCM and store on the disk
    
-   **Option A – PCM 24-bit audio**
    ```bash
-   sudo MCM_MEDIA_PROXY_PORT=8002 ffmpeg -re -f mcm_audio \
+   sudo MCM_MEDIA_PROXY_PORT=8002 ffmpeg -re -f mcm_audio_pcm24 \
       -channels 2 \
       -sample_rate 48000 \
       -ptime 1ms \
-      -pcm_fmt pcm24 \
-      -protocol_type auto \
-      -payload_type st30 \
-      -ip_addr 192.168.96.1 \
-      -port 9001 \
-      -i - output.wav
-   ```
-
-   **Option B – PCM 16-bit audio**
-   ```bash
-   sudo MCM_MEDIA_PROXY_PORT=8002 ffmpeg -re -f mcm_audio \
-      -channels 2 \
-      -sample_rate 48000 \
-      -ptime 1ms \
-      -pcm_fmt pcm16 \
       -protocol_type auto \
       -payload_type st30 \
       -ip_addr 192.168.96.1 \
@@ -176,21 +155,8 @@ TBD
    ```
 2. Start FFmpeg to stream an audio file to the receiver via MCM
 
-   **Option A – PCM 24-bit audio**
    ```bash
-   sudo MCM_MEDIA_PROXY_PORT=8001 ffmpeg -i <audio-file-path> -f mcm_audio \
-      -channels 2 \
-      -sample_rate 48000 \
-      -ptime 1ms \
-      -protocol_type auto \
-      -payload_type st30 \
-      -ip_addr 192.168.96.2 \
-      -port 9001 -
-   ```
-
-   **Option B – PCM 16-bit audio**
-   ```bash
-   sudo MCM_MEDIA_PROXY_PORT=8001 ffmpeg -i <audio-file-path> -f mcm_audio_pcm16 \
+   sudo MCM_MEDIA_PROXY_PORT=8001 ffmpeg -i <audio-file-path> -f mcm_audio_pcm24 \
       -channels 2 \
       -sample_rate 48000 \
       -ptime 1ms \

--- a/ffmpeg-plugin/README.md
+++ b/ffmpeg-plugin/README.md
@@ -113,12 +113,12 @@ The table below shows a proper way to configure the sender and the receiver depe
 
 The next arguments are supported to configure an audio transmission
 
-| Argument      | Type    | Description                                      | Default   |
-| ------------- | :-----: | ------------------------------------------------ | :-------: |
-| `channels`    | Integer | Number of audio channels (`1`, `2`, etc.)        | `2`       |
-| `sample_rate` | Integer | Audio sample rate (`44100`, `48000`, or `96000`) | `48000`   |
-| `ptime`       | String  | MTL audio packet time (`"1ms"` or `"125us"`)     | `"1ms"`   |
-| `pcm_fmt`     | String  | PCM audio format (`"pcm24"` or `"pcm16"`)        | `"pcm24"` |
+| Argument      | Type    | Description                                                                                                                                                                            | Default   |
+| ------------- | :-----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------: |
+| `channels`    | Integer | Number of audio channels (`1`, `2`, etc.)                                                                                                                                              | `2`       |
+| `sample_rate` | Integer | Audio sample rate (`44100`, `48000`, or `96000`)                                                                                                                                       | `48000`   |
+| `ptime`       | String  | Audio packet time according to ST2110-30. For 48000 and 96000 sampling: `"1ms"`, `"125us"`, `"250us"`, `"333us"`, `"4ms"`, or `"80us"`. For 44100 sampling: `"1.09ms"`, `"0.14ms"`, or `"0.09ms"` | `"1ms"`   |
+| `pcm_fmt`     | String  | PCM audio format (`"pcm24"` or `"pcm16"`)                                                                                                                                              | `"pcm24"` |
 
 ## Example – Run audio transmission
 

--- a/ffmpeg-plugin/mcm_audio_rx.c
+++ b/ffmpeg-plugin/mcm_audio_rx.c
@@ -71,6 +71,12 @@ static int mcm_audio_read_header(AVFormatContext* avctx)
     if (err)
         return err;
 
+    err = mcm_check_audio_params_compat(mcm_sample_rate, mcm_ptime);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Incompatible audio parameters\n");
+        return AVERROR(EINVAL);
+    }
+
     /* audio format */
     param.payload_args.audio_args.type = AUDIO_TYPE_FRAME_LEVEL;
     param.payload_args.audio_args.channel = s->channels;

--- a/ffmpeg-plugin/mcm_audio_tx.c
+++ b/ffmpeg-plugin/mcm_audio_tx.c
@@ -74,6 +74,12 @@ static int mcm_audio_write_header(AVFormatContext* avctx)
     if (err)
         return err;
 
+    err = mcm_check_audio_params_compat(mcm_sample_rate, mcm_ptime);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Incompatible audio parameters\n");
+        return AVERROR(EINVAL);
+    }
+
     switch (codecpar->codec_id) {
     case AV_CODEC_ID_PCM_S24BE:
         mcm_fmt = AUDIO_FMT_PCM24;

--- a/ffmpeg-plugin/mcm_audio_tx.c
+++ b/ffmpeg-plugin/mcm_audio_tx.c
@@ -173,19 +173,6 @@ static const AVClass mcm_audio_muxer_class = {
     .category = AV_CLASS_CATEGORY_DEVICE_AUDIO_OUTPUT,
 };
 
-const FFOutputFormat ff_mcm_audio_muxer = {
-    .p.name = "mcm_audio",
-    .p.long_name = NULL_IF_CONFIG_SMALL("Media Communications Mesh audio pcm24"),
-    .priv_data_size = sizeof(McmAudioMuxerContext),
-    .write_header = mcm_audio_write_header,
-    .write_packet = mcm_audio_write_packet,
-    .write_trailer = mcm_audio_write_trailer,
-    .p.audio_codec = AV_CODEC_ID_PCM_S24BE,
-    .p.video_codec = AV_CODEC_ID_NONE,
-    .p.flags = AVFMT_NOFILE,
-    .p.priv_class = &mcm_audio_muxer_class,
-};
-
 const FFOutputFormat ff_mcm_audio_pcm16_muxer = {
     .p.name = "mcm_audio_pcm16",
     .p.long_name = NULL_IF_CONFIG_SMALL("Media Communications Mesh audio pcm16"),
@@ -194,6 +181,19 @@ const FFOutputFormat ff_mcm_audio_pcm16_muxer = {
     .write_packet = mcm_audio_write_packet,
     .write_trailer = mcm_audio_write_trailer,
     .p.audio_codec = AV_CODEC_ID_PCM_S16BE,
+    .p.video_codec = AV_CODEC_ID_NONE,
+    .p.flags = AVFMT_NOFILE,
+    .p.priv_class = &mcm_audio_muxer_class,
+};
+
+const FFOutputFormat ff_mcm_audio_pcm24_muxer = {
+    .p.name = "mcm_audio_pcm24",
+    .p.long_name = NULL_IF_CONFIG_SMALL("Media Communications Mesh audio pcm24"),
+    .priv_data_size = sizeof(McmAudioMuxerContext),
+    .write_header = mcm_audio_write_header,
+    .write_packet = mcm_audio_write_packet,
+    .write_trailer = mcm_audio_write_trailer,
+    .p.audio_codec = AV_CODEC_ID_PCM_S24BE,
     .p.video_codec = AV_CODEC_ID_NONE,
     .p.flags = AVFMT_NOFILE,
     .p.priv_class = &mcm_audio_muxer_class,

--- a/ffmpeg-plugin/mcm_common.c
+++ b/ffmpeg-plugin/mcm_common.c
@@ -93,6 +93,34 @@ int mcm_parse_audio_packet_time(AVFormatContext* avctx, mcm_audio_ptime *ptime,
         *ptime = AUDIO_PTIME_125US;
         return 0;
     }
+    if (!strcmp(str, "250us")) {
+        *ptime = AUDIO_PTIME_250US;
+        return 0;
+    }
+    if (!strcmp(str, "333us")) {
+        *ptime = AUDIO_PTIME_333US;
+        return 0;
+    }
+    if (!strcmp(str, "4ms")) {
+        *ptime = AUDIO_PTIME_4MS;
+        return 0;
+    }
+    if (!strcmp(str, "80us")) {
+        *ptime = AUDIO_PTIME_80US;
+        return 0;
+    }
+    if (!strcmp(str, "1.09ms")) {
+        *ptime = AUDIO_PTIME_1_09MS;
+        return 0;
+    }
+    if (!strcmp(str, "0.14ms")) {
+        *ptime = AUDIO_PTIME_0_14MS;
+        return 0;
+    }
+    if (!strcmp(str, "0.09ms")) {
+        *ptime = AUDIO_PTIME_0_09MS;
+        return 0;
+    }
 
     av_log(avctx, AV_LOG_ERROR, "Audio packet time not supported\n");
     return AVERROR(EINVAL);
@@ -115,4 +143,36 @@ int mcm_parse_audio_pcm_format(AVFormatContext* avctx, mcm_audio_format *fmt,
 
     av_log(avctx, AV_LOG_ERROR, "Audio PCM format not supported\n");
     return AVERROR(EINVAL);
+}
+
+/* Check compatibility of ST2110-30 related audio parameters */
+int mcm_check_audio_params_compat(mcm_audio_sampling sample_rate,
+                                  mcm_audio_ptime ptime)
+{
+    switch (sample_rate) {
+    case AUDIO_SAMPLING_48K:
+    case AUDIO_SAMPLING_96K:
+        switch (ptime) {
+        case AUDIO_PTIME_1MS:
+        case AUDIO_PTIME_125US:
+        case AUDIO_PTIME_250US:
+        case AUDIO_PTIME_333US:
+        case AUDIO_PTIME_4MS:
+        case AUDIO_PTIME_80US:
+            return 0;
+        default:
+            return AVERROR(EINVAL);
+        }
+    case AUDIO_SAMPLING_44K:
+        switch (ptime) {
+        case AUDIO_PTIME_1_09MS:
+        case AUDIO_PTIME_0_14MS:
+        case AUDIO_PTIME_0_09MS:
+            return 0;
+        default:
+            return AVERROR(EINVAL);
+        }
+    default:
+        return AVERROR(EINVAL);
+    }
 }

--- a/ffmpeg-plugin/mcm_common.c
+++ b/ffmpeg-plugin/mcm_common.c
@@ -126,25 +126,6 @@ int mcm_parse_audio_packet_time(AVFormatContext* avctx, mcm_audio_ptime *ptime,
     return AVERROR(EINVAL);
 }
 
-/* Parse MCM audio PCM format and codec id */
-int mcm_parse_audio_pcm_format(AVFormatContext* avctx, mcm_audio_format *fmt,
-                               enum AVCodecID *codec_id, char *str)
-{
-    if (!str || !strcmp(str, "pcm24")) {
-        *fmt = AUDIO_FMT_PCM24;
-        *codec_id = AV_CODEC_ID_PCM_S24BE;
-        return 0;
-    }
-    if (!strcmp(str, "pcm16")) {
-        *fmt = AUDIO_FMT_PCM16;
-        *codec_id = AV_CODEC_ID_PCM_S16BE;
-        return 0;
-    }
-
-    av_log(avctx, AV_LOG_ERROR, "Audio PCM format not supported\n");
-    return AVERROR(EINVAL);
-}
-
 /* Check compatibility of ST2110-30 related audio parameters */
 int mcm_check_audio_params_compat(mcm_audio_sampling sample_rate,
                                   mcm_audio_ptime ptime)

--- a/ffmpeg-plugin/mcm_common.h
+++ b/ffmpeg-plugin/mcm_common.h
@@ -28,8 +28,6 @@ int mcm_parse_audio_sample_rate(AVFormatContext* avctx, mcm_audio_sampling *samp
                                 int value);
 int mcm_parse_audio_packet_time(AVFormatContext* avctx, mcm_audio_ptime *ptime,
                                 char *str);
-int mcm_parse_audio_pcm_format(AVFormatContext* avctx, mcm_audio_format *fmt,
-                               enum AVCodecID *codec_id, char *str);
 int mcm_check_audio_params_compat(mcm_audio_sampling sample_rate,
                                   mcm_audio_ptime ptime);
 

--- a/ffmpeg-plugin/mcm_common.h
+++ b/ffmpeg-plugin/mcm_common.h
@@ -30,6 +30,8 @@ int mcm_parse_audio_packet_time(AVFormatContext* avctx, mcm_audio_ptime *ptime,
                                 char *str);
 int mcm_parse_audio_pcm_format(AVFormatContext* avctx, mcm_audio_format *fmt,
                                enum AVCodecID *codec_id, char *str);
+int mcm_check_audio_params_compat(mcm_audio_sampling sample_rate,
+                                  mcm_audio_ptime ptime);
 
 #ifdef __cplusplus
 }

--- a/sdk/src/mcm_dp.c
+++ b/sdk/src/mcm_dp.c
@@ -6,6 +6,7 @@
 #include <bsd/string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "memif_impl.h"
 #include "udp_impl.h"
@@ -13,10 +14,112 @@
 #include "mcm_dp.h"
 #include "media_proxy_ctrl.h"
 
+/* Calculate audio buffer size based on ST2110-30 related parameters */
+static int mcm_calc_audio_buffer_size(mcm_audio_args *params, uint32_t *size)
+{
+    uint32_t sample_size = 0;
+    uint32_t sample_num = 0;
+
+    switch (params->format) {
+    case AUDIO_FMT_PCM8:
+        sample_size = 1;
+        break;
+    case AUDIO_FMT_PCM16:
+        sample_size = 2;
+        break;
+    case AUDIO_FMT_PCM24:
+        sample_size = 3;
+        break;
+    case AUDIO_FMT_AM824:
+        sample_size = 4;
+        break;
+    default:
+        *size = 0;
+        return -EINVAL;
+    }
+
+    switch (params->sampling) {
+    case AUDIO_SAMPLING_48K:
+        switch (params->ptime) {
+        case AUDIO_PTIME_1MS:
+            sample_num = 48;
+            break;
+        case AUDIO_PTIME_125US:
+            sample_num = 6;
+            break;
+        case AUDIO_PTIME_250US:
+            sample_num = 12;
+            break;
+        case AUDIO_PTIME_333US:
+            sample_num = 16;
+            break;
+        case AUDIO_PTIME_4MS:
+            sample_num = 192;
+            break;
+        case AUDIO_PTIME_80US:
+            sample_num = 4;
+            break;
+        default:
+            *size = 0;
+            return -EINVAL;
+        }
+        break;
+    case AUDIO_SAMPLING_96K:
+        switch (params->ptime) {
+        case AUDIO_PTIME_1MS:
+            sample_num = 96;
+            break;
+        case AUDIO_PTIME_125US:
+            sample_num = 12;
+            break;
+        case AUDIO_PTIME_250US:
+            sample_num = 24;
+            break;
+        case AUDIO_PTIME_333US:
+            sample_num = 32;
+            break;
+        case AUDIO_PTIME_4MS:
+            sample_num = 384;
+            break;
+        case AUDIO_PTIME_80US:
+            sample_num = 8;
+            break;
+        default:
+            *size = 0;
+            return -EINVAL;
+        }
+        break;
+    case AUDIO_SAMPLING_44K:
+        switch (params->ptime) {
+        case AUDIO_PTIME_1_09MS:
+            sample_num = 48;
+            break;
+        case AUDIO_PTIME_0_14MS:
+            sample_num = 6;
+            break;
+        case AUDIO_PTIME_0_09MS:
+            sample_num = 4;
+            break;
+        default:
+            *size = 0;
+            return -EINVAL;
+        }
+        break;
+    default:
+        *size = 0;
+        return -EINVAL;
+    }
+
+    *size = sample_size * sample_num * params->channel;
+
+    return 0;
+}
+
 static void parse_memif_param(mcm_conn_param* request, memif_socket_args_t* memif_socket_args, memif_conn_args_t* memif_conn_args)
 {
     char type_str[8] = "";
     char interface_name[32];
+    int err;
 
     if (request->type == is_tx) {
         strlcpy(type_str, "tx", sizeof(type_str));
@@ -36,7 +139,20 @@ static void parse_memif_param(mcm_conn_param* request, memif_socket_args_t* memi
         strlcpy(memif_socket_args->path, request->memif_interface.socket_path, sizeof(memif_socket_args->path));
     }
 
-    memif_conn_args->buffer_size = request->payload_args.video_args.width * request->payload_args.video_args.height * 4;
+    switch (request->payload_type) {
+    case PAYLOAD_TYPE_ST30_AUDIO:
+        err = mcm_calc_audio_buffer_size(&request->payload_args.audio_args, &memif_conn_args->buffer_size);
+        if (err)
+            log_error("Invalid audio parameters.");
+        break;
+
+    case PAYLOAD_TYPE_ST20_VIDEO:
+    case PAYLOAD_TYPE_ST22_VIDEO:
+    case PAYLOAD_TYPE_RTSP_VIDEO:
+    default:
+        memif_conn_args->buffer_size = request->payload_args.video_args.width * request->payload_args.video_args.height * 4;
+    }
+
     memif_conn_args->log2_ring_size = 4;
 }
 


### PR DESCRIPTION
This PR includes the following commits
* Fix audio buffer size in memif protocol mode
* Add compatibility check for audio parameters in FFmpeg plugin
* Update documentation on audio ptime options
* Rework MCM audio FFmpeg plugin to support PCM 16/24