### PR TITLE
Fix audio buffer size in FFmpeg MCM plugin + fix Rx ring size

### DIFF
--- a/ffmpeg-plugin/mcm_audio_rx.c
+++ b/ffmpeg-plugin/mcm_audio_rx.c
@@ -161,7 +161,7 @@ static const AVOption mcm_audio_rx_options[] = {
     { "ip_addr", "set remote IP address", OFFSET(ip_addr), AV_OPT_TYPE_STRING, {.str = "192.168.96.1"}, .flags = DEC },
     { "port", "set local port", OFFSET(port), AV_OPT_TYPE_STRING, {.str = "9001"}, .flags = DEC },
     { "protocol_type", "set protocol type", OFFSET(protocol_type), AV_OPT_TYPE_STRING, {.str = "auto"}, .flags = DEC },
-    { "payload_type", "set payload type", OFFSET(payload_type), AV_OPT_TYPE_STRING, {.str = "st20"}, .flags = DEC },
+    { "payload_type", "set payload type", OFFSET(payload_type), AV_OPT_TYPE_STRING, {.str = "st30"}, .flags = DEC },
     { "socket_name", "set memif socket name", OFFSET(socket_name), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = DEC },
     { "interface_id", "set interface id", OFFSET(interface_id), AV_OPT_TYPE_INT, {.i64 = 0}, -1, INT_MAX, DEC },
     { "channels", "number of audio channels", OFFSET(channels), AV_OPT_TYPE_INT, {.i64 = 2}, 1, INT_MAX, DEC },

--- a/ffmpeg-plugin/mcm_audio_tx.c
+++ b/ffmpeg-plugin/mcm_audio_tx.c
@@ -11,6 +11,7 @@
 #include "libavformat/mux.h"
 #include "libavdevice/mcm_common.h"
 #include <mcm_dp.h>
+#include <unistd.h>
 
 typedef struct McmAudioMuxerContext {
     const AVClass *class; /**< Class for private options. */
@@ -28,6 +29,8 @@ typedef struct McmAudioMuxerContext {
     char* ptime;
 
     mcm_conn_context *tx_handle;
+    mcm_buffer *unsent_mcm_buf;
+    int unsent_len;
 } McmAudioMuxerContext;
 
 static int mcm_audio_write_header(AVFormatContext* avctx)
@@ -114,29 +117,50 @@ static int mcm_audio_write_header(AVFormatContext* avctx)
 static int mcm_audio_write_packet(AVFormatContext* avctx, AVPacket* pkt)
 {
     McmAudioMuxerContext *s = avctx->priv_data;
+    size_t frame_size = s->tx_handle->frame_size;
     const uint8_t *data = pkt->data;
-    mcm_buffer *buf = NULL;
     int size = pkt->size;
     int len, err = 0;
 
     while (size > 0) {
-        buf = mcm_dequeue_buffer(s->tx_handle, -1, &err);
-        if (buf == NULL) {
-            av_log(avctx, AV_LOG_ERROR, "Dequeue buffer error %d\n", err);
-            return AVERROR(EIO);
+        char *dest;
+
+        if (!s->unsent_mcm_buf) {
+            s->unsent_mcm_buf = mcm_dequeue_buffer(s->tx_handle, -1, &err);
+            if (s->unsent_mcm_buf == NULL) {
+                av_log(avctx, AV_LOG_ERROR, "Initial dequeue buffer error %d\n", err);
+                return AVERROR(EIO);
+            }
         }
 
-        len = FFMIN(buf->len, size);
-        memcpy(buf->data, data, len);
+        len = FFMIN(frame_size, size + s->unsent_len);
+
+        if (len < frame_size) {
+            memcpy((char *)s->unsent_mcm_buf->data + s->unsent_len, data, size);
+            s->unsent_len += size;
+            break;
+        }
+
+        dest = s->unsent_mcm_buf->data;
+
+        if (s->unsent_len) {
+            memcpy(dest, s->unsent_mcm_buf->data, s->unsent_len);
+            dest += s->unsent_len;
+            len -= s->unsent_len;
+            s->unsent_len = 0;
+        }
+
+        memcpy(dest, data, len);
         data += len;
         size -= len;
 
-        buf->len = len;
-
-        if ((err = mcm_enqueue_buffer(s->tx_handle, buf)) != 0) {
+        err = mcm_enqueue_buffer(s->tx_handle, s->unsent_mcm_buf);
+        if (err) {
             av_log(avctx, AV_LOG_ERROR, "Enqueue buffer error %d\n", err);
             return AVERROR(EIO);
         }
+
+        s->unsent_mcm_buf = NULL;
     }
 
     return 0;
@@ -145,6 +169,27 @@ static int mcm_audio_write_packet(AVFormatContext* avctx, AVPacket* pkt)
 static int mcm_audio_write_trailer(AVFormatContext* avctx)
 {
     McmAudioMuxerContext *s = avctx->priv_data;
+
+    if (s->unsent_mcm_buf) {
+        int err;
+
+        /* zero the unused rest of the buffer */
+        memset((char *)s->unsent_mcm_buf->data + s->unsent_len, 0,
+               s->unsent_mcm_buf->len - s->unsent_len);
+
+        err = mcm_enqueue_buffer(s->tx_handle, s->unsent_mcm_buf);
+        if (err) {
+            av_log(avctx, AV_LOG_ERROR, "Enqueue buffer error %d\n", err);
+            return AVERROR(EIO);
+        }
+    }
+
+    /* Delay for 50ms to allow Media Proxy to complete transmission of all
+     * buffers sitting in the memif queue before destroying the connection.
+     *
+     * TODO: Replace the delay with an API call when it is implemented in SDK.
+     */
+    usleep(50000);
 
     mcm_destroy_connection(s->tx_handle);
     return 0;

--- a/ffmpeg-plugin/mcm_audio_tx.c
+++ b/ffmpeg-plugin/mcm_audio_tx.c
@@ -144,7 +144,6 @@ static int mcm_audio_write_packet(AVFormatContext* avctx, AVPacket* pkt)
         dest = s->unsent_mcm_buf->data;
 
         if (s->unsent_len) {
-            memcpy(dest, s->unsent_mcm_buf->data, s->unsent_len);
             dest += s->unsent_len;
             len -= s->unsent_len;
             s->unsent_len = 0;

--- a/media-proxy/src/mtl.c
+++ b/media-proxy/src/mtl.c
@@ -1566,7 +1566,7 @@ int rx_st30_shm_init(rx_st30_session_context_t* rx_ctx, memif_ops_t* memif_ops)
     rx_ctx->memif_conn_args.socket = rx_ctx->memif_socket;
     rx_ctx->memif_conn_args.interface_id = memif_ops->interface_id;
     rx_ctx->memif_conn_args.buffer_size = (uint32_t)rx_ctx->pkt_len;
-    rx_ctx->memif_conn_args.log2_ring_size = 2;
+    rx_ctx->memif_conn_args.log2_ring_size = 4;
     memcpy((char*)rx_ctx->memif_conn_args.interface_name, memif_ops->interface_name,
         sizeof(rx_ctx->memif_conn_args.interface_name));
     rx_ctx->memif_conn_args.is_master = memif_ops->is_master;


### PR DESCRIPTION
This PR includes the following commits

* Fix audio buffer size in FFmpeg MCM plugin + fix Rx ring size
