### PR TITLE
Format code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,11 @@
 ---
-Language:        Cpp
-BasedOnStyle:  WebKit
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+ColumnLimit: 100
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+IncludeBlocks: Preserve
+SortIncludes: false
+...

--- a/format-coding.sh
+++ b/format-coding.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022 Intel Corporation
+
+# Based on clang-format
+# For ubuntu, pls "apt-get install clang-format"
+
+set -e
+
+echo "clang-format check"
+find . \( -path ./out -o -path ./ffmpeg-plugin \) -prune -o -regex '.*\.\(cpp\|hpp\|cc\|c\|h\)' \
+	-exec clang-format --verbose -i {} +

--- a/media-proxy/include/api_server_grpc.h
+++ b/media-proxy/include/api_server_grpc.h
@@ -38,36 +38,47 @@ using controller::HealthCheckRequest;
 using controller::HealthCheckResponse;
 using controller::HealthCheckResponse_ServingStatus;
 
-class ConfigureServiceImpl final : public Configure::Service {
-public:
-    ConfigureServiceImpl(ProxyContext* ctx);
-    Status TxStart(ServerContext* context, const TxControlRequest* request, ControlReply* reply) override;
-    Status RxStart(ServerContext* context, const RxControlRequest* request, ControlReply* reply) override;
-    Status TxStop(ServerContext* context, const StopControlRequest* request, ControlReply* reply) override;
-    Status RxStop(ServerContext* context, const StopControlRequest* request, ControlReply* reply) override;
-    Status Stop(ServerContext* context, const StopControlRequest* request, ControlReply* reply) override;
+class ConfigureServiceImpl final : public Configure::Service
+{
+  public:
+    ConfigureServiceImpl(ProxyContext *ctx);
+    Status TxStart(ServerContext *context, const TxControlRequest *request,
+                   ControlReply *reply) override;
+    Status RxStart(ServerContext *context, const RxControlRequest *request,
+                   ControlReply *reply) override;
+    Status TxStop(ServerContext *context, const StopControlRequest *request,
+                  ControlReply *reply) override;
+    Status RxStop(ServerContext *context, const StopControlRequest *request,
+                  ControlReply *reply) override;
+    Status Stop(ServerContext *context, const StopControlRequest *request,
+                ControlReply *reply) override;
 
-private:
-    ProxyContext* m_ctx;
+  private:
+    ProxyContext *m_ctx;
 };
 
-class MsmDataPlaneServiceImpl final : public MsmDataPlane::Service {
-public:
-    MsmDataPlaneServiceImpl(ProxyContext* ctx);
-    Status stream_add_del(ServerContext* context, const StreamData* request, StreamResult* reply) override;
+class MsmDataPlaneServiceImpl final : public MsmDataPlane::Service
+{
+  public:
+    MsmDataPlaneServiceImpl(ProxyContext *ctx);
+    Status stream_add_del(ServerContext *context, const StreamData *request,
+                          StreamResult *reply) override;
 
-private:
-    ProxyContext* m_ctx;
+  private:
+    ProxyContext *m_ctx;
 };
 
-class HealthServiceImpl final : public Health::Service {
-public:
-    HealthServiceImpl(ProxyContext* ctx);
-    Status Check(ServerContext* context, const HealthCheckRequest* request, HealthCheckResponse* reply) override;
-    Status Watch(ServerContext* context, const HealthCheckRequest* request, HealthCheckResponse* reply) override;
+class HealthServiceImpl final : public Health::Service
+{
+  public:
+    HealthServiceImpl(ProxyContext *ctx);
+    Status Check(ServerContext *context, const HealthCheckRequest *request,
+                 HealthCheckResponse *reply) override;
+    Status Watch(ServerContext *context, const HealthCheckRequest *request,
+                 HealthCheckResponse *reply) override;
 
-private:
-    ProxyContext* m_ctx;
+  private:
+    ProxyContext *m_ctx;
 };
 
-void RunRPCServer(ProxyContext* ctx);
+void RunRPCServer(ProxyContext *ctx);

--- a/media-proxy/include/api_server_tcp.h
+++ b/media-proxy/include/api_server_tcp.h
@@ -1,9 +1,9 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
-*/
+ */
 
 #pragma once
 #include "proxy_context.h"
 
-void RunTCPServer(ProxyContext* ctx);
+void RunTCPServer(ProxyContext *ctx);

--- a/media-proxy/include/app_platform.h
+++ b/media-proxy/include/app_platform.h
@@ -66,74 +66,66 @@ enum st_tx_frame_status {
 struct st_tx_frame {
     enum st_tx_frame_status stat;
     size_t size;
-    bool second_field; /* for interlaced mode */
-    bool slice_trigger; /* for slice */
+    bool second_field;    /* for interlaced mode */
+    bool slice_trigger;   /* for slice */
     uint16_t lines_ready; /* for slice */
 };
 
 struct st_rx_frame {
-    void* frame;
+    void *frame;
     size_t size;
 };
 
-static inline int st_pthread_mutex_init(pthread_mutex_t* mutex,
-    pthread_mutexattr_t* attr)
+static inline int st_pthread_mutex_init(pthread_mutex_t *mutex, pthread_mutexattr_t *attr)
 {
     return pthread_mutex_init(mutex, attr);
 }
 
-static inline int st_pthread_mutex_trylock(pthread_mutex_t* mutex)
+static inline int st_pthread_mutex_trylock(pthread_mutex_t *mutex)
 {
     return pthread_mutex_trylock(mutex);
 }
 
-static inline int st_pthread_mutex_lock(pthread_mutex_t* mutex)
+static inline int st_pthread_mutex_lock(pthread_mutex_t *mutex)
 {
     return pthread_mutex_lock(mutex);
 }
 
-static inline int st_pthread_mutex_unlock(pthread_mutex_t* mutex)
+static inline int st_pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
     return pthread_mutex_unlock(mutex);
 }
 
-static inline int st_pthread_mutex_destroy(pthread_mutex_t* mutex)
+static inline int st_pthread_mutex_destroy(pthread_mutex_t *mutex)
 {
     return pthread_mutex_destroy(mutex);
 }
 
-static inline int st_pthread_cond_init(pthread_cond_t* cond,
-    pthread_condattr_t* cond_attr)
+static inline int st_pthread_cond_init(pthread_cond_t *cond, pthread_condattr_t *cond_attr)
 {
     return pthread_cond_init(cond, cond_attr);
 }
 
-static inline int st_pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex)
+static inline int st_pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
 {
     return pthread_cond_wait(cond, mutex);
 }
 
-static inline int st_pthread_cond_destroy(pthread_cond_t* cond)
+static inline int st_pthread_cond_destroy(pthread_cond_t *cond)
 {
     return pthread_cond_destroy(cond);
 }
 
-static inline int st_pthread_cond_signal(pthread_cond_t* cond)
-{
-    return pthread_cond_signal(cond);
-}
+static inline int st_pthread_cond_signal(pthread_cond_t *cond) { return pthread_cond_signal(cond); }
 
-static inline int st_open(const char* path, int flags) { return open(path, flags); }
+static inline int st_open(const char *path, int flags) { return open(path, flags); }
 
-static inline int st_open_mode(const char* path, int flags, mode_t mode)
+static inline int st_open_mode(const char *path, int flags, mode_t mode)
 {
     return open(path, flags, mode);
 }
 
-static inline FILE* st_fopen(const char* path, const char* mode)
-{
-    return fopen(path, mode);
-}
+static inline FILE *st_fopen(const char *path, const char *mode) { return fopen(path, mode); }
 
 static inline void st_pause(void)
 {
@@ -144,8 +136,7 @@ static inline void st_pause(void)
 #endif
 }
 
-static inline void st_usleep(
-    useconds_t usec)
+static inline void st_usleep(useconds_t usec)
 { // windows usleep function precision is only 1~15ms
 #ifdef WINDOWSENV
     LARGE_INTEGER delay;
@@ -165,7 +156,7 @@ static inline void st_usleep(
 #endif
 }
 
-static inline void st_getrealtime(struct timespec* pspec)
+static inline void st_getrealtime(struct timespec *pspec)
 {
 #ifdef WINDOWSENV
     unsigned __int64 t;

--- a/media-proxy/include/mtl.h
+++ b/media-proxy/include/mtl.h
@@ -12,8 +12,8 @@ extern "C" {
 #endif
 
 #include <limits.h>
-#include <mtl/st30_api.h> /* st2110-30 */
-#include <mtl/st40_api.h> /* st2110-40 */
+#include <mtl/st30_api.h>        /* st2110-30 */
+#include <mtl/st40_api.h>        /* st2110-40 */
 #include <mtl/st_pipeline_api.h> /* st2110 pipeline */
 
 #include <mcm_dp.h>
@@ -40,10 +40,7 @@ extern "C" {
 #define SCH_CNT 3
 #define TASKLETS 1000
 
-enum direction {
-    TX,
-    RX
-};
+enum direction { TX, RX };
 
 typedef struct {
     uint8_t is_master;
@@ -74,9 +71,9 @@ typedef struct {
     enum st_frame_fmt output_fmt;
 
 #if defined(ZERO_COPY)
-    uint8_t* source_begin;
-    uint8_t* source_end;
-    uint8_t* frame_cursor;
+    uint8_t *source_begin;
+    uint8_t *source_end;
+    uint8_t *frame_cursor;
 
     mtl_iova_t source_begin_iova;
     size_t source_begin_iova_map_sz;
@@ -90,18 +87,18 @@ typedef struct {
     memif_socket_handle_t memif_socket;
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
     char name[32];
     pthread_t memif_event_thread;
 
-    void* frames_malloc_addr;
-    void* frames_begin_addr;
+    void *frames_malloc_addr;
+    void *frames_begin_addr;
     mtl_iova_t frames_begin_iova;
     size_t frames_iova_map_sz;
-    struct st20_ext_frame* ext_frames;
+    struct st20_ext_frame *ext_frames;
 } rx_session_context_t;
 
 typedef struct {
@@ -118,9 +115,9 @@ typedef struct {
     size_t frame_size;
 
 #if defined(ZERO_COPY)
-    uint8_t* source_begin;
-    uint8_t* source_end;
-    uint8_t* frame_cursor;
+    uint8_t *source_begin;
+    uint8_t *source_end;
+    uint8_t *frame_cursor;
 
     mtl_iova_t source_begin_iova;
     size_t source_begin_iova_map_sz;
@@ -133,7 +130,7 @@ typedef struct {
     /* memif conenction handle */
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
@@ -159,18 +156,18 @@ typedef struct {
     size_t frame_size;
 
 #if defined(ZERO_COPY)
-    uint8_t* source_begin;
-    uint8_t* source_end;
-    uint8_t* frame_cursor;
+    uint8_t *source_begin;
+    uint8_t *source_end;
+    uint8_t *frame_cursor;
 
     mtl_iova_t source_begin_iova;
     size_t source_begin_iova_map_sz;
 
-    void* ext_fb_malloc;
-    uint8_t* ext_fb;
+    void *ext_fb_malloc;
+    uint8_t *ext_fb;
     mtl_iova_t ext_fb_iova;
     size_t ext_fb_iova_map_sz;
-    struct st_ext_frame* p_ext_frames;
+    struct st_ext_frame *p_ext_frames;
     int ext_idx;
     bool ext_fb_in_use[3]; /* assume 3 framebuffer */
     mtl_dma_mem_handle dma_mem;
@@ -183,7 +180,7 @@ typedef struct {
     /* memif conenction handle */
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
@@ -214,19 +211,19 @@ typedef struct {
     enum st_frame_fmt output_fmt;
 
 #if defined(ZERO_COPY)
-    uint8_t* source_begin;
-    uint8_t* source_end;
-    uint8_t* frame_cursor;
+    uint8_t *source_begin;
+    uint8_t *source_end;
+    uint8_t *frame_cursor;
 
     mtl_iova_t source_begin_iova;
     size_t source_begin_iova_map_sz;
 
-    void* ext_fb_malloc;
-    uint8_t* ext_fb;
+    void *ext_fb_malloc;
+    uint8_t *ext_fb;
     mtl_iova_t ext_fb_iova;
     size_t ext_fb_iova_map_sz;
-    struct st20_ext_frame* ext_frames;
-    struct st_ext_frame* p_ext_frames;
+    struct st20_ext_frame *ext_frames;
+    struct st_ext_frame *p_ext_frames;
     int ext_idx;
     bool ext_fb_in_use[3]; /* assume 3 framebuffer */
     mtl_dma_mem_handle dma_mem;
@@ -240,15 +237,15 @@ typedef struct {
     memif_socket_handle_t memif_socket;
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
     char name[32];
     pthread_t memif_event_thread;
 
-    void* frames_malloc_addr;
-    void* frames_begin_addr;
+    void *frames_malloc_addr;
+    void *frames_begin_addr;
     mtl_iova_t frames_begin_iova;
     size_t frames_iova_map_sz;
 } rx_st22p_session_context_t;
@@ -261,7 +258,7 @@ typedef struct {
     uint16_t framebuff_cnt;
     uint16_t framebuff_producer_idx;
     uint16_t framebuff_consumer_idx;
-    struct st_tx_frame* framebuffs;
+    struct st_tx_frame *framebuffs;
 
     int st30_frame_done_cnt;
     int st30_packet_done_cnt;
@@ -286,7 +283,7 @@ typedef struct {
     /* memif conenction handle */
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
@@ -324,7 +321,7 @@ typedef struct {
     memif_socket_handle_t memif_socket;
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
@@ -374,7 +371,7 @@ typedef struct {
     memif_socket_handle_t memif_socket;
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
@@ -384,7 +381,7 @@ typedef struct {
     pthread_t memif_event_thread;
 
     /*udp poll*/
-    //mtl_sch_handle schs[SCH_CNT];
+    // mtl_sch_handle schs[SCH_CNT];
     mtl_tasklet_handle udp_tasklet;
     struct mtl_tasklet_ops udp_tasklet_ops;
     struct mudp_pollfd udp_pollfd;
@@ -392,12 +389,12 @@ typedef struct {
     int new_NALU;
     bool check_first_new_NALU;
     bool fragments_bunch;
-    mcm_buffer* rtp_header;
+    mcm_buffer *rtp_header;
     uint16_t tx_buf_num;
-    char* dst;
-    char* dst_nalu_size_point;
-    //int sch_idx;
-    //int tasklet_idx;
+    char *dst;
+    char *dst_nalu_size_point;
+    // int sch_idx;
+    // int tasklet_idx;
 
 } rx_udp_h264_session_context_t;
 
@@ -409,7 +406,7 @@ typedef struct {
     uint16_t framebuff_cnt;
     uint16_t framebuff_producer_idx;
     uint16_t framebuff_consumer_idx;
-    struct st_tx_frame* framebuffs;
+    struct st_tx_frame *framebuffs;
 
     int st40_frame_done_cnt;
     int st40_packet_done_cnt;
@@ -432,7 +429,7 @@ typedef struct {
     /* memif conenction handle */
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
@@ -469,7 +466,7 @@ typedef struct {
     memif_socket_handle_t memif_socket;
     memif_conn_handle_t memif_conn;
 
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
     uint8_t shm_ready;
 
@@ -487,104 +484,117 @@ typedef struct {
     enum direction type;
     mcm_payload_type payload_type;
     union {
-        tx_session_context_t* tx_session;
-        rx_session_context_t* rx_session;
-        tx_st22p_session_context_t* tx_st22p_session;
-        rx_st22p_session_context_t* rx_st22p_session;
-        tx_st30_session_context_t* tx_st30_session;
-        rx_st30_session_context_t* rx_st30_session;
-        rx_udp_h264_session_context_t* rx_udp_h264_session;
-        tx_st40_session_context_t* tx_st40_session;
-        rx_st40_session_context_t* rx_st40_session;
+        tx_session_context_t *tx_session;
+        rx_session_context_t *rx_session;
+        tx_st22p_session_context_t *tx_st22p_session;
+        rx_st22p_session_context_t *rx_st22p_session;
+        tx_st30_session_context_t *tx_st30_session;
+        rx_st30_session_context_t *rx_st30_session;
+        rx_udp_h264_session_context_t *rx_udp_h264_session;
+        tx_st40_session_context_t *tx_st40_session;
+        rx_st40_session_context_t *rx_st40_session;
     };
 } mtl_session_context_t;
 
 /* Initialize MTL library */
-mtl_handle inst_init(struct mtl_init_params* st_param);
+mtl_handle inst_init(struct mtl_init_params *st_param);
 
 /* Deinitialize MTL */
 void mtl_deinit(mtl_handle dev_handle);
 
 /* TX: Create ST20P session */
-tx_session_context_t* mtl_st20p_tx_session_create(mtl_handle dev_handle, struct st20p_tx_ops* opts, memif_ops_t* memif_ops);
+tx_session_context_t *mtl_st20p_tx_session_create(mtl_handle dev_handle, struct st20p_tx_ops *opts,
+                                                  memif_ops_t *memif_ops);
 
 /* RX: Create ST20P session */
-rx_session_context_t* mtl_st20p_rx_session_create(mtl_handle dev_handle, struct st20p_rx_ops* opts, memif_ops_t* memif_ops);
+rx_session_context_t *mtl_st20p_rx_session_create(mtl_handle dev_handle, struct st20p_rx_ops *opts,
+                                                  memif_ops_t *memif_ops);
 
 /* TX: Stop ST20P session */
-void mtl_st20p_tx_session_stop(tx_session_context_t* tx_ctx);
+void mtl_st20p_tx_session_stop(tx_session_context_t *tx_ctx);
 
 /* RX: Stop ST20P session */
-void mtl_st20p_rx_session_stop(rx_session_context_t* rx_ctx);
+void mtl_st20p_rx_session_stop(rx_session_context_t *rx_ctx);
 
 /* TX: Destroy ST20P session */
-void mtl_st20p_tx_session_destroy(tx_session_context_t** p_tx_ctx);
+void mtl_st20p_tx_session_destroy(tx_session_context_t **p_tx_ctx);
 
 /* RX: Destroy ST20P session */
-void mtl_st20p_rx_session_destroy(rx_session_context_t** p_rx_ctx);
+void mtl_st20p_rx_session_destroy(rx_session_context_t **p_rx_ctx);
 
 /* TX: Create ST22P session */
-tx_st22p_session_context_t* mtl_st22p_tx_session_create(mtl_handle dev_handle, struct st22p_tx_ops* opts, memif_ops_t* memif_ops);
+tx_st22p_session_context_t *mtl_st22p_tx_session_create(mtl_handle dev_handle,
+                                                        struct st22p_tx_ops *opts,
+                                                        memif_ops_t *memif_ops);
 
 /* RX: Create ST22P session */
-rx_st22p_session_context_t* mtl_st22p_rx_session_create(mtl_handle dev_handle, struct st22p_rx_ops* opts, memif_ops_t* memif_ops);
+rx_st22p_session_context_t *mtl_st22p_rx_session_create(mtl_handle dev_handle,
+                                                        struct st22p_rx_ops *opts,
+                                                        memif_ops_t *memif_ops);
 
 /* TX: Create ST30 session */
-tx_st30_session_context_t* mtl_st30_tx_session_create(mtl_handle dev_handle, struct st30_tx_ops* opts, memif_ops_t* memif_ops);
+tx_st30_session_context_t *
+mtl_st30_tx_session_create(mtl_handle dev_handle, struct st30_tx_ops *opts, memif_ops_t *memif_ops);
 
 /* RX: Create ST30 session */
-rx_st30_session_context_t* mtl_st30_rx_session_create(mtl_handle dev_handle, struct st30_rx_ops* opts, memif_ops_t* memif_ops);
+rx_st30_session_context_t *
+mtl_st30_rx_session_create(mtl_handle dev_handle, struct st30_rx_ops *opts, memif_ops_t *memif_ops);
 
 /* TX: Create ST40 session */
-tx_st40_session_context_t* mtl_st40_tx_session_create(mtl_handle dev_handle, struct st40_tx_ops* opts, memif_ops_t* memif_ops);
+tx_st40_session_context_t *
+mtl_st40_tx_session_create(mtl_handle dev_handle, struct st40_tx_ops *opts, memif_ops_t *memif_ops);
 
 /* RX: Create ST40 session */
-rx_st40_session_context_t* mtl_st40_rx_session_create(mtl_handle dev_handle, struct st40_rx_ops* opts, memif_ops_t* memif_ops);
+rx_st40_session_context_t *
+mtl_st40_rx_session_create(mtl_handle dev_handle, struct st40_rx_ops *opts, memif_ops_t *memif_ops);
 
 /* TX: Stop ST22P session */
-void mtl_st22p_tx_session_stop(tx_st22p_session_context_t* tx_ctx);
+void mtl_st22p_tx_session_stop(tx_st22p_session_context_t *tx_ctx);
 
 /* RX: Stop ST22P session */
-void mtl_st22p_rx_session_stop(rx_st22p_session_context_t* rx_ctx);
+void mtl_st22p_rx_session_stop(rx_st22p_session_context_t *rx_ctx);
 
 /* RX: Stop RTSP session */
-void mtl_rtsp_rx_session_stop(rx_udp_h264_session_context_t* rx_ctx);
+void mtl_rtsp_rx_session_stop(rx_udp_h264_session_context_t *rx_ctx);
 
 /* TX: Destroy ST22P session */
-void mtl_st22p_tx_session_destroy(tx_st22p_session_context_t** p_tx_ctx);
+void mtl_st22p_tx_session_destroy(tx_st22p_session_context_t **p_tx_ctx);
 
 /* RX: Destroy ST22P session */
-void mtl_st22p_rx_session_destroy(rx_st22p_session_context_t** p_rx_ctx);
+void mtl_st22p_rx_session_destroy(rx_st22p_session_context_t **p_rx_ctx);
 
 /* RX: Destroy RTSP session */
-void mtl_rtsp_rx_session_destroy(rx_udp_h264_session_context_t** p_rx_ctx);
+void mtl_rtsp_rx_session_destroy(rx_udp_h264_session_context_t **p_rx_ctx);
 
 /* RX: Create UDP H264 session */
-rx_udp_h264_session_context_t* mtl_udp_h264_rx_session_create(mtl_handle dev_handle, mcm_dp_addr* dp_addr, memif_ops_t* memif_ops, mtl_sch_handle schs[]);
+rx_udp_h264_session_context_t *mtl_udp_h264_rx_session_create(mtl_handle dev_handle,
+                                                              mcm_dp_addr *dp_addr,
+                                                              memif_ops_t *memif_ops,
+                                                              mtl_sch_handle schs[]);
 
 /* TX: Stop ST30 session */
-void mtl_st30_tx_session_stop(tx_st30_session_context_t* pctx);
+void mtl_st30_tx_session_stop(tx_st30_session_context_t *pctx);
 
 /* RX: Stop ST30 session */
-void mtl_st30_rx_session_stop(rx_st30_session_context_t* pctx);
+void mtl_st30_rx_session_stop(rx_st30_session_context_t *pctx);
 
 /* TX: Destroy ST30 session */
-void mtl_st30_tx_session_destroy(tx_st30_session_context_t** ppctx);
+void mtl_st30_tx_session_destroy(tx_st30_session_context_t **ppctx);
 
 /* RX: Destroy ST30 session */
-void mtl_st30_rx_session_destroy(rx_st30_session_context_t** ppctx);
+void mtl_st30_rx_session_destroy(rx_st30_session_context_t **ppctx);
 
 /* TX: Stop ST40 session */
-void mtl_st40_tx_session_stop(tx_st40_session_context_t* pctx);
+void mtl_st40_tx_session_stop(tx_st40_session_context_t *pctx);
 
 /* RX: Stop ST40 session */
-void mtl_st40_rx_session_stop(rx_st40_session_context_t* pctx);
+void mtl_st40_rx_session_stop(rx_st40_session_context_t *pctx);
 
 /* TX: Destroy ST40 session */
-void mtl_st40_tx_session_destroy(tx_st40_session_context_t** ppctx);
+void mtl_st40_tx_session_destroy(tx_st40_session_context_t **ppctx);
 
 /* RX: Destroy ST40 session */
-void mtl_st40_rx_session_destroy(rx_st40_session_context_t** ppctx);
+void mtl_st40_rx_session_destroy(rx_st40_session_context_t **ppctx);
 
 #ifdef __cplusplus
 }

--- a/media-proxy/include/proxy_context.h
+++ b/media-proxy/include/proxy_context.h
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
-*/
+ */
 
 #ifndef __PROXY_CONTEXT_H
 #define __PROXY_CONTEXT_H
@@ -34,8 +34,9 @@ using controller::TxControlRequest;
 
 #pragma once
 
-class ProxyContext {
-public:
+class ProxyContext
+{
+  public:
     std::string mRpcCtrlAddr;
     int mRpcCtrlPort;
 
@@ -45,9 +46,9 @@ public:
     std::string mVideoFormat;
 
     // direction mDir;
-    std::vector<mtl_session_context_t*> mStCtx;
-    std::vector<rx_session_context_t*> mRxCtx;
-    std::vector<tx_session_context_t*> mTxCtx;
+    std::vector<mtl_session_context_t *> mStCtx;
+    std::vector<rx_session_context_t *> mRxCtx;
+    std::vector<tx_session_context_t *> mTxCtx;
     mtl_handle mDevHandle = NULL;
 
     /*udp pool*/
@@ -77,38 +78,38 @@ public:
     std::string getTCPListenAddress(void);
     int getTCPListenPort(void);
 
-    void ParseStInitParam(const TxControlRequest* request, struct mtl_init_params* init_param);
-    void ParseStInitParam(const RxControlRequest* request, struct mtl_init_params* init_param);
-    void ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* init_param);
+    void ParseStInitParam(const TxControlRequest *request, struct mtl_init_params *init_param);
+    void ParseStInitParam(const RxControlRequest *request, struct mtl_init_params *init_param);
+    void ParseStInitParam(const mcm_conn_param *request, struct mtl_init_params *init_param);
 
-    void ParseMemIFParam(const TxControlRequest* request, memif_ops_t& memif_ops);
-    void ParseMemIFParam(const RxControlRequest* request, memif_ops_t& memif_ops);
-    void ParseMemIFParam(const mcm_conn_param* request, memif_ops_t& memif_ops);
+    void ParseMemIFParam(const TxControlRequest *request, memif_ops_t &memif_ops);
+    void ParseMemIFParam(const RxControlRequest *request, memif_ops_t &memif_ops);
+    void ParseMemIFParam(const mcm_conn_param *request, memif_ops_t &memif_ops);
 
-    void ParseSt20TxOps(const TxControlRequest* request, struct st20p_tx_ops* opts);
-    void ParseSt20RxOps(const RxControlRequest* request, struct st20p_rx_ops* opts);
-    void ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx_ops* opts);
-    void ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx_ops* opts);
-    void ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx_ops* opts);
-    void ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx_ops* opts);
-    void ParseSt30TxOps(const mcm_conn_param* request, struct st30_tx_ops* opts);
-    void ParseSt30RxOps(const mcm_conn_param* request, struct st30_rx_ops* opts);
-    void ParseSt40TxOps(const mcm_conn_param* request, struct st40_tx_ops* opts);
-    void ParseSt40RxOps(const mcm_conn_param* request, struct st40_rx_ops* opts);
-    int TxStart(const TxControlRequest* request);
-    int RxStart(const RxControlRequest* request);
-    int TxStart(const mcm_conn_param* request);
-    int RxStart(const mcm_conn_param* request);
+    void ParseSt20TxOps(const TxControlRequest *request, struct st20p_tx_ops *opts);
+    void ParseSt20RxOps(const RxControlRequest *request, struct st20p_rx_ops *opts);
+    void ParseSt20TxOps(const mcm_conn_param *request, struct st20p_tx_ops *opts);
+    void ParseSt20RxOps(const mcm_conn_param *request, struct st20p_rx_ops *opts);
+    void ParseSt22TxOps(const mcm_conn_param *request, struct st22p_tx_ops *opts);
+    void ParseSt22RxOps(const mcm_conn_param *request, struct st22p_rx_ops *opts);
+    void ParseSt30TxOps(const mcm_conn_param *request, struct st30_tx_ops *opts);
+    void ParseSt30RxOps(const mcm_conn_param *request, struct st30_rx_ops *opts);
+    void ParseSt40TxOps(const mcm_conn_param *request, struct st40_tx_ops *opts);
+    void ParseSt40RxOps(const mcm_conn_param *request, struct st40_rx_ops *opts);
+    int TxStart(const TxControlRequest *request);
+    int RxStart(const RxControlRequest *request);
+    int TxStart(const mcm_conn_param *request);
+    int RxStart(const mcm_conn_param *request);
     void TxStop(const int32_t session_id);
     void RxStop(const int32_t session_id);
     void Stop();
 
-private:
+  private:
     std::atomic<std::uint32_t> mSessionCount;
     pthread_mutex_t sessions_count_mutex_lock;
 
-    ProxyContext(const ProxyContext&) = delete;
-    ProxyContext& operator=(const ProxyContext&) = delete;
+    ProxyContext(const ProxyContext &) = delete;
+    ProxyContext &operator=(const ProxyContext &) = delete;
     uint32_t incrementMSessionCount(bool postIncrement);
     st_frame_fmt getStFrameFmt(video_pixel_format fmt);
 };

--- a/media-proxy/include/shm_memif.h
+++ b/media-proxy/include/shm_memif.h
@@ -28,13 +28,13 @@ typedef struct {
     uint16_t qid;
 
     /* tx buffers */
-    memif_buffer_t* tx_bufs;
+    memif_buffer_t *tx_bufs;
     /* allocated tx buffers counter */
     /* number of tx buffers pointing to shared memory */
     uint16_t tx_buf_num;
 
     /* rx buffers */
-    memif_buffer_t* rx_bufs;
+    memif_buffer_t *rx_bufs;
     /* allcoated rx buffers counter */
     /* number of rx buffers pointing to shared memory */
     uint16_t rx_buf_num;
@@ -44,31 +44,31 @@ void print_memif_details(memif_conn_handle_t conn);
 
 /* informs user about connected status. private_ctx is used by user to identify
  * connection */
-int rx_st20p_on_connect(memif_conn_handle_t conn, void* priv_data);
-int rx_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid);
+int rx_st20p_on_connect(memif_conn_handle_t conn, void *priv_data);
+int rx_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid);
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int rx_on_disconnect(memif_conn_handle_t conn, void* priv_data);
-int rx_st20p_on_disconnect(memif_conn_handle_t conn, void* priv_data);
+int rx_on_disconnect(memif_conn_handle_t conn, void *priv_data);
+int rx_st20p_on_disconnect(memif_conn_handle_t conn, void *priv_data);
 
-int rx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data);
-int rx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data);
-int rx_st30_on_connect(memif_conn_handle_t conn, void* priv_data);
-int rx_st40_on_connect(memif_conn_handle_t conn, void* priv_data);
-int rx_udp_h264_on_connect(memif_conn_handle_t conn, void* priv_data);
+int rx_st22p_on_connect(memif_conn_handle_t conn, void *priv_data);
+int rx_st22p_on_disconnect(memif_conn_handle_t conn, void *priv_data);
+int rx_st30_on_connect(memif_conn_handle_t conn, void *priv_data);
+int rx_st40_on_connect(memif_conn_handle_t conn, void *priv_data);
+int rx_udp_h264_on_connect(memif_conn_handle_t conn, void *priv_data);
 
-int tx_st20p_on_connect(memif_conn_handle_t conn, void* priv_data);
-int tx_st20p_on_disconnect(memif_conn_handle_t conn, void* priv_data);
-int tx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data);
-int tx_on_disconnect(memif_conn_handle_t conn, void* priv_data);
-int tx_st20p_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid);
-int tx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data);
-int tx_st22p_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid);
-int tx_st30_on_connect(memif_conn_handle_t conn, void* priv_data);
-int tx_st30_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid);
-int tx_st40_on_connect(memif_conn_handle_t conn, void* priv_data);
-int tx_st40_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid);
+int tx_st20p_on_connect(memif_conn_handle_t conn, void *priv_data);
+int tx_st20p_on_disconnect(memif_conn_handle_t conn, void *priv_data);
+int tx_st22p_on_disconnect(memif_conn_handle_t conn, void *priv_data);
+int tx_on_disconnect(memif_conn_handle_t conn, void *priv_data);
+int tx_st20p_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid);
+int tx_st22p_on_connect(memif_conn_handle_t conn, void *priv_data);
+int tx_st22p_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid);
+int tx_st30_on_connect(memif_conn_handle_t conn, void *priv_data);
+int tx_st30_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid);
+int tx_st40_on_connect(memif_conn_handle_t conn, void *priv_data);
+int tx_st40_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid);
 
 #ifdef __cplusplus
 }

--- a/media-proxy/include/utils.h
+++ b/media-proxy/include/utils.h
@@ -9,21 +9,21 @@
 
 #include <stdio.h>
 
-#define INFO(...)                     \
-    do {                              \
-        printf("INFO: " __VA_ARGS__); \
-        printf("\n");                 \
+#define INFO(...)                                                                                  \
+    do {                                                                                           \
+        printf("INFO: " __VA_ARGS__);                                                              \
+        printf("\n");                                                                              \
     } while (0)
-#define ERROR(...)                     \
-    do {                               \
-        printf("ERROR: " __VA_ARGS__); \
-        printf("\n");                  \
+#define ERROR(...)                                                                                 \
+    do {                                                                                           \
+        printf("ERROR: " __VA_ARGS__);                                                             \
+        printf("\n");                                                                              \
     } while (0)
 
-#define DEBUG(...)                     \
-    do {                               \
-        printf("DEBUG: " __VA_ARGS__); \
-        printf("\n");                  \
+#define DEBUG(...)                                                                                 \
+    do {                                                                                           \
+        printf("DEBUG: " __VA_ARGS__);                                                             \
+        printf("\n");                                                                              \
     } while (0)
 
 #endif

--- a/media-proxy/src/api_server_grpc.cc
+++ b/media-proxy/src/api_server_grpc.cc
@@ -6,12 +6,10 @@
 
 #include "api_server_grpc.h"
 
-ConfigureServiceImpl::ConfigureServiceImpl(ProxyContext* ctx)
-    : m_ctx(ctx)
-{
-}
+ConfigureServiceImpl::ConfigureServiceImpl(ProxyContext *ctx) : m_ctx(ctx) {}
 
-Status ConfigureServiceImpl::TxStart(ServerContext* context, const TxControlRequest* request, ControlReply* reply)
+Status ConfigureServiceImpl::TxStart(ServerContext *context, const TxControlRequest *request,
+                                     ControlReply *reply)
 {
     int session_id = 0;
     std::string ret_msg = "";
@@ -29,7 +27,8 @@ Status ConfigureServiceImpl::TxStart(ServerContext* context, const TxControlRequ
     return Status::OK;
 }
 
-Status ConfigureServiceImpl::RxStart(ServerContext* context, const RxControlRequest* request, ControlReply* reply)
+Status ConfigureServiceImpl::RxStart(ServerContext *context, const RxControlRequest *request,
+                                     ControlReply *reply)
 {
     int session_id = 0;
     std::string ret_msg = "";
@@ -47,7 +46,8 @@ Status ConfigureServiceImpl::RxStart(ServerContext* context, const RxControlRequ
     return Status::OK;
 }
 
-Status ConfigureServiceImpl::TxStop(ServerContext* context, const StopControlRequest* request, ControlReply* reply)
+Status ConfigureServiceImpl::TxStop(ServerContext *context, const StopControlRequest *request,
+                                    ControlReply *reply)
 {
     std::cout << "\nReceived command: Stop." << std::endl;
 
@@ -57,7 +57,8 @@ Status ConfigureServiceImpl::TxStop(ServerContext* context, const StopControlReq
     return Status::OK;
 }
 
-Status ConfigureServiceImpl::RxStop(ServerContext* context, const StopControlRequest* request, ControlReply* reply)
+Status ConfigureServiceImpl::RxStop(ServerContext *context, const StopControlRequest *request,
+                                    ControlReply *reply)
 {
     std::cout << "\nReceived command: Stop." << std::endl;
 
@@ -67,7 +68,8 @@ Status ConfigureServiceImpl::RxStop(ServerContext* context, const StopControlReq
     return Status::OK;
 }
 
-Status ConfigureServiceImpl::Stop(ServerContext* context, const StopControlRequest* request, ControlReply* reply)
+Status ConfigureServiceImpl::Stop(ServerContext *context, const StopControlRequest *request,
+                                  ControlReply *reply)
 {
     std::cout << "\nReceived command: Stop." << std::endl;
 
@@ -77,34 +79,31 @@ Status ConfigureServiceImpl::Stop(ServerContext* context, const StopControlReque
     return Status::OK;
 }
 
-MsmDataPlaneServiceImpl::MsmDataPlaneServiceImpl(ProxyContext* ctx)
-    : m_ctx(ctx)
-{
-}
+MsmDataPlaneServiceImpl::MsmDataPlaneServiceImpl(ProxyContext *ctx) : m_ctx(ctx) {}
 
-Status MsmDataPlaneServiceImpl::stream_add_del(ServerContext* context, const StreamData* request, StreamResult* reply)
+Status MsmDataPlaneServiceImpl::stream_add_del(ServerContext *context, const StreamData *request,
+                                               StreamResult *reply)
 {
     return Status::OK;
 }
 
-HealthServiceImpl::HealthServiceImpl(ProxyContext* ctx)
-    : m_ctx(ctx)
-{
-}
+HealthServiceImpl::HealthServiceImpl(ProxyContext *ctx) : m_ctx(ctx) {}
 
-Status HealthServiceImpl::Check(ServerContext* context, const HealthCheckRequest* request, HealthCheckResponse* reply)
+Status HealthServiceImpl::Check(ServerContext *context, const HealthCheckRequest *request,
+                                HealthCheckResponse *reply)
 {
     reply->set_status(controller::HealthCheckResponse_ServingStatus_SERVING);
 
     return Status::OK;
 }
 
-Status HealthServiceImpl::Watch(ServerContext* context, const HealthCheckRequest* request, HealthCheckResponse* reply)
+Status HealthServiceImpl::Watch(ServerContext *context, const HealthCheckRequest *request,
+                                HealthCheckResponse *reply)
 {
     return Status::OK;
 }
 
-void RunRPCServer(ProxyContext* ctx)
+void RunRPCServer(ProxyContext *ctx)
 {
     ConfigureServiceImpl service(ctx);
 

--- a/media-proxy/src/media_proxy.cc
+++ b/media-proxy/src/media_proxy.cc
@@ -20,30 +20,34 @@
 #define DEFAULT_TCP_PORT "8002"
 
 /* print a description of all supported options */
-void usage(FILE* fp, const char* path)
+void usage(FILE *fp, const char *path)
 {
     /* take only the last portion of the path */
-    const char* basename = strrchr(path, '/');
+    const char *basename = strrchr(path, '/');
     basename = basename ? basename + 1 : path;
 
     fprintf(fp, "Usage: %s [OPTION]\n", basename);
     fprintf(fp, "-h, --help\t\t"
                 "Print this help and exit.\n");
-    fprintf(fp, "-d, --dev=dev_port\t"
-                "PCI device port (defaults: %s).\n",
-        DEFAULT_DEV_PORT);
-    fprintf(fp, "-i, --ip=ip_address\t"
-                "IP address for media data transportation (defaults: %s).\n",
-        DEFAULT_DP_IP);
-    fprintf(fp, "-g, --grpc=port_number\t"
-                "Port number gRPC controller (defaults: %s).\n",
-        DEFAULT_GRPC_PORT);
-    fprintf(fp, "-t, --tcp=port_number\t"
-                "Port number for TCP socket controller (defaults: %s).\n",
-        DEFAULT_TCP_PORT);
+    fprintf(fp,
+            "-d, --dev=dev_port\t"
+            "PCI device port (defaults: %s).\n",
+            DEFAULT_DEV_PORT);
+    fprintf(fp,
+            "-i, --ip=ip_address\t"
+            "IP address for media data transportation (defaults: %s).\n",
+            DEFAULT_DP_IP);
+    fprintf(fp,
+            "-g, --grpc=port_number\t"
+            "Port number gRPC controller (defaults: %s).\n",
+            DEFAULT_GRPC_PORT);
+    fprintf(fp,
+            "-t, --tcp=port_number\t"
+            "Port number for TCP socket controller (defaults: %s).\n",
+            DEFAULT_TCP_PORT);
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
     std::string grpc_port = DEFAULT_GRPC_PORT;
     std::string tcp_port = DEFAULT_TCP_PORT;
@@ -52,13 +56,9 @@ int main(int argc, char* argv[])
     int help_flag = 0;
     int opt;
     struct option longopts[] = {
-        { "help", no_argument, &help_flag, 1 },
-        { "dev", required_argument, NULL, 'd' },
-        { "ip", required_argument, NULL, 'i' },
-        { "grpc", required_argument, NULL, 'g' },
-        { "tcp", required_argument, NULL, 't' },
-        { 0 }
-    };
+        {"help", no_argument, &help_flag, 1},  {"dev", required_argument, NULL, 'd'},
+        {"ip", required_argument, NULL, 'i'},  {"grpc", required_argument, NULL, 'g'},
+        {"tcp", required_argument, NULL, 't'}, {0}};
 
     /* infinite loop, to be broken when we are done parsing options */
     while (1) {
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
         setenv("KAHAWAI_CFG_PATH", IMTL_CONFIG_PATH, 0);
     }
 
-    ProxyContext* ctx = new ProxyContext("0.0.0.0:" + grpc_port, "0.0.0.0:" + tcp_port);
+    ProxyContext *ctx = new ProxyContext("0.0.0.0:" + grpc_port, "0.0.0.0:" + tcp_port);
     ctx->setDevicePort(dev_port);
     ctx->setDataPlaneAddress(dp_ip);
 

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -12,22 +12,20 @@
 #include <mtl/mtl_sch_api.h>
 
 ProxyContext::ProxyContext(void)
-    : mRpcCtrlAddr("0.0.0.0:8001")
-    , mTcpCtrlAddr("0.0.0.0:8002")
-    , schs_ready(false), imtl_init_preparing(false), mSessionCount(0)
+    : mRpcCtrlAddr("0.0.0.0:8001"), mTcpCtrlAddr("0.0.0.0:8002"), schs_ready(false),
+      imtl_init_preparing(false), mSessionCount(0)
 {
     mTcpCtrlPort = 8002;
 }
 
 ProxyContext::ProxyContext(std::string_view rpc_addr, std::string_view tcp_addr)
-    : mRpcCtrlAddr(rpc_addr)
-    , mTcpCtrlAddr(tcp_addr)
-    , schs_ready(false), imtl_init_preparing(false), mSessionCount(0)
+    : mRpcCtrlAddr(rpc_addr), mTcpCtrlAddr(tcp_addr), schs_ready(false), imtl_init_preparing(false),
+      mSessionCount(0)
 {
     auto colon = tcp_addr.find_first_of(":");
-    if (colon >= tcp_addr.size() ||
-        std::from_chars(tcp_addr.data() + colon + 1, tcp_addr.data() + tcp_addr.size(), mTcpCtrlPort).ec != std::errc())
-    {
+    if (colon >= tcp_addr.size() || std::from_chars(tcp_addr.data() + colon + 1,
+                                                    tcp_addr.data() + tcp_addr.size(), mTcpCtrlPort)
+                                            .ec != std::errc()) {
         ERROR("ProxyContext::ProxyContext(): Illegal TCP listen address.");
         throw;
     }
@@ -35,66 +33,35 @@ ProxyContext::ProxyContext(std::string_view rpc_addr, std::string_view tcp_addr)
     st_pthread_mutex_init(&sessions_count_mutex_lock, NULL);
 }
 
-void ProxyContext::setRPCListenAddress(std::string_view addr)
-{
-    mRpcCtrlAddr = addr;
-}
+void ProxyContext::setRPCListenAddress(std::string_view addr) { mRpcCtrlAddr = addr; }
 
-void ProxyContext::setTCPListenAddress(std::string_view addr)
-{
-    mTcpCtrlAddr = addr;
-}
+void ProxyContext::setTCPListenAddress(std::string_view addr) { mTcpCtrlAddr = addr; }
 
-void ProxyContext::setDevicePort(std::string_view dev)
-{
-    mDevPort = dev;
-}
+void ProxyContext::setDevicePort(std::string_view dev) { mDevPort = dev; }
 
-void ProxyContext::setDataPlaneAddress(std::string_view ip)
-{
-    mDpAddress = ip;
-}
+void ProxyContext::setDataPlaneAddress(std::string_view ip) { mDpAddress = ip; }
 
-void ProxyContext::setDataPlanePort(std::string_view port)
-{
-    mDpPort = port;
-}
+void ProxyContext::setDataPlanePort(std::string_view port) { mDpPort = port; }
 
-std::string ProxyContext::getRPCListenAddress(void)
-{
-    return mRpcCtrlAddr;
-}
+std::string ProxyContext::getRPCListenAddress(void) { return mRpcCtrlAddr; }
 
-std::string ProxyContext::getTCPListenAddress(void)
-{
-    return mTcpCtrlAddr;
-}
+std::string ProxyContext::getTCPListenAddress(void) { return mTcpCtrlAddr; }
 
-int ProxyContext::getTCPListenPort(void)
-{
-    return mTcpCtrlPort;
-}
+int ProxyContext::getTCPListenPort(void) { return mTcpCtrlPort; }
 
-std::string ProxyContext::getDevicePort(void)
-{
-    return mDevPort;
-}
+std::string ProxyContext::getDevicePort(void) { return mDevPort; }
 
-std::string ProxyContext::getDataPlaneAddress(void)
-{
-    return mDpAddress;
-}
+std::string ProxyContext::getDataPlaneAddress(void) { return mDpAddress; }
 
-std::string ProxyContext::getDataPlanePort(void)
-{
-    return mDpPort;
-}
+std::string ProxyContext::getDataPlanePort(void) { return mDpPort; }
 
-uint32_t ProxyContext::incrementMSessionCount(bool postIncrement=true)
+uint32_t ProxyContext::incrementMSessionCount(bool postIncrement = true)
 {
     uint32_t retValue;
-    st_pthread_mutex_lock(&this->sessions_count_mutex_lock);  /* lock to protect mSessionCount from change by multi-session simultaneously */
-    if(postIncrement)
+    st_pthread_mutex_lock(
+        &this->sessions_count_mutex_lock); /* lock to protect mSessionCount from change by
+                                              multi-session simultaneously */
+    if (postIncrement)
         retValue = (this->mSessionCount)++;
     else
         retValue = ++(this->mSessionCount);
@@ -105,27 +72,28 @@ uint32_t ProxyContext::incrementMSessionCount(bool postIncrement=true)
 st_frame_fmt ProxyContext::getStFrameFmt(video_pixel_format mcm_frame_fmt)
 {
     st_frame_fmt mtl_frame_fmt;
-    switch(mcm_frame_fmt) {
-        case PIX_FMT_NV12:
-            mtl_frame_fmt = ST_FRAME_FMT_YUV420CUSTOM8;
-            break;
-        case PIX_FMT_YUV422P:
-            mtl_frame_fmt = ST_FRAME_FMT_YUV422PLANAR8;
-            break;
-        case PIX_FMT_YUV444P_10BIT_LE:
-            mtl_frame_fmt = ST_FRAME_FMT_YUV444PLANAR10LE;
-            break;
-        case PIX_FMT_RGB8:
-            mtl_frame_fmt = ST_FRAME_FMT_RGB8;
-            break;
-        case PIX_FMT_YUV422P_10BIT_LE:
-        default:
-            mtl_frame_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
+    switch (mcm_frame_fmt) {
+    case PIX_FMT_NV12:
+        mtl_frame_fmt = ST_FRAME_FMT_YUV420CUSTOM8;
+        break;
+    case PIX_FMT_YUV422P:
+        mtl_frame_fmt = ST_FRAME_FMT_YUV422PLANAR8;
+        break;
+    case PIX_FMT_YUV444P_10BIT_LE:
+        mtl_frame_fmt = ST_FRAME_FMT_YUV444PLANAR10LE;
+        break;
+    case PIX_FMT_RGB8:
+        mtl_frame_fmt = ST_FRAME_FMT_RGB8;
+        break;
+    case PIX_FMT_YUV422P_10BIT_LE:
+    default:
+        mtl_frame_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
     }
     return mtl_frame_fmt;
 }
 
-void ProxyContext::ParseStInitParam(const TxControlRequest* request, struct mtl_init_params* st_param)
+void ProxyContext::ParseStInitParam(const TxControlRequest *request,
+                                    struct mtl_init_params *st_param)
 {
     StInit init = request->st_init();
     st_param->num_ports = init.number_ports();
@@ -147,10 +115,11 @@ void ProxyContext::ParseStInitParam(const TxControlRequest* request, struct mtl_
     if (init.logical_cores().empty()) {
         st_param->lcores = NULL;
     } else {
-        st_param->lcores = (char*)init.logical_cores().c_str();
+        st_param->lcores = (char *)init.logical_cores().c_str();
     }
 
-    INFO("ProxyContext: ParseStInitParam(const TxControlRequest* request, struct mtl_init_params* st_param)");
+    INFO("ProxyContext: ParseStInitParam(const TxControlRequest* request, struct mtl_init_params* "
+         "st_param)");
     INFO("num_ports : %d", st_param->num_ports);
     INFO("port      : %s", st_param->port[MTL_PORT_P]);
     INFO("sip_addr  :");
@@ -168,7 +137,8 @@ void ProxyContext::ParseStInitParam(const TxControlRequest* request, struct mtl_
     INFO("tx_sessions_cnt_max : %d", st_param->tx_queues_cnt[MTL_PORT_P]);
 }
 
-void ProxyContext::ParseStInitParam(const RxControlRequest* request, struct mtl_init_params* st_param)
+void ProxyContext::ParseStInitParam(const RxControlRequest *request,
+                                    struct mtl_init_params *st_param)
 {
     StInit init = request->st_init();
     st_param->num_ports = init.number_ports();
@@ -190,10 +160,11 @@ void ProxyContext::ParseStInitParam(const RxControlRequest* request, struct mtl_
     if (init.logical_cores().empty()) {
         st_param->lcores = NULL;
     } else {
-        st_param->lcores = (char*)init.logical_cores().c_str();
+        st_param->lcores = (char *)init.logical_cores().c_str();
     }
 
-    INFO("ProxyContext: ParseStInitParam(const RxControlRequest* request, struct mtl_init_params* st_param)");
+    INFO("ProxyContext: ParseStInitParam(const RxControlRequest* request, struct mtl_init_params* "
+         "st_param)");
     INFO("num_ports : %d", st_param->num_ports);
     INFO("port      : %s", st_param->port[MTL_PORT_P]);
     INFO("sip_addr  :");
@@ -211,7 +182,7 @@ void ProxyContext::ParseStInitParam(const RxControlRequest* request, struct mtl_
     INFO("tx_sessions_cnt_max : %d", st_param->tx_queues_cnt[MTL_PORT_P]);
 }
 
-void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* st_param)
+void ProxyContext::ParseStInitParam(const mcm_conn_param *request, struct mtl_init_params *st_param)
 {
     strlcpy(st_param->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     inet_pton(AF_INET, getDataPlaneAddress().c_str(), st_param->sip_addr[MTL_PORT_P]);
@@ -221,22 +192,23 @@ void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_in
     st_param->flags |= MTL_FLAG_TX_VIDEO_MIGRATE;
     st_param->flags |= MTL_FLAG_RX_VIDEO_MIGRATE;
     st_param->flags |= request->payload_mtl_flags_mask;
-    st_param->pacing = (st21_tx_pacing_way) request->payload_mtl_pacing;
+    st_param->pacing = (st21_tx_pacing_way)request->payload_mtl_pacing;
     st_param->log_level = MTL_LOG_LEVEL_DEBUG;
     st_param->priv = NULL;
     st_param->ptp_get_time_fn = NULL;
     // Native af_xdp have only 62 queues available
-    if(st_param->pmd[MTL_PORT_P] == MTL_PMD_NATIVE_AF_XDP) {
-      st_param->rx_queues_cnt[MTL_PORT_P] = 62;
-      st_param->tx_queues_cnt[MTL_PORT_P] = 62;
+    if (st_param->pmd[MTL_PORT_P] == MTL_PMD_NATIVE_AF_XDP) {
+        st_param->rx_queues_cnt[MTL_PORT_P] = 62;
+        st_param->tx_queues_cnt[MTL_PORT_P] = 62;
     } else {
-      st_param->rx_queues_cnt[MTL_PORT_P] = 128;
-      st_param->tx_queues_cnt[MTL_PORT_P] = 128;
+        st_param->rx_queues_cnt[MTL_PORT_P] = 128;
+        st_param->tx_queues_cnt[MTL_PORT_P] = 128;
     }
     st_param->lcores = NULL;
     st_param->memzone_max = 9000;
 
-    INFO("ProxyContext: ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* st_param)");
+    INFO("ProxyContext: ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* "
+         "st_param)");
     INFO("num_ports : '%d'", st_param->num_ports);
     INFO("port      : '%s'", st_param->port[MTL_PORT_P]);
     INFO("port pmd  : '%d'", int(st_param->pmd[MTL_PORT_P]));
@@ -252,21 +224,27 @@ void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_in
     INFO("tx_sessions_cnt_max : %d", st_param->tx_queues_cnt[MTL_PORT_P]);
 }
 
-void ProxyContext::ParseMemIFParam(const TxControlRequest* request, memif_ops_t& memif_ops)
+void ProxyContext::ParseMemIFParam(const TxControlRequest *request, memif_ops_t &memif_ops)
 {
-    strlcpy(memif_ops.app_name, request->memif_ops().app_name().c_str(), sizeof(memif_ops.app_name));
-    strlcpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(), sizeof(memif_ops.interface_name));
-    strlcpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(), sizeof(memif_ops.socket_path));
+    strlcpy(memif_ops.app_name, request->memif_ops().app_name().c_str(),
+            sizeof(memif_ops.app_name));
+    strlcpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(),
+            sizeof(memif_ops.interface_name));
+    strlcpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(),
+            sizeof(memif_ops.socket_path));
 }
 
-void ProxyContext::ParseMemIFParam(const RxControlRequest* request, memif_ops_t& memif_ops)
+void ProxyContext::ParseMemIFParam(const RxControlRequest *request, memif_ops_t &memif_ops)
 {
-    strlcpy(memif_ops.app_name, request->memif_ops().app_name().c_str(), sizeof(memif_ops.app_name));
-    strlcpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(), sizeof(memif_ops.interface_name));
-    strlcpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(), sizeof(memif_ops.socket_path));
+    strlcpy(memif_ops.app_name, request->memif_ops().app_name().c_str(),
+            sizeof(memif_ops.app_name));
+    strlcpy(memif_ops.interface_name, request->memif_ops().interface_name().c_str(),
+            sizeof(memif_ops.interface_name));
+    strlcpy(memif_ops.socket_path, request->memif_ops().socket_path().c_str(),
+            sizeof(memif_ops.socket_path));
 }
 
-void ProxyContext::ParseSt20RxOps(const RxControlRequest* request, struct st20p_rx_ops* ops_rx)
+void ProxyContext::ParseSt20RxOps(const RxControlRequest *request, struct st20p_rx_ops *ops_rx)
 {
     St20pRxOps st20_rx = request->st20_rx();
     StRxPort rx_port = st20_rx.rx_port();
@@ -315,7 +293,7 @@ void ProxyContext::ParseSt20RxOps(const RxControlRequest* request, struct st20p_
     INFO("framebuff_cnt : %d", ops_rx->framebuff_cnt);
 }
 
-void ProxyContext::ParseSt20TxOps(const TxControlRequest* request, struct st20p_tx_ops* ops_tx)
+void ProxyContext::ParseSt20TxOps(const TxControlRequest *request, struct st20p_tx_ops *ops_tx)
 {
     St20pTxOps st20_tx = request->st20_tx();
     StTxPort tx_port = st20_tx.tx_port();
@@ -359,7 +337,7 @@ void ProxyContext::ParseSt20TxOps(const TxControlRequest* request, struct st20p_
     INFO("framebuff_cnt : %d", ops_tx->framebuff_cnt);
 }
 
-void ProxyContext::ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx_ops* ops_rx)
+void ProxyContext::ParseSt20RxOps(const mcm_conn_param *request, struct st20p_rx_ops *ops_rx)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -372,7 +350,7 @@ void ProxyContext::ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx
     // ops_rx->port.udp_port[MTL_PORT_P] = RX_ST20_UDP_PORT;
     strlcpy(ops_rx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops_rx->port.num_port = 1;
-    if(request->payload_type_nr == 0 ) {
+    if (request->payload_type_nr == 0) {
         ops_rx->port.payload_type = ST_APP_PAYLOAD_TYPE_VIDEO;
     } else {
         ops_rx->port.payload_type = request->payload_type_nr;
@@ -411,7 +389,7 @@ void ProxyContext::ParseSt20RxOps(const mcm_conn_param* request, struct st20p_rx
     INFO("framebuff_cnt : %d", ops_rx->framebuff_cnt);
 }
 
-void ProxyContext::ParseMemIFParam(const mcm_conn_param* request, memif_ops_t& memif_ops)
+void ProxyContext::ParseMemIFParam(const mcm_conn_param *request, memif_ops_t &memif_ops)
 {
     uint32_t sessionCount = incrementMSessionCount();
     std::string type_str = "";
@@ -424,13 +402,16 @@ void ProxyContext::ParseMemIFParam(const mcm_conn_param* request, memif_ops_t& m
 
     memif_ops.is_master = 1;
     memif_ops.interface_id = 0;
-    snprintf(memif_ops.app_name, sizeof(memif_ops.app_name), "memif_%s_%d", type_str.c_str(), int(sessionCount));
-    snprintf(memif_ops.interface_name, sizeof(memif_ops.interface_name), "memif_%s_%d", type_str.c_str(), int(sessionCount));
-    snprintf(memif_ops.socket_path, sizeof(memif_ops.socket_path), "/run/mcm/media_proxy_%s_%d.sock", type_str.c_str(), int(sessionCount));
+    snprintf(memif_ops.app_name, sizeof(memif_ops.app_name), "memif_%s_%d", type_str.c_str(),
+             int(sessionCount));
+    snprintf(memif_ops.interface_name, sizeof(memif_ops.interface_name), "memif_%s_%d",
+             type_str.c_str(), int(sessionCount));
+    snprintf(memif_ops.socket_path, sizeof(memif_ops.socket_path),
+             "/run/mcm/media_proxy_%s_%d.sock", type_str.c_str(), int(sessionCount));
     memif_ops.m_session_count = ++sessionCount;
 }
 
-void ProxyContext::ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx_ops* ops_tx)
+void ProxyContext::ParseSt20TxOps(const mcm_conn_param *request, struct st20p_tx_ops *ops_tx)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -442,7 +423,7 @@ void ProxyContext::ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx
     strlcpy(ops_tx->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops_tx->port.udp_src_port[MTL_PORT_P] = atoi(request->local_addr.port);
     ops_tx->port.num_port = 1;
-    if(request->payload_type_nr == 0 ) {
+    if (request->payload_type_nr == 0) {
         ops_tx->port.payload_type = ST_APP_PAYLOAD_TYPE_VIDEO;
     } else {
         ops_tx->port.payload_type = request->payload_type_nr;
@@ -477,7 +458,7 @@ void ProxyContext::ParseSt20TxOps(const mcm_conn_param* request, struct st20p_tx
     INFO("framebuff_cnt : %d", ops_tx->framebuff_cnt);
 }
 
-void ProxyContext::ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx_ops* ops)
+void ProxyContext::ParseSt22TxOps(const mcm_conn_param *request, struct st22p_tx_ops *ops)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -489,7 +470,7 @@ void ProxyContext::ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx
     strlcpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->port.udp_src_port[MTL_PORT_P] = atoi(request->local_addr.port);
     ops->port.num_port = 1;
-    if(request->payload_type_nr == 0 ) {
+    if (request->payload_type_nr == 0) {
         ops->port.payload_type = ST_APP_PAYLOAD_TYPE_ST22;
     } else {
         ops->port.payload_type = request->payload_type_nr;
@@ -528,7 +509,7 @@ void ProxyContext::ParseSt22TxOps(const mcm_conn_param* request, struct st22p_tx
     INFO("framebuff_cnt : %d", ops->framebuff_cnt);
 }
 
-void ProxyContext::ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx_ops* ops)
+void ProxyContext::ParseSt22RxOps(const mcm_conn_param *request, struct st22p_rx_ops *ops)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -541,7 +522,7 @@ void ProxyContext::ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx
     // ops->port.udp_port[MTL_PORT_P] = RX_ST20_UDP_PORT;
     strlcpy(ops->port.port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     ops->port.num_port = 1;
-    if(request->payload_type_nr == 0 ) {
+    if (request->payload_type_nr == 0) {
         ops->port.payload_type = ST_APP_PAYLOAD_TYPE_ST22;
     } else {
         ops->port.payload_type = request->payload_type_nr;
@@ -582,7 +563,7 @@ void ProxyContext::ParseSt22RxOps(const mcm_conn_param* request, struct st22p_rx
     INFO("framebuff_cnt : %d", ops->framebuff_cnt);
 }
 
-void ProxyContext::ParseSt30TxOps(const mcm_conn_param* request, struct st30_tx_ops* ops)
+void ProxyContext::ParseSt30TxOps(const mcm_conn_param *request, struct st30_tx_ops *ops)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -617,7 +598,7 @@ void ProxyContext::ParseSt30TxOps(const mcm_conn_param* request, struct st30_tx_
     INFO("framebuff_cnt : %d", ops->framebuff_cnt);
 }
 
-void ProxyContext::ParseSt30RxOps(const mcm_conn_param* request, struct st30_rx_ops* ops)
+void ProxyContext::ParseSt30RxOps(const mcm_conn_param *request, struct st30_rx_ops *ops)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -652,7 +633,7 @@ void ProxyContext::ParseSt30RxOps(const mcm_conn_param* request, struct st30_rx_
     INFO("framebuff_cnt : %d", ops->framebuff_cnt);
 }
 
-void ProxyContext::ParseSt40TxOps(const mcm_conn_param* request, struct st40_tx_ops* ops)
+void ProxyContext::ParseSt40TxOps(const mcm_conn_param *request, struct st40_tx_ops *ops)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -687,7 +668,7 @@ void ProxyContext::ParseSt40TxOps(const mcm_conn_param* request, struct st40_tx_
     INFO("fps           : %d", ops->fps);
 }
 
-void ProxyContext::ParseSt40RxOps(const mcm_conn_param* request, struct st40_rx_ops* ops)
+void ProxyContext::ParseSt40RxOps(const mcm_conn_param *request, struct st40_rx_ops *ops)
 {
     static int session_id = 0;
     char session_name[NAME_MAX] = "";
@@ -715,13 +696,13 @@ void ProxyContext::ParseSt40RxOps(const mcm_conn_param* request, struct st40_rx_
     INFO("name          : %s", ops->name);
 }
 
-int ProxyContext::RxStart(const RxControlRequest* request)
+int ProxyContext::RxStart(const RxControlRequest *request)
 {
     INFO("ProxyContext: RxStart(const RxControlRequest* request)");
-    struct st20p_rx_ops opts = { 0 };
-    mtl_session_context_t* st_ctx = NULL;
-    rx_session_context_t* rx_ctx = NULL;
-    memif_ops_t memif_ops = { 0 };
+    struct st20p_rx_ops opts = {0};
+    mtl_session_context_t *st_ctx = NULL;
+    rx_session_context_t *rx_ctx = NULL;
+    memif_ops_t memif_ops = {0};
 
     if (mDevHandle == NULL) {
         struct mtl_init_params st_param = {};
@@ -757,13 +738,13 @@ int ProxyContext::RxStart(const RxControlRequest* request)
     return (st_ctx->id);
 }
 
-int ProxyContext::TxStart(const TxControlRequest* request)
+int ProxyContext::TxStart(const TxControlRequest *request)
 {
     INFO("ProxyContext: TxStart(const TxControlRequest* request)");
-    struct st20p_tx_ops opts = { 0 };
-    mtl_session_context_t* st_ctx = NULL;
-    tx_session_context_t* tx_ctx = NULL;
-    memif_ops_t memif_ops = { 0 };
+    struct st20p_tx_ops opts = {0};
+    mtl_session_context_t *st_ctx = NULL;
+    tx_session_context_t *tx_ctx = NULL;
+    memif_ops_t memif_ops = {0};
 
     if (mDevHandle == NULL) {
         struct mtl_init_params st_param = {};
@@ -799,19 +780,20 @@ int ProxyContext::TxStart(const TxControlRequest* request)
     return (st_ctx->id);
 }
 
-int ProxyContext::RxStart(const mcm_conn_param* request)
+int ProxyContext::RxStart(const mcm_conn_param *request)
 {
     INFO("ProxyContext: RxStart(const mcm_conn_param* request)");
-    struct st20p_rx_ops opts = { 0 };
-    mtl_session_context_t* st_ctx = NULL;
-    memif_ops_t memif_ops = { 0 };
+    struct st20p_rx_ops opts = {0};
+    mtl_session_context_t *st_ctx = NULL;
+    memif_ops_t memif_ops = {0};
     int ret;
 
-    /*add lock to protect MTL library initialization to aviod being called by multi-session simultaneously*/
+    /*add lock to protect MTL library initialization to aviod being called by multi-session
+     * simultaneously*/
     if (mDevHandle == NULL && imtl_init_preparing == false) {
 
         imtl_init_preparing = true;
-        struct mtl_init_params st_param = { 0 };
+        struct mtl_init_params st_param = {0};
 
         /* set default parameters */
         ParseStInitParam(request, &st_param);
@@ -864,7 +846,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
     ParseMemIFParam(request, memif_ops);
     switch (request->payload_type) {
     case PAYLOAD_TYPE_ST22_VIDEO: {
-        rx_st22p_session_context_t* rx_ctx = NULL;
+        rx_st22p_session_context_t *rx_ctx = NULL;
         struct st22p_rx_ops opts = {};
 
         ParseSt22RxOps(request, &opts);
@@ -879,7 +861,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         break;
     }
     case PAYLOAD_TYPE_ST30_AUDIO: {
-        rx_st30_session_context_t* rx_ctx = NULL;
+        rx_st30_session_context_t *rx_ctx = NULL;
         struct st30_rx_ops opts = {};
 
         ParseSt30RxOps(request, &opts);
@@ -894,7 +876,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         break;
     }
     case PAYLOAD_TYPE_ST40_ANCILLARY: {
-        rx_st40_session_context_t* rx_ctx = NULL;
+        rx_st40_session_context_t *rx_ctx = NULL;
         struct st40_rx_ops opts = {};
 
         ParseSt40RxOps(request, &opts);
@@ -909,7 +891,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
         break;
     }
     case PAYLOAD_TYPE_RTSP_VIDEO: {
-        rx_udp_h264_session_context_t* rx_ctx = NULL;
+        rx_udp_h264_session_context_t *rx_ctx = NULL;
         mcm_dp_addr local_addr = request->local_addr;
         /*udp poll*/
         rx_ctx = mtl_udp_h264_rx_session_create(mDevHandle, &local_addr, &memif_ops, schs);
@@ -924,7 +906,7 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
     case PAYLOAD_TYPE_ST20_VIDEO:
     case PAYLOAD_TYPE_NONE:
     default: {
-        rx_session_context_t* rx_ctx = NULL;
+        rx_session_context_t *rx_ctx = NULL;
         struct st20p_rx_ops opts = {};
 
         ParseSt20RxOps(request, &opts);
@@ -949,18 +931,19 @@ int ProxyContext::RxStart(const mcm_conn_param* request)
     return (st_ctx->id);
 }
 
-int ProxyContext::TxStart(const mcm_conn_param* request)
+int ProxyContext::TxStart(const mcm_conn_param *request)
 {
     INFO("ProxyContext: TxStart(const mcm_conn_param* request)");
-    mtl_session_context_t* st_ctx = NULL;
-    memif_ops_t memif_ops = { 0 };
+    mtl_session_context_t *st_ctx = NULL;
+    memif_ops_t memif_ops = {0};
 
-    /* add lock to protect MTL library initialization to avoid being called by multi-session simultaneously */
+    /* add lock to protect MTL library initialization to avoid being called by multi-session
+     * simultaneously */
     if (mDevHandle == NULL && imtl_init_preparing == false) {
 
         imtl_init_preparing = true;
 
-        struct mtl_init_params st_param = { 0 };
+        struct mtl_init_params st_param = {0};
 
         /* set default parameters */
         ParseStInitParam(request, &st_param);
@@ -985,7 +968,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
 
     switch (request->payload_type) {
     case PAYLOAD_TYPE_ST22_VIDEO: {
-        tx_st22p_session_context_t* tx_ctx = NULL;
+        tx_st22p_session_context_t *tx_ctx = NULL;
         struct st22p_tx_ops opts = {};
 
         ParseSt22TxOps(request, &opts);
@@ -1000,7 +983,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         break;
     }
     case PAYLOAD_TYPE_ST30_AUDIO: {
-        tx_st30_session_context_t* tx_ctx = NULL;
+        tx_st30_session_context_t *tx_ctx = NULL;
         struct st30_tx_ops opts = {};
 
         ParseSt30TxOps(request, &opts);
@@ -1015,7 +998,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
         break;
     }
     case PAYLOAD_TYPE_ST40_ANCILLARY: {
-        tx_st40_session_context_t* tx_ctx = NULL;
+        tx_st40_session_context_t *tx_ctx = NULL;
         struct st40_tx_ops opts = {};
 
         ParseSt40TxOps(request, &opts);
@@ -1031,7 +1014,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
     }
     case PAYLOAD_TYPE_ST20_VIDEO:
     default: {
-        tx_session_context_t* tx_ctx = NULL;
+        tx_session_context_t *tx_ctx = NULL;
         struct st20p_tx_ops opts = {};
 
         ParseSt20TxOps(request, &opts);
@@ -1058,9 +1041,7 @@ int ProxyContext::TxStart(const mcm_conn_param* request)
 void ProxyContext::TxStop(const int32_t session_id)
 {
     auto ctx = std::find_if(mStCtx.begin(), mStCtx.end(),
-        [session_id](auto it) {
-            return it->id == session_id;
-        });
+                            [session_id](auto it) { return it->id == session_id; });
 
     if (ctx != mStCtx.end()) {
         INFO("%s, Stop TX session ID: %d", __func__, session_id);
@@ -1103,10 +1084,8 @@ void ProxyContext::TxStop(const int32_t session_id)
 void ProxyContext::RxStop(const int32_t session_id)
 {
     auto it = std::find_if(mStCtx.begin(), mStCtx.end(),
-        [session_id](auto it) {
-            return it->id == session_id;
-        });
-    mtl_session_context_t* ctx = *it;
+                           [session_id](auto it) { return it->id == session_id; });
+    mtl_session_context_t *ctx = *it;
 
     if (it != mStCtx.end()) {
         INFO("%s, Stop RX session ID: %d", __func__, session_id);

--- a/media-proxy/src/shm_memif_common.c
+++ b/media-proxy/src/shm_memif_common.c
@@ -17,10 +17,10 @@ void print_memif_details(memif_conn_handle_t conn)
     memif_details_t md;
     memset(&md, 0, sizeof(md));
     ssize_t buflen = 2048;
-    char* buf = NULL;
+    char *buf = NULL;
     int err = 0;
 
-    buf = (char*)malloc(buflen);
+    buf = (char *)malloc(buflen);
     if (buf == NULL) {
         INFO("Not Enough Memory.");
         return;
@@ -36,12 +36,12 @@ void print_memif_details(memif_conn_handle_t conn)
         }
     }
 
-    printf("\tinterface name: %s\n", (char*)md.if_name);
-    printf("\tapp name: %s\n", (char*)md.inst_name);
-    printf("\tremote interface name: %s\n", (char*)md.remote_if_name);
-    printf("\tremote app name: %s\n", (char*)md.remote_inst_name);
+    printf("\tinterface name: %s\n", (char *)md.if_name);
+    printf("\tapp name: %s\n", (char *)md.inst_name);
+    printf("\tremote interface name: %s\n", (char *)md.remote_if_name);
+    printf("\tremote app name: %s\n", (char *)md.remote_inst_name);
     printf("\tid: %u\n", md.id);
-    printf("\tsecret: %s\n", (char*)md.secret);
+    printf("\tsecret: %s\n", (char *)md.secret);
     printf("\trole: ");
     if (md.role)
         printf("slave\n");
@@ -62,7 +62,7 @@ void print_memif_details(memif_conn_handle_t conn)
         printf("unknown\n");
         break;
     }
-    printf("\tsocket path: %s\n", (char*)md.socket_path);
+    printf("\tsocket path: %s\n", (char *)md.socket_path);
     printf("\tregions num: %d\n", md.regions_num);
     for (int i = 0; i < md.regions_num; i++) {
         printf("\t\tregions idx: %d\n", md.regions[i].index);
@@ -93,10 +93,10 @@ void print_memif_details(memif_conn_handle_t conn)
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int rx_on_disconnect(memif_conn_handle_t conn, void* priv_data)
+int rx_on_disconnect(memif_conn_handle_t conn, void *priv_data)
 {
     int err = 0;
-    rx_session_context_t* rx_ctx = priv_data;
+    rx_session_context_t *rx_ctx = priv_data;
     memif_socket_handle_t socket;
 
     if (conn == NULL) {
@@ -134,7 +134,7 @@ int rx_on_disconnect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-int rx_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int rx_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int err = 0;
     memif_buffer_t shm_bufs;
@@ -159,11 +159,11 @@ int rx_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int tx_on_disconnect(memif_conn_handle_t conn, void* priv_data)
+int tx_on_disconnect(memif_conn_handle_t conn, void *priv_data)
 {
     static int counter = 0;
     int err = 0;
-    tx_session_context_t* tx_ctx = priv_data;
+    tx_session_context_t *tx_ctx = priv_data;
     memif_socket_handle_t socket;
 
     // if (tx_ctx == NULL) {

--- a/media-proxy/src/shm_memif_st22.c
+++ b/media-proxy/src/shm_memif_st22.c
@@ -9,17 +9,17 @@
 #include "mtl.h"
 #include "shm_memif.h"
 
-int rx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data)
+int rx_st22p_on_connect(memif_conn_handle_t conn, void *priv_data)
 {
-    rx_st22p_session_context_t* rx_ctx = (rx_st22p_session_context_t*)priv_data;
+    rx_st22p_session_context_t *rx_ctx = (rx_st22p_session_context_t *)priv_data;
     int err = 0;
 
     INFO("RX memif connected!");
 
 #if defined(ZERO_COPY)
-    memif_details_t md = { 0 };
+    memif_details_t md = {0};
     ssize_t buflen = 2048;
-    char* buf = (char*)calloc(1, buflen);
+    char *buf = (char *)calloc(1, buflen);
 
     err = memif_get_details(conn, &md, buf, buflen);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -43,7 +43,7 @@ int rx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data)
 #endif
 
     /* rx buffers */
-    rx_ctx->shm_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
+    rx_ctx->shm_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
     rx_ctx->shm_buf_num = rx_ctx->fb_count;
 
     err = memif_refill_queue(conn, 0, -1, 0);
@@ -59,10 +59,10 @@ int rx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-int rx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data)
+int rx_st22p_on_disconnect(memif_conn_handle_t conn, void *priv_data)
 {
     int err = 0;
-    rx_st22p_session_context_t* rx_ctx = priv_data;
+    rx_st22p_session_context_t *rx_ctx = priv_data;
     memif_socket_handle_t socket;
 
     if (conn == NULL || priv_data == NULL) {
@@ -77,7 +77,8 @@ int rx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data)
     rx_ctx->shm_ready = 0;
 
 #if defined(ZERO_COPY)
-    if (mtl_dma_unmap(rx_ctx->st, rx_ctx->source_begin, rx_ctx->source_begin_iova, rx_ctx->source_begin_iova_map_sz) < 0) {
+    if (mtl_dma_unmap(rx_ctx->st, rx_ctx->source_begin, rx_ctx->source_begin_iova,
+                      rx_ctx->source_begin_iova_map_sz) < 0) {
         ERROR("Fail to unmap DMA memory address.");
     }
 #endif
@@ -98,9 +99,9 @@ int rx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-int tx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data)
+int tx_st22p_on_connect(memif_conn_handle_t conn, void *priv_data)
 {
-    tx_st22p_session_context_t* tx_ctx = (tx_st22p_session_context_t*)priv_data;
+    tx_st22p_session_context_t *tx_ctx = (tx_st22p_session_context_t *)priv_data;
     int err = 0;
 
     INFO("TX memif connected!");
@@ -112,9 +113,9 @@ int tx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data)
     }
 
 #if defined(ZERO_COPY)
-    memif_details_t md = { 0 };
+    memif_details_t md = {0};
     ssize_t buflen = 2048;
-    char* buf = (char*)calloc(1, buflen);
+    char *buf = (char *)calloc(1, buflen);
 
     err = memif_get_details(conn, &md, buf, buflen);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -143,11 +144,11 @@ int tx_st22p_on_connect(memif_conn_handle_t conn, void* priv_data)
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int tx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data)
+int tx_st22p_on_disconnect(memif_conn_handle_t conn, void *priv_data)
 {
     static int counter = 0;
     int err = 0;
-    tx_st22p_session_context_t* tx_ctx = priv_data;
+    tx_st22p_session_context_t *tx_ctx = priv_data;
     memif_socket_handle_t socket;
 
     if (conn == NULL || priv_data == NULL) {
@@ -164,7 +165,8 @@ int tx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data)
     // mtl_st22p_tx_session_destroy(&tx_ctx);
 
 #if defined(ZERO_COPY)
-    if (mtl_dma_unmap(tx_ctx->st, tx_ctx->source_begin, tx_ctx->source_begin_iova, tx_ctx->source_begin_iova_map_sz) < 0) {
+    if (mtl_dma_unmap(tx_ctx->st, tx_ctx->source_begin, tx_ctx->source_begin_iova,
+                      tx_ctx->source_begin_iova_map_sz) < 0) {
         ERROR("Fail to unmap DMA memory address.");
     }
 #endif
@@ -187,16 +189,16 @@ int tx_st22p_on_disconnect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-static void tx_st22p_build_frame(memif_buffer_t shm_bufs, struct st_frame* frame)
+static void tx_st22p_build_frame(memif_buffer_t shm_bufs, struct st_frame *frame)
 {
     mtl_memcpy(frame->addr[0], shm_bufs.data, shm_bufs.len);
 }
 
-int tx_st22p_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int tx_st22p_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int err = 0;
-    tx_st22p_session_context_t* tx_ctx = (tx_st22p_session_context_t*)priv_data;
-    memif_buffer_t shm_bufs = { 0 };
+    tx_st22p_session_context_t *tx_ctx = (tx_st22p_session_context_t *)priv_data;
+    memif_buffer_t shm_bufs = {0};
     uint16_t buf_num = 0;
 
     if (tx_ctx->stop) {
@@ -213,7 +215,7 @@ int tx_st22p_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
     // INFO("memif_rx_burst: size: %d, num: %d", shm_bufs.len, buf_num);
 
     st22p_tx_handle handle = tx_ctx->handle;
-    struct st_frame* frame = NULL;
+    struct st_frame *frame = NULL;
 
     do {
         frame = st22p_tx_get_frame(handle);
@@ -227,15 +229,18 @@ int tx_st22p_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
 
     /* Send out frame. */
 #if defined(ZERO_COPY)
-    struct st_ext_frame ext_frame = { 0 };
+    struct st_ext_frame ext_frame = {0};
     ext_frame.addr[0] = shm_bufs.data;
-    ext_frame.iova[0] = tx_ctx->source_begin_iova + ((uint8_t*)shm_bufs.data - tx_ctx->source_begin);
+    ext_frame.iova[0] =
+        tx_ctx->source_begin_iova + ((uint8_t *)shm_bufs.data - tx_ctx->source_begin);
     ext_frame.linesize[0] = st_frame_least_linesize(frame->fmt, frame->width, 0);
     uint8_t planes = st_frame_fmt_planes(frame->fmt);
     for (uint8_t plane = 1; plane < planes; plane++) { /* assume planes continous */
         ext_frame.linesize[plane] = st_frame_least_linesize(frame->fmt, frame->width, plane);
-        ext_frame.addr[plane] = (uint8_t*)ext_frame.addr[plane - 1] + ext_frame.linesize[plane - 1] * frame->height;
-        ext_frame.iova[plane] = ext_frame.iova[plane - 1] + ext_frame.linesize[plane - 1] * frame->height;
+        ext_frame.addr[plane] =
+            (uint8_t *)ext_frame.addr[plane - 1] + ext_frame.linesize[plane - 1] * frame->height;
+        ext_frame.iova[plane] =
+            ext_frame.iova[plane - 1] + ext_frame.linesize[plane - 1] * frame->height;
     }
     ext_frame.size = shm_bufs.len;
     ext_frame.opaque = conn;

--- a/media-proxy/src/shm_memif_st30.c
+++ b/media-proxy/src/shm_memif_st30.c
@@ -9,16 +9,16 @@
 #include "mtl.h"
 #include "shm_memif.h"
 
-int rx_st30_on_connect(memif_conn_handle_t conn, void* priv_data)
+int rx_st30_on_connect(memif_conn_handle_t conn, void *priv_data)
 {
-    rx_st30_session_context_t* rx_ctx = (rx_st30_session_context_t*)priv_data;
+    rx_st30_session_context_t *rx_ctx = (rx_st30_session_context_t *)priv_data;
     int err = 0;
 
     INFO("RX memif connected!");
 
-    memif_details_t md = { 0 };
+    memif_details_t md = {0};
     ssize_t buflen = 2048;
-    char* buf = (char*)calloc(1, buflen);
+    char *buf = (char *)calloc(1, buflen);
 
     err = memif_get_details(conn, &md, buf, buflen);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -32,7 +32,7 @@ int rx_st30_on_connect(memif_conn_handle_t conn, void* priv_data)
     free(buf);
 
     /* RX buffers */
-    rx_ctx->shm_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
+    rx_ctx->shm_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
     rx_ctx->shm_buf_num = rx_ctx->fb_count;
 
     err = memif_refill_queue(conn, 0, -1, 0);
@@ -48,20 +48,20 @@ int rx_st30_on_connect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-static void tx_st30_build_frame(memif_buffer_t shm_bufs, void* frame, size_t frame_size)
+static void tx_st30_build_frame(memif_buffer_t shm_bufs, void *frame, size_t frame_size)
 {
     mtl_memcpy(frame, shm_bufs.data, frame_size);
 }
 
-int tx_st30_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int tx_st30_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int err = 0;
-    tx_st30_session_context_t* tx_ctx = (tx_st30_session_context_t*)priv_data;
-    memif_buffer_t shm_bufs = { 0 };
+    tx_st30_session_context_t *tx_ctx = (tx_st30_session_context_t *)priv_data;
+    memif_buffer_t shm_bufs = {0};
     uint16_t buf_num = 0;
 
     uint16_t producer_idx;
-    struct st_tx_frame* framebuff;
+    struct st_tx_frame *framebuff;
 
     if (tx_ctx->stop) {
         INFO("TX session already stopped.");
@@ -90,7 +90,7 @@ int tx_st30_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
         break;
     }
 
-    void* frame_addr = st30_tx_get_framebuffer(tx_ctx->handle, producer_idx);
+    void *frame_addr = st30_tx_get_framebuffer(tx_ctx->handle, producer_idx);
 
     /* fill frame data. */
     tx_st30_build_frame(shm_bufs, frame_addr, tx_ctx->st30_frame_size);
@@ -112,9 +112,9 @@ int tx_st30_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
     return 0;
 }
 
-int tx_st30_on_connect(memif_conn_handle_t conn, void* priv_data)
+int tx_st30_on_connect(memif_conn_handle_t conn, void *priv_data)
 {
-    tx_st30_session_context_t* tx_ctx = (tx_st30_session_context_t*)priv_data;
+    tx_st30_session_context_t *tx_ctx = (tx_st30_session_context_t *)priv_data;
     int err = 0;
 
     INFO("TX memif connected!");
@@ -125,9 +125,9 @@ int tx_st30_on_connect(memif_conn_handle_t conn, void* priv_data)
         return err;
     }
 
-    memif_details_t md = { 0 };
+    memif_details_t md = {0};
     ssize_t buflen = 2048;
-    char* buf = (char*)calloc(1, buflen);
+    char *buf = (char *)calloc(1, buflen);
 
     err = memif_get_details(conn, &md, buf, buflen);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -141,7 +141,7 @@ int tx_st30_on_connect(memif_conn_handle_t conn, void* priv_data)
     free(buf);
 
     /* TX buffers */
-    tx_ctx->shm_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * tx_ctx->fb_count);
+    tx_ctx->shm_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * tx_ctx->fb_count);
     tx_ctx->shm_buf_num = tx_ctx->fb_count;
 
     tx_ctx->shm_ready = 1;

--- a/media-proxy/src/shm_memif_st40.c
+++ b/media-proxy/src/shm_memif_st40.c
@@ -9,16 +9,16 @@
 #include "mtl.h"
 #include "shm_memif.h"
 
-int rx_st40_on_connect(memif_conn_handle_t conn, void* priv_data)
+int rx_st40_on_connect(memif_conn_handle_t conn, void *priv_data)
 {
-    rx_st40_session_context_t* rx_ctx = (rx_st40_session_context_t*)priv_data;
+    rx_st40_session_context_t *rx_ctx = (rx_st40_session_context_t *)priv_data;
     int err = 0;
 
     INFO("RX memif connected!");
 
-    memif_details_t md = { 0 };
+    memif_details_t md = {0};
     ssize_t buflen = 2048;
-    char* buf = (char*)calloc(1, buflen);
+    char *buf = (char *)calloc(1, buflen);
 
     err = memif_get_details(conn, &md, buf, buflen);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -32,7 +32,7 @@ int rx_st40_on_connect(memif_conn_handle_t conn, void* priv_data)
     free(buf);
 
     /* RX buffers */
-    rx_ctx->shm_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
+    rx_ctx->shm_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
     rx_ctx->shm_buf_num = rx_ctx->fb_count;
 
     err = memif_refill_queue(conn, 0, -1, 0);
@@ -48,7 +48,7 @@ int rx_st40_on_connect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-static void tx_st40_build_frame(memif_buffer_t shm_bufs, struct st40_frame* dst)
+static void tx_st40_build_frame(memif_buffer_t shm_bufs, struct st40_frame *dst)
 {
     dst->meta[0].c = 0;
     dst->meta[0].line_number = 10;
@@ -64,9 +64,9 @@ static void tx_st40_build_frame(memif_buffer_t shm_bufs, struct st40_frame* dst)
     dst->data_size = shm_bufs.len;
 }
 
-int tx_st40_on_connect(memif_conn_handle_t conn, void* priv_data)
+int tx_st40_on_connect(memif_conn_handle_t conn, void *priv_data)
 {
-    tx_st40_session_context_t* tx_ctx = (tx_st40_session_context_t*)priv_data;
+    tx_st40_session_context_t *tx_ctx = (tx_st40_session_context_t *)priv_data;
     int err = 0;
 
     INFO("TX memif connected!");
@@ -77,9 +77,9 @@ int tx_st40_on_connect(memif_conn_handle_t conn, void* priv_data)
         return err;
     }
 
-    memif_details_t md = { 0 };
+    memif_details_t md = {0};
     ssize_t buflen = 2048;
-    char* buf = (char*)calloc(1, buflen);
+    char *buf = (char *)calloc(1, buflen);
 
     err = memif_get_details(conn, &md, buf, buflen);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -99,15 +99,15 @@ int tx_st40_on_connect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-int tx_st40_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int tx_st40_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int err = 0;
-    tx_st40_session_context_t* tx_ctx = (tx_st40_session_context_t*)priv_data;
-    memif_buffer_t shm_bufs = { 0 };
+    tx_st40_session_context_t *tx_ctx = (tx_st40_session_context_t *)priv_data;
+    memif_buffer_t shm_bufs = {0};
     uint16_t buf_num = 0;
 
     uint16_t producer_idx;
-    struct st_tx_frame* framebuff;
+    struct st_tx_frame *framebuff;
 
     if (tx_ctx->stop) {
         INFO("TX session already stopped.");
@@ -136,7 +136,7 @@ int tx_st40_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
         break;
     }
 
-    struct st40_frame* frame_addr = st40_tx_get_framebuffer(tx_ctx->handle, producer_idx);
+    struct st40_frame *frame_addr = st40_tx_get_framebuffer(tx_ctx->handle, producer_idx);
     // void* mbuf;
     // void* usrptr = NULL;
     // uint16_t mbuf_len = 0;

--- a/media-proxy/src/shm_memif_udp.c
+++ b/media-proxy/src/shm_memif_udp.c
@@ -9,16 +9,16 @@
 #include "mtl.h"
 #include "shm_memif.h"
 
-int rx_udp_h264_on_connect(memif_conn_handle_t conn, void* priv_data)
+int rx_udp_h264_on_connect(memif_conn_handle_t conn, void *priv_data)
 {
-    rx_udp_h264_session_context_t* rx_ctx = (rx_udp_h264_session_context_t*)priv_data;
+    rx_udp_h264_session_context_t *rx_ctx = (rx_udp_h264_session_context_t *)priv_data;
     int err = 0;
 
     INFO("RX memif connected!");
 
-    memif_details_t md = { 0 };
+    memif_details_t md = {0};
     ssize_t buflen = 2048;
-    char* buf = (char*)calloc(1, buflen);
+    char *buf = (char *)calloc(1, buflen);
 
     err = memif_get_details(conn, &md, buf, buflen);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -32,7 +32,7 @@ int rx_udp_h264_on_connect(memif_conn_handle_t conn, void* priv_data)
     free(buf);
 
     /* rx buffers */
-    rx_ctx->shm_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
+    rx_ctx->shm_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * rx_ctx->fb_count);
     rx_ctx->shm_buf_num = rx_ctx->fb_count;
 
     err = memif_refill_queue(conn, 0, -1, 0);

--- a/media-proxy/tests/common.h
+++ b/media-proxy/tests/common.h
@@ -20,10 +20,10 @@
 /* maximum tx/rx memif buffers */
 #define MAX_MEMIF_BUFS 256
 
-#define INFO(...)                     \
-    do {                              \
-        printf("INFO: " __VA_ARGS__); \
-        printf("\n");                 \
+#define INFO(...)                                                                                  \
+    do {                                                                                           \
+        printf("INFO: " __VA_ARGS__);                                                              \
+        printf("\n");                                                                              \
     } while (0)
 
 void print_memif_details(memif_conn_handle_t conn)
@@ -34,7 +34,7 @@ void print_memif_details(memif_conn_handle_t conn)
     memif_details_t md;
     memset(&md, 0, sizeof(md));
     ssize_t buflen = 2048;
-    char* buf = (char*)malloc(buflen);
+    char *buf = (char *)malloc(buflen);
     memset(buf, 0, buflen);
     int err, e;
 
@@ -47,12 +47,12 @@ void print_memif_details(memif_conn_handle_t conn)
         }
     }
 
-    printf("\tinterface name: %s\n", (char*)md.if_name);
-    printf("\tapp name: %s\n", (char*)md.inst_name);
-    printf("\tremote interface name: %s\n", (char*)md.remote_if_name);
-    printf("\tremote app name: %s\n", (char*)md.remote_inst_name);
+    printf("\tinterface name: %s\n", (char *)md.if_name);
+    printf("\tapp name: %s\n", (char *)md.inst_name);
+    printf("\tremote interface name: %s\n", (char *)md.remote_if_name);
+    printf("\tremote app name: %s\n", (char *)md.remote_inst_name);
     printf("\tid: %u\n", md.id);
-    printf("\tsecret: %s\n", (char*)md.secret);
+    printf("\tsecret: %s\n", (char *)md.secret);
     printf("\trole: ");
     if (md.role)
         printf("slave\n");
@@ -73,7 +73,7 @@ void print_memif_details(memif_conn_handle_t conn)
         printf("unknown\n");
         break;
     }
-    printf("\tsocket path: %s\n", (char*)md.socket_path);
+    printf("\tsocket path: %s\n", (char *)md.socket_path);
     printf("\tregions num: %d\n", md.regions_num);
     for (int i = 0; i < md.regions_num; i++) {
         printf("\t\tregions idx: %d\n", md.regions[i].index);
@@ -102,15 +102,15 @@ void print_memif_details(memif_conn_handle_t conn)
     free(buf);
 }
 
-void alloc_memif_buffers(shm_connection_t* c)
+void alloc_memif_buffers(shm_connection_t *c)
 {
-    c->rx_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * MAX_MEMIF_BUFS);
+    c->rx_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * MAX_MEMIF_BUFS);
     c->rx_buf_num = 0;
-    c->tx_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * MAX_MEMIF_BUFS);
+    c->tx_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * MAX_MEMIF_BUFS);
     c->tx_buf_num = 0;
 }
 
-void free_memif_buffers(shm_connection_t* c)
+void free_memif_buffers(shm_connection_t *c)
 {
     if (c->rx_bufs != NULL)
         free(c->rx_bufs);

--- a/media-proxy/tests/memif_test_rx.c
+++ b/media-proxy/tests/memif_test_rx.c
@@ -14,8 +14,8 @@
 #define IF_ID 0
 
 typedef struct {
-    char* video_fn;
-    FILE* video_fd;
+    char *video_fn;
+    FILE *video_fd;
 
     size_t frame_idx;
     uint16_t width;
@@ -24,19 +24,19 @@ typedef struct {
     uint32_t frame_cnt;
 
     shm_connection_t memif_intf;
-    char* memif_app_name;
-    char* memif_if_name;
+    char *memif_app_name;
+    char *memif_if_name;
     uint32_t memif_if_id;
-    char* memif_socket_path;
+    char *memif_socket_path;
 } app_context_t;
 
 /* informs user about connected status. private_ctx is used by user to identify
  * connection */
-int on_connect(memif_conn_handle_t conn, void* priv_data)
+int on_connect(memif_conn_handle_t conn, void *priv_data)
 {
     int err = 0;
-    app_context_t* app_ctx = (app_context_t*)priv_data;
-    shm_connection_t* pmemif = &app_ctx->memif_intf;
+    app_context_t *app_ctx = (app_context_t *)priv_data;
+    shm_connection_t *pmemif = &app_ctx->memif_intf;
 
     INFO("RX memif connected!");
 
@@ -62,10 +62,10 @@ int on_connect(memif_conn_handle_t conn, void* priv_data)
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int on_disconnect(memif_conn_handle_t conn, void* priv_data)
+int on_disconnect(memif_conn_handle_t conn, void *priv_data)
 {
-    app_context_t* app_ctx = (app_context_t*)priv_data;
-    shm_connection_t* pmemif = &app_ctx->memif_intf;
+    app_context_t *app_ctx = (app_context_t *)priv_data;
+    shm_connection_t *pmemif = &app_ctx->memif_intf;
 
     if (pmemif->is_connected == 0)
         return 0;
@@ -90,16 +90,16 @@ int on_disconnect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-int on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int ret = 0;
     uint16_t buf_num = FRAME_COUNT;
     uint16_t rx_buf_num = 0;
-    app_context_t* app_ctx = (app_context_t*)priv_data;
-    shm_connection_t* pmemif = &app_ctx->memif_intf;
-    memif_buffer_t* rx_bufs = NULL;
+    app_context_t *app_ctx = (app_context_t *)priv_data;
+    shm_connection_t *pmemif = &app_ctx->memif_intf;
+    memif_buffer_t *rx_bufs = NULL;
     static int counter = 0;
-    FILE* fp = NULL;
+    FILE *fp = NULL;
 
     rx_bufs = pmemif->rx_bufs;
 
@@ -127,16 +127,16 @@ int on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
     return ret;
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     int ret = 0;
     int opt = 0;
-    app_context_t app_ctx = { 0 };
+    app_context_t app_ctx = {0};
 
     uint8_t is_master = 0;
-    memif_socket_args_t memif_socket_args = { 0 };
+    memif_socket_args_t memif_socket_args = {0};
     memif_socket_handle_t memif_socket;
-    memif_conn_args_t memif_conn_args = { 0 };
+    memif_conn_args_t memif_conn_args = {0};
     /* memif conenction handle */
     memif_conn_handle_t memif_conn = NULL;
     /*
@@ -175,7 +175,9 @@ int main(int argc, char** argv)
             is_master = 1;
             break;
         default: /* '?' */
-            fprintf(stderr, "Usage: %s [-a App name] [-i interface name] [-f file] [-s socket] [-m] \n", argv[0]);
+            fprintf(stderr,
+                    "Usage: %s [-a App name] [-i interface name] [-f file] [-s socket] [-m] \n",
+                    argv[0]);
             exit(EXIT_FAILURE);
         }
     }
@@ -215,15 +217,15 @@ int main(int argc, char** argv)
     memif_conn_args.buffer_size = app_ctx.frame_size;
     memif_conn_args.log2_ring_size = 2;
     strncpy(memif_conn_args.interface_name, app_ctx.memif_if_name,
-        sizeof(memif_conn_args.interface_name));
+            sizeof(memif_conn_args.interface_name));
     memif_conn_args.is_master = is_master;
 
     /* rx buffers */
     // memif_buffer_t *rx_bufs = (memif_buffer_t*)malloc(sizeof(memif_buffer_t) * FRAME_COUNT);
 
     INFO("Create memif interface.");
-    ret = memif_create(&memif_conn, &memif_conn_args,
-        on_connect, on_disconnect, on_receive, &app_ctx);
+    ret = memif_create(&memif_conn, &memif_conn_args, on_connect, on_disconnect, on_receive,
+                       &app_ctx);
     if (ret != MEMIF_ERR_SUCCESS) {
         INFO("memif_create_socket: %s", memif_strerror(ret));
         exit(-1);

--- a/media-proxy/tests/memif_test_tx.c
+++ b/media-proxy/tests/memif_test_tx.c
@@ -14,8 +14,8 @@
 #define IF_ID 0
 
 typedef struct {
-    char* video_fn;
-    FILE* video_fd;
+    char *video_fn;
+    FILE *video_fd;
 
     size_t frame_idx;
     uint16_t width;
@@ -24,13 +24,14 @@ typedef struct {
 
     bool loop_mode;
     shm_connection_t memif_intf;
-    char* memif_app_name;
-    char* memif_if_name;
+    char *memif_app_name;
+    char *memif_if_name;
     uint32_t memif_if_id;
-    char* memif_socket_path;
+    char *memif_socket_path;
 } app_context_t;
 
-int build_frames(app_context_t* p_app_ctx, memif_buffer_t* tx_bufs, uint32_t buf_size, uint16_t buf_num)
+int build_frames(app_context_t *p_app_ctx, memif_buffer_t *tx_bufs, uint32_t buf_size,
+                 uint16_t buf_num)
 {
     int ret = 0;
 
@@ -54,7 +55,7 @@ int build_frames(app_context_t* p_app_ctx, memif_buffer_t* tx_bufs, uint32_t buf
     return ret;
 }
 
-int try_send_msg(app_context_t* p_app_ctx)
+int try_send_msg(app_context_t *p_app_ctx)
 {
     int err = 0;
 
@@ -62,8 +63,8 @@ int try_send_msg(app_context_t* p_app_ctx)
     uint16_t qid = 0;
     uint32_t buf_size = p_app_ctx->frame_size;
     uint16_t tx_buf_num = 0, tx = 0;
-    memif_buffer_t* tx_bufs = NULL;
-    shm_connection_t* pmemif = &p_app_ctx->memif_intf;
+    memif_buffer_t *tx_bufs = NULL;
+    shm_connection_t *pmemif = &p_app_ctx->memif_intf;
 
     if (!pmemif->is_connected) {
         return 0;
@@ -72,8 +73,7 @@ int try_send_msg(app_context_t* p_app_ctx)
     tx_bufs = pmemif->tx_bufs;
 
     // INFO("Alloc memory for memif.");
-    err = memif_buffer_alloc(pmemif->conn, pmemif->qid, pmemif->tx_bufs, 1,
-        &tx_buf_num, buf_size);
+    err = memif_buffer_alloc(pmemif->conn, pmemif->qid, pmemif->tx_bufs, 1, &tx_buf_num, buf_size);
     if (err != MEMIF_ERR_SUCCESS) {
         if (err == MEMIF_ERR_NOBUF_RING) {
             usleep(1000); /* 1ms */
@@ -105,10 +105,10 @@ int try_send_msg(app_context_t* p_app_ctx)
 
 /* informs user about connected status. private_ctx is used by user to identify
  * connection */
-int on_connect(memif_conn_handle_t conn, void* priv_data)
+int on_connect(memif_conn_handle_t conn, void *priv_data)
 {
     int err = 0;
-    shm_connection_t* pmemif = (shm_connection_t*)priv_data;
+    shm_connection_t *pmemif = (shm_connection_t *)priv_data;
 
     INFO("TX memif connected!");
 
@@ -129,11 +129,11 @@ int on_connect(memif_conn_handle_t conn, void* priv_data)
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int on_disconnect(memif_conn_handle_t conn, void* priv_data)
+int on_disconnect(memif_conn_handle_t conn, void *priv_data)
 {
     INFO("TX memif disconnected!");
 
-    shm_connection_t* pmemif = (shm_connection_t*)priv_data;
+    shm_connection_t *pmemif = (shm_connection_t *)priv_data;
 
     pmemif->is_connected = 0;
 
@@ -149,12 +149,12 @@ int on_disconnect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-int on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int err = 0;
     uint16_t rx_buf_num = 0;
-    shm_connection_t* pmemif = (shm_connection_t*)priv_data;
-    memif_buffer_t* rx_bufs = NULL;
+    shm_connection_t *pmemif = (shm_connection_t *)priv_data;
+    memif_buffer_t *rx_bufs = NULL;
 
     INFO("TX on receive.");
 
@@ -174,10 +174,10 @@ int on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
     return 0;
 }
 
-void* send_msg_thread(void* arg)
+void *send_msg_thread(void *arg)
 {
     int ret = 0;
-    app_context_t* p_app_ctx = (app_context_t*)arg;
+    app_context_t *p_app_ctx = (app_context_t *)arg;
 
     p_app_ctx->video_fd = fopen(p_app_ctx->video_fn, "rb");
     if (p_app_ctx->video_fd == NULL) {
@@ -196,17 +196,17 @@ void* send_msg_thread(void* arg)
     return NULL;
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     int ret = 0;
     int opt = 0;
     pthread_t frame_thread;
-    app_context_t app_ctx = { 0 };
+    app_context_t app_ctx = {0};
 
     uint8_t is_master = 0;
-    memif_socket_args_t memif_socket_args = { 0 };
+    memif_socket_args_t memif_socket_args = {0};
     memif_socket_handle_t memif_socket;
-    memif_conn_args_t memif_conn_args = { 0 };
+    memif_conn_args_t memif_conn_args = {0};
 
     app_ctx.loop_mode = false;
     app_ctx.video_fn = "./test.yuv";
@@ -247,7 +247,10 @@ int main(int argc, char** argv)
             app_ctx.loop_mode = true;
             break;
         default: /* '?' */
-            fprintf(stderr, "Usage: %s [-w width] [-h height] [-n app_name] [-i interface_name] [-d interface_id] [-f file] [-s socket] [-m] [-l] \n", argv[0]);
+            fprintf(stderr,
+                    "Usage: %s [-w width] [-h height] [-n app_name] [-i interface_name] [-d "
+                    "interface_id] [-f file] [-s socket] [-m] [-l] \n",
+                    argv[0]);
             exit(EXIT_FAILURE);
         }
     }
@@ -285,13 +288,13 @@ int main(int argc, char** argv)
     memif_conn_args.buffer_size = app_ctx.frame_size;
     memif_conn_args.log2_ring_size = 2;
     strncpy(memif_conn_args.interface_name, app_ctx.memif_if_name,
-        sizeof(memif_conn_args.interface_name));
+            sizeof(memif_conn_args.interface_name));
     memif_conn_args.interface_id = app_ctx.memif_if_id;
     memif_conn_args.is_master = is_master;
 
     INFO("Create memif interface.");
-    ret = memif_create(&app_ctx.memif_intf.conn, &memif_conn_args,
-        on_connect, on_disconnect, on_receive, &app_ctx.memif_intf);
+    ret = memif_create(&app_ctx.memif_intf.conn, &memif_conn_args, on_connect, on_disconnect,
+                       on_receive, &app_ctx.memif_intf);
     if (ret != MEMIF_ERR_SUCCESS) {
         INFO("memif_create: %s", memif_strerror(ret));
         exit(-1);

--- a/sdk/3rdparty/libmemif/examples/common/common.c
+++ b/sdk/3rdparty/libmemif/examples/common/common.c
@@ -1,161 +1,144 @@
 #include <common.h>
 
-void
-print_memif_ring_details (memif_connection_t *c, uint16_t qid, uint8_t is_rx)
+void print_memif_ring_details(memif_connection_t *c, uint16_t qid, uint8_t is_rx)
 {
-  /* TODO: print memif shared memory details */
+    /* TODO: print memif shared memory details */
 }
 
-void
-print_memif_rx_ring_details (memif_connection_t *c, uint16_t qid)
+void print_memif_rx_ring_details(memif_connection_t *c, uint16_t qid)
 {
-  print_memif_ring_details (c, qid, /* RX */ 1);
+    print_memif_ring_details(c, qid, /* RX */ 1);
 }
 
-void
-print_memif_tx_ring_details (memif_connection_t *c, uint16_t qid)
+void print_memif_tx_ring_details(memif_connection_t *c, uint16_t qid)
 {
-  print_memif_ring_details (c, qid, /* TX */ 0);
+    print_memif_ring_details(c, qid, /* TX */ 0);
 }
 
-void
-print_version ()
+void print_version()
 {
-  printf ("libmemif version: %s, memif version: %s\n", LIBMEMIF_VERSION,
-	  memif_get_version_str ());
+    printf("libmemif version: %s, memif version: %s\n", LIBMEMIF_VERSION, memif_get_version_str());
 }
 
-int
-parse_ip4 (const char *input, uint8_t out[4])
+int parse_ip4(const char *input, uint8_t out[4])
 {
-  int i = 0;
-  char *ui, *end;
-  char *tmp = strdup (input);
+    int i = 0;
+    char *ui, *end;
+    char *tmp = strdup(input);
 
-  ui = strtok (tmp, ".");
-  while (ui != NULL && i < 4) {
-    out[i++] = strtol (ui, &end, 10);
-    ui = strtok (NULL, ".");
-  }
-
-  free (tmp);
-
-  return (i==4) ? 0 : -1;
-}
-
-int
-parse_mac (const char *input, uint8_t out[6])
-{
-  int i = 0;
-  char *ui, *end;
-  char *tmp = strdup (input);
-
-  ui = strtok (tmp, ":");
-  while (ui != NULL && i < 6) {
-    out[i++] = strtol (ui, &end, 16);
-    ui = strtok (NULL, ":");
-  }
-
-  free (tmp);
-
-  return (i==6) ? 0 : -1;
-}
-
-void
-alloc_memif_buffers (memif_connection_t *c)
-{
-  c->rx_bufs =
-    (memif_buffer_t *) malloc (sizeof (memif_buffer_t) * MAX_MEMIF_BUFS);
-  c->rx_buf_num = 0;
-  c->tx_bufs =
-    (memif_buffer_t *) malloc (sizeof (memif_buffer_t) * MAX_MEMIF_BUFS);
-  c->tx_buf_num = 0;
-}
-
-void
-free_memif_buffers (memif_connection_t *c)
-{
-  if (c->rx_bufs != NULL)
-    free (c->rx_bufs);
-  c->rx_bufs = NULL;
-  c->rx_buf_num = 0;
-  if (c->tx_bufs != NULL)
-    free (c->tx_bufs);
-  c->tx_bufs = NULL;
-  c->tx_buf_num = 0;
-}
-
-void
-print_memif_details (memif_connection_t *c)
-{
-  printf ("MEMIF DETAILS\n");
-  printf ("==============================\n");
-
-  memif_details_t md;
-  memset (&md, 0, sizeof (md));
-  ssize_t buflen = 2048;
-  char *buf = (char *) malloc (buflen);
-  memset (buf, 0, buflen);
-  int err, e;
-
-  err = memif_get_details (c->conn, &md, buf, buflen);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("%s", memif_strerror (err));
-      if (err == MEMIF_ERR_NOCONN)
-	{
-	  free (buf);
-	  return;
-	}
+    ui = strtok(tmp, ".");
+    while (ui != NULL && i < 4) {
+        out[i++] = strtol(ui, &end, 10);
+        ui = strtok(NULL, ".");
     }
 
-  printf ("\tinterface name: %s\n", (char *) md.if_name);
-  printf ("\tapp name: %s\n", (char *) md.inst_name);
-  printf ("\tremote interface name: %s\n", (char *) md.remote_if_name);
-  printf ("\tremote app name: %s\n", (char *) md.remote_inst_name);
-  printf ("\tid: %u\n", md.id);
-  printf ("\tsecret: %s\n", (char *) md.secret);
-  printf ("\trole: ");
-  if (md.role)
-    printf ("slave\n");
-  else
-    printf ("master\n");
-  printf ("\tmode: ");
-  switch (md.mode)
-    {
+    free(tmp);
+
+    return (i == 4) ? 0 : -1;
+}
+
+int parse_mac(const char *input, uint8_t out[6])
+{
+    int i = 0;
+    char *ui, *end;
+    char *tmp = strdup(input);
+
+    ui = strtok(tmp, ":");
+    while (ui != NULL && i < 6) {
+        out[i++] = strtol(ui, &end, 16);
+        ui = strtok(NULL, ":");
+    }
+
+    free(tmp);
+
+    return (i == 6) ? 0 : -1;
+}
+
+void alloc_memif_buffers(memif_connection_t *c)
+{
+    c->rx_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * MAX_MEMIF_BUFS);
+    c->rx_buf_num = 0;
+    c->tx_bufs = (memif_buffer_t *)malloc(sizeof(memif_buffer_t) * MAX_MEMIF_BUFS);
+    c->tx_buf_num = 0;
+}
+
+void free_memif_buffers(memif_connection_t *c)
+{
+    if (c->rx_bufs != NULL)
+        free(c->rx_bufs);
+    c->rx_bufs = NULL;
+    c->rx_buf_num = 0;
+    if (c->tx_bufs != NULL)
+        free(c->tx_bufs);
+    c->tx_bufs = NULL;
+    c->tx_buf_num = 0;
+}
+
+void print_memif_details(memif_connection_t *c)
+{
+    printf("MEMIF DETAILS\n");
+    printf("==============================\n");
+
+    memif_details_t md;
+    memset(&md, 0, sizeof(md));
+    ssize_t buflen = 2048;
+    char *buf = (char *)malloc(buflen);
+    memset(buf, 0, buflen);
+    int err, e;
+
+    err = memif_get_details(c->conn, &md, buf, buflen);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("%s", memif_strerror(err));
+        if (err == MEMIF_ERR_NOCONN) {
+            free(buf);
+            return;
+        }
+    }
+
+    printf("\tinterface name: %s\n", (char *)md.if_name);
+    printf("\tapp name: %s\n", (char *)md.inst_name);
+    printf("\tremote interface name: %s\n", (char *)md.remote_if_name);
+    printf("\tremote app name: %s\n", (char *)md.remote_inst_name);
+    printf("\tid: %u\n", md.id);
+    printf("\tsecret: %s\n", (char *)md.secret);
+    printf("\trole: ");
+    if (md.role)
+        printf("slave\n");
+    else
+        printf("master\n");
+    printf("\tmode: ");
+    switch (md.mode) {
     case 0:
-      printf ("ethernet\n");
-      break;
+        printf("ethernet\n");
+        break;
     case 1:
-      printf ("ip\n");
-      break;
+        printf("ip\n");
+        break;
     case 2:
-      printf ("punt/inject\n");
-      break;
+        printf("punt/inject\n");
+        break;
     default:
-      printf ("unknown\n");
-      break;
+        printf("unknown\n");
+        break;
     }
-  printf ("\tsocket path: %s\n", (char *) md.socket_path);
-  printf ("\trx queues:\n");
-  for (e = 0; e < md.rx_queues_num; e++)
-    {
-      printf ("\t\tqueue id: %u\n", md.rx_queues[e].qid);
-      printf ("\t\tring size: %u\n", md.rx_queues[e].ring_size);
-      printf ("\t\tbuffer size: %u\n", md.rx_queues[e].buffer_size);
+    printf("\tsocket path: %s\n", (char *)md.socket_path);
+    printf("\trx queues:\n");
+    for (e = 0; e < md.rx_queues_num; e++) {
+        printf("\t\tqueue id: %u\n", md.rx_queues[e].qid);
+        printf("\t\tring size: %u\n", md.rx_queues[e].ring_size);
+        printf("\t\tbuffer size: %u\n", md.rx_queues[e].buffer_size);
     }
-  printf ("\ttx queues:\n");
-  for (e = 0; e < md.tx_queues_num; e++)
-    {
-      printf ("\t\tqueue id: %u\n", md.tx_queues[e].qid);
-      printf ("\t\tring size: %u\n", md.tx_queues[e].ring_size);
-      printf ("\t\tbuffer size: %u\n", md.tx_queues[e].buffer_size);
+    printf("\ttx queues:\n");
+    for (e = 0; e < md.tx_queues_num; e++) {
+        printf("\t\tqueue id: %u\n", md.tx_queues[e].qid);
+        printf("\t\tring size: %u\n", md.tx_queues[e].ring_size);
+        printf("\t\tbuffer size: %u\n", md.tx_queues[e].buffer_size);
     }
-  printf ("\tlink: ");
-  if (md.link_up_down)
-    printf ("up\n");
-  else
-    printf ("down\n");
+    printf("\tlink: ");
+    if (md.link_up_down)
+        printf("up\n");
+    else
+        printf("down\n");
 
-  free (buf);
+    free(buf);
 }

--- a/sdk/3rdparty/libmemif/examples/common/common.h
+++ b/sdk/3rdparty/libmemif/examples/common/common.h
@@ -25,96 +25,88 @@
 #include <sys/types.h>
 
 #ifdef ICMP_DBG
-#define DBG(...)                                                              \
-  do                                                                          \
-    {                                                                         \
-      printf (APP_NAME ":%s:%d: ", __func__, __LINE__);                       \
-      printf (__VA_ARGS__);                                                   \
-      printf ("\n");                                                          \
-    }                                                                         \
-  while (0)
+#define DBG(...)                                                                                   \
+    do {                                                                                           \
+        printf(APP_NAME ":%s:%d: ", __func__, __LINE__);                                           \
+        printf(__VA_ARGS__);                                                                       \
+        printf("\n");                                                                              \
+    } while (0)
 #else
 #define DBG(...)
 #endif
 
-#define INFO(...)                                                             \
-  do                                                                          \
-    {                                                                         \
-      printf ("INFO: " __VA_ARGS__);                                          \
-      printf ("\n");                                                          \
-    }                                                                         \
-  while (0)
+#define INFO(...)                                                                                  \
+    do {                                                                                           \
+        printf("INFO: " __VA_ARGS__);                                                              \
+        printf("\n");                                                                              \
+    } while (0)
 
 /* maximum tx/rx memif buffers */
 #define MAX_MEMIF_BUFS 1024
 
 struct memif_connection;
 
-typedef int (memif_packet_handler_t) (struct memif_connection *conn);
+typedef int(memif_packet_handler_t)(struct memif_connection *conn);
 
-typedef int (packet_generator_t) (struct memif_connection *c,
-				  uint16_t num_pkts);
+typedef int(packet_generator_t)(struct memif_connection *c, uint16_t num_pkts);
 
-typedef struct memif_connection
-{
-  uint16_t index;
-  /* memif conenction handle */
-  memif_conn_handle_t conn;
-  uint8_t is_connected;
-  /* transmit queue id */
-  uint16_t tx_qid;
-  /* tx buffers */
-  memif_buffer_t *tx_bufs;
-  /* allocated tx buffers counter */
-  /* number of tx buffers pointing to shared memory */
-  uint16_t tx_buf_num;
-  /* rx buffers */
-  memif_buffer_t *rx_bufs;
-  /* allcoated rx buffers counter */
-  /* number of rx buffers pointing to shared memory */
-  uint16_t rx_buf_num;
-  memif_packet_handler_t *packet_handler;
-  /* interface ip address */
-  uint8_t ip_addr[4];
-  /* interface hw address */
-  uint8_t hw_addr[6];
-  /* buffer size */
-  uint16_t buffer_size;
-  /* headroom size */
-  uint16_t headroom_size;
+typedef struct memif_connection {
+    uint16_t index;
+    /* memif conenction handle */
+    memif_conn_handle_t conn;
+    uint8_t is_connected;
+    /* transmit queue id */
+    uint16_t tx_qid;
+    /* tx buffers */
+    memif_buffer_t *tx_bufs;
+    /* allocated tx buffers counter */
+    /* number of tx buffers pointing to shared memory */
+    uint16_t tx_buf_num;
+    /* rx buffers */
+    memif_buffer_t *rx_bufs;
+    /* allcoated rx buffers counter */
+    /* number of rx buffers pointing to shared memory */
+    uint16_t rx_buf_num;
+    memif_packet_handler_t *packet_handler;
+    /* interface ip address */
+    uint8_t ip_addr[4];
+    /* interface hw address */
+    uint8_t hw_addr[6];
+    /* buffer size */
+    uint16_t buffer_size;
+    /* headroom size */
+    uint16_t headroom_size;
 } memif_connection_t;
 
-void print_version ();
+void print_version();
 
-int parse_ip4 (const char *input, uint8_t out[4]);
+int parse_ip4(const char *input, uint8_t out[4]);
 
-int parse_mac (const char *input, uint8_t out[6]);
+int parse_mac(const char *input, uint8_t out[6]);
 
-void alloc_memif_buffers (memif_connection_t *c);
+void alloc_memif_buffers(memif_connection_t *c);
 
-void free_memif_buffers (memif_connection_t *c);
+void free_memif_buffers(memif_connection_t *c);
 
-void print_memif_details (memif_connection_t *c);
+void print_memif_details(memif_connection_t *c);
 
-void print_memif_rx_ring_details (memif_connection_t *c, uint16_t qid);
+void print_memif_rx_ring_details(memif_connection_t *c, uint16_t qid);
 
-void print_memif_tx_ring_details (memif_connection_t *c, uint16_t qid);
+void print_memif_tx_ring_details(memif_connection_t *c, uint16_t qid);
 
-int send_packets (memif_connection_t *conn, uint16_t qid,
-		  packet_generator_t *gen, uint32_t num_pkts,
-		  uint16_t max_pkt_size);
-
-/* Expect packets smaller than 2048b */
-int responder (memif_conn_handle_t conn, void *private_ctx, uint16_t qid);
+int send_packets(memif_connection_t *conn, uint16_t qid, packet_generator_t *gen, uint32_t num_pkts,
+                 uint16_t max_pkt_size);
 
 /* Expect packets smaller than 2048b */
-int responder_zero_copy (memif_conn_handle_t conn, void *private_ctx,
-			 uint16_t qid);
+int responder(memif_conn_handle_t conn, void *private_ctx, uint16_t qid);
+
+/* Expect packets smaller than 2048b */
+int responder_zero_copy(memif_conn_handle_t conn, void *private_ctx, uint16_t qid);
 
 /* reply with the same data */
-int basic_packet_handler (memif_connection_t *conn);
+int basic_packet_handler(memif_connection_t *conn);
 
 /* ICMPv4 and ARP handler */
-int icmp_packet_handler (memif_connection_t *conn);
+int icmp_packet_handler(memif_connection_t *conn);
 
 #endif /* COMMON_H */

--- a/sdk/3rdparty/libmemif/examples/common/icmp_proto.c
+++ b/sdk/3rdparty/libmemif/examples/common/icmp_proto.c
@@ -41,435 +41,399 @@
 
 #include <icmp_proto.h>
 
-static uint16_t
-cksum (void *addr, ssize_t len)
+static uint16_t cksum(void *addr, ssize_t len)
 {
-  char *data = (char *) addr;
+    char *data = (char *)addr;
 
-  uint32_t acc = 0xffff;
+    uint32_t acc = 0xffff;
 
-  ssize_t i;
-  for (i = 0; (i + 1) < len; i += 2)
-    {
-      uint16_t word;
-      memcpy (&word, data + i, 2);
-      acc += ntohs (word);
-      if (acc > 0xffff)
-	acc -= 0xffff;
+    ssize_t i;
+    for (i = 0; (i + 1) < len; i += 2) {
+        uint16_t word;
+        memcpy(&word, data + i, 2);
+        acc += ntohs(word);
+        if (acc > 0xffff)
+            acc -= 0xffff;
     }
 
-  if (len & 1)
-    {
-      uint16_t word = 0;
-      memcpy (&word, data + len - 1, 1);
-      acc += ntohs (word);
-      if (acc > 0xffff)
-	acc -= 0xffff;
+    if (len & 1) {
+        uint16_t word = 0;
+        memcpy(&word, data + len - 1, 1);
+        acc += ntohs(word);
+        if (acc > 0xffff)
+            acc -= 0xffff;
     }
-  return htons (~acc);
+    return htons(~acc);
 }
 
-int
-print_packet (void *pck)
+int print_packet(void *pck)
 {
-  if (pck == NULL)
-    {
-      printf ("ICMP_PROTO: no data\n");
-      return -1;
+    if (pck == NULL) {
+        printf("ICMP_PROTO: no data\n");
+        return -1;
     }
-  struct iphdr *ip;
-  struct icmphdr *icmp;
-  ip = (struct iphdr *) pck;
-  icmp = (struct icmphdr *) (pck + sizeof (struct iphdr));
-  printf ("received packet:\n");
-  printf ("\tiphdr:\n");
-  printf ("\t\tihl: %u\n\t\tversion: %u\n\t\tlen: %u\n\t\tid: %u\n", ip->ihl,
-	  ip->version, __bswap_16 (ip->tot_len), ip->id);
-  printf ("\t\tprotocol: %u\n", ip->protocol);
+    struct iphdr *ip;
+    struct icmphdr *icmp;
+    ip = (struct iphdr *)pck;
+    icmp = (struct icmphdr *)(pck + sizeof(struct iphdr));
+    printf("received packet:\n");
+    printf("\tiphdr:\n");
+    printf("\t\tihl: %u\n\t\tversion: %u\n\t\tlen: %u\n\t\tid: %u\n", ip->ihl, ip->version,
+           __bswap_16(ip->tot_len), ip->id);
+    printf("\t\tprotocol: %u\n", ip->protocol);
 
-  printf ("\t\tsaddr: ");
-  int i;
-  for (i = 0; i < 4; i++)
-    {
-      printf ("%u.", ((uint8_t *) &ip->saddr)[i]);
+    printf("\t\tsaddr: ");
+    int i;
+    for (i = 0; i < 4; i++) {
+        printf("%u.", ((uint8_t *)&ip->saddr)[i]);
     }
-  printf ("\n");
+    printf("\n");
 
-  printf ("\t\tdaddr: ");
-  for (i = 0; i < 4; i++)
-    {
-      printf ("%u.", ((uint8_t *) &ip->daddr)[i]);
+    printf("\t\tdaddr: ");
+    for (i = 0; i < 4; i++) {
+        printf("%u.", ((uint8_t *)&ip->daddr)[i]);
     }
-  printf ("\n");
-  printf ("\ticmphdr:\n");
-  printf ("\t\ttype: %s\n",
-	  (icmp->type == ICMP_ECHO) ? "ICMP_ECHO" : "ICMP_ECHOREPLY");
+    printf("\n");
+    printf("\ticmphdr:\n");
+    printf("\t\ttype: %s\n", (icmp->type == ICMP_ECHO) ? "ICMP_ECHO" : "ICMP_ECHOREPLY");
 
-  return 0;
-}
-
-static ssize_t
-resolve_arp (void *arp)
-{
-  struct arphdr *resp = (struct arphdr *) arp;
-
-  resp->ar_hrd = __bswap_16 (ARPHRD_ETHER);
-
-  resp->ar_pro = __bswap_16 (0x0800);
-
-  resp->ar_hln = 6;
-  resp->ar_pln = 4;
-
-  resp->ar_op = __bswap_16 (ARPOP_REPLY);
-
-  return sizeof (struct arphdr);
-}
-
-static ssize_t
-resolve_eth_arp (struct ether_arp *eth_arp, void *eth_arp_resp,
-		 uint8_t ip_addr[4])
-{
-  struct ether_arp *resp = (struct ether_arp *) eth_arp_resp;
-
-  resolve_arp (&resp->ea_hdr);
-
-  memcpy (resp->arp_tha, eth_arp->arp_sha, 6);
-  memcpy (resp->arp_tpa, eth_arp->arp_spa, 4);
-
-  memcpy (
-    resp->arp_sha,
-    (((struct ether_header *) (eth_arp_resp - sizeof (struct ether_header)))
-       ->ether_shost),
-    6);
-
-  memcpy (resp->arp_spa, ip_addr, 4);
-
-  return sizeof (struct ether_arp);
-}
-
-static ssize_t
-resolve_eth (struct ether_header *eth, void *eth_resp, uint8_t hw_addr[6])
-{
-  struct ether_header *resp = (struct ether_header *) eth_resp;
-  memcpy (resp->ether_dhost, eth->ether_shost, 6);
-
-  memcpy (resp->ether_shost, hw_addr, 6);
-
-  resp->ether_type = eth->ether_type;
-
-  return sizeof (struct ether_header);
-}
-
-static ssize_t
-resolve_ip (struct iphdr *ip, void *ip_resp, uint8_t ip_addr[4])
-{
-  struct iphdr *resp = (struct iphdr *) ip_resp;
-  resp->ihl = 5;
-  resp->version = 4;
-  resp->tos = 0;
-  /*len updated later */
-  resp->tot_len = 0x0000;
-  resp->id = 0;
-  resp->frag_off = 0;
-  resp->ttl = 0x40;
-  resp->protocol = 1;
-  ((uint8_t *) &resp->saddr)[0] = ip_addr[0];
-  ((uint8_t *) &resp->saddr)[1] = ip_addr[1];
-  ((uint8_t *) &resp->saddr)[2] = ip_addr[2];
-  ((uint8_t *) &resp->saddr)[3] = ip_addr[3];
-  resp->daddr = ip->saddr;
-
-  /* resp->check =  cksum (resp, sizeof (struct iphdr)); */
-
-  return sizeof (struct iphdr);
-}
-
-static ssize_t
-resolve_icmp (struct icmphdr *icmp, void *icmp_resp)
-{
-  struct icmphdr *resp = (struct icmphdr *) icmp_resp;
-  resp->type = 0x00;
-  resp->code = 0;
-  resp->un.echo.id = icmp->un.echo.id;
-  resp->un.echo.sequence = icmp->un.echo.sequence;
-
-  /*resp->checksum = cksum (resp, sizeof (struct icmphdr)); */
-
-  return sizeof (struct icmphdr);
-}
-
-static ssize_t
-generate_eth (struct ether_header *eh, uint8_t hw_daddr[6])
-{
-  uint8_t hw_addr[6];
-  int i;
-  for (i = 0; i < 6; i++)
-    {
-      hw_addr[i] = 'a';
-    }
-  memcpy (eh->ether_shost, hw_addr, 6);
-  memcpy (eh->ether_dhost, hw_daddr, 6);
-
-  eh->ether_type = 0x0008;
-
-  return sizeof (struct ether_header);
-}
-
-static ssize_t
-generate_ip (struct iphdr *ip, uint8_t saddr[4], uint8_t daddr[4])
-{
-  ip->ihl = 5;
-  ip->version = 4;
-  ip->tos = 0;
-  /*len updated later */
-  ip->tot_len = 0x5400;
-  ip->id = 0;
-  ip->frag_off = 0;
-  ip->ttl = 0x40;
-  ip->protocol = 1;
-  /* saddr */
-  ((uint8_t *) &ip->saddr)[0] = saddr[0];
-  ((uint8_t *) &ip->saddr)[1] = saddr[1];
-  ((uint8_t *) &ip->saddr)[2] = saddr[2];
-  ((uint8_t *) &ip->saddr)[3] = saddr[3];
-  /* daddr */
-  ((uint8_t *) &ip->daddr)[0] = daddr[0];
-  ((uint8_t *) &ip->daddr)[1] = daddr[1];
-  ((uint8_t *) &ip->daddr)[2] = daddr[2];
-  ((uint8_t *) &ip->daddr)[3] = daddr[3];
-
-  ip->check = cksum (ip, sizeof (struct iphdr));
-
-  return sizeof (struct iphdr);
-}
-
-static ssize_t
-generate_icmp (struct icmphdr *icmp, uint32_t seq)
-{
-  icmp->type = ICMP_ECHO;
-  icmp->code = 0;
-  icmp->un.echo.id = 0;
-  icmp->un.echo.sequence = seq;
-
-  return sizeof (struct icmphdr);
-}
-
-int
-generate_packet (void *pck, uint32_t *size, uint8_t saddr[4], uint8_t daddr[4],
-		 uint8_t hw_daddr[6], uint32_t seq)
-{
-  struct ether_header *eh;
-  struct iphdr *ip;
-  struct icmphdr *icmp;
-
-  *size = 0;
-
-  eh = (struct ether_header *) pck;
-  *size += generate_eth (eh, hw_daddr);
-
-  ip = (struct iphdr *) (pck + *size);
-  *size += generate_ip (ip, saddr, daddr);
-
-  icmp = (struct icmphdr *) (pck + *size);
-  *size += generate_icmp (icmp, seq);
-
-  ((struct icmphdr *) (pck + *size - sizeof (struct icmphdr)))->checksum =
-    cksum (pck + *size - sizeof (struct icmphdr), sizeof (struct icmphdr));
-
-  ip->tot_len = __bswap_16 (*size - sizeof (struct ether_header));
-  ip->check = 0;
-  ip->check = cksum (ip, sizeof (struct iphdr));
-
-  return 0;
-}
-
-int
-generate_packet2 (void *pck, uint32_t *size, uint8_t saddr[4],
-		  uint8_t daddr[4], uint8_t hw_daddr[6], uint32_t seq,
-		  icmpr_flow_mode_t mode)
-{
-  struct ether_header *eh;
-  struct iphdr *ip;
-  struct icmphdr *icmp;
-
-  *size = 0;
-
-  if (mode == ICMPR_FLOW_MODE_ETH)
-    {
-      eh = (struct ether_header *) pck;
-      *size += generate_eth (eh, hw_daddr);
-    }
-
-  ip = (struct iphdr *) (pck + *size);
-  *size += generate_ip (ip, saddr, daddr);
-
-  icmp = (struct icmphdr *) (pck + *size);
-  *size += generate_icmp (icmp, seq);
-
-  ((struct icmphdr *) (pck + *size - sizeof (struct icmphdr)))->checksum =
-    cksum (pck + *size - sizeof (struct icmphdr), sizeof (struct icmphdr));
-
-  ip->tot_len = __bswap_16 (*size - sizeof (struct ether_header));
-  ip->check = 0;
-  ip->check = cksum (ip, sizeof (struct iphdr));
-
-  return 0;
-}
-
-#define GET_HEADER(out, hdr, src, off)                                        \
-  do                                                                          \
-    {                                                                         \
-      out = (hdr *) (src + off);                                              \
-      off += sizeof (hdr);                                                    \
-    }                                                                         \
-  while (0)
-
-int
-resolve_packet (void *pck, uint32_t *size, uint8_t ip_addr[4],
-		uint8_t hw_addr[6])
-{
-  struct ether_header *eh;
-  struct ether_arp *eah;
-  struct iphdr *ip;
-  struct icmphdr *icmp;
-  uint32_t offset = 0;
-
-  if (pck == NULL)
     return 0;
+}
+
+static ssize_t resolve_arp(void *arp)
+{
+    struct arphdr *resp = (struct arphdr *)arp;
+
+    resp->ar_hrd = __bswap_16(ARPHRD_ETHER);
+
+    resp->ar_pro = __bswap_16(0x0800);
+
+    resp->ar_hln = 6;
+    resp->ar_pln = 4;
+
+    resp->ar_op = __bswap_16(ARPOP_REPLY);
+
+    return sizeof(struct arphdr);
+}
+
+static ssize_t resolve_eth_arp(struct ether_arp *eth_arp, void *eth_arp_resp, uint8_t ip_addr[4])
+{
+    struct ether_arp *resp = (struct ether_arp *)eth_arp_resp;
+
+    resolve_arp(&resp->ea_hdr);
+
+    memcpy(resp->arp_tha, eth_arp->arp_sha, 6);
+    memcpy(resp->arp_tpa, eth_arp->arp_spa, 4);
+
+    memcpy(resp->arp_sha,
+           (((struct ether_header *)(eth_arp_resp - sizeof(struct ether_header)))->ether_shost), 6);
+
+    memcpy(resp->arp_spa, ip_addr, 4);
+
+    return sizeof(struct ether_arp);
+}
+
+static ssize_t resolve_eth(struct ether_header *eth, void *eth_resp, uint8_t hw_addr[6])
+{
+    struct ether_header *resp = (struct ether_header *)eth_resp;
+    memcpy(resp->ether_dhost, eth->ether_shost, 6);
+
+    memcpy(resp->ether_shost, hw_addr, 6);
+
+    resp->ether_type = eth->ether_type;
+
+    return sizeof(struct ether_header);
+}
+
+static ssize_t resolve_ip(struct iphdr *ip, void *ip_resp, uint8_t ip_addr[4])
+{
+    struct iphdr *resp = (struct iphdr *)ip_resp;
+    resp->ihl = 5;
+    resp->version = 4;
+    resp->tos = 0;
+    /*len updated later */
+    resp->tot_len = 0x0000;
+    resp->id = 0;
+    resp->frag_off = 0;
+    resp->ttl = 0x40;
+    resp->protocol = 1;
+    ((uint8_t *)&resp->saddr)[0] = ip_addr[0];
+    ((uint8_t *)&resp->saddr)[1] = ip_addr[1];
+    ((uint8_t *)&resp->saddr)[2] = ip_addr[2];
+    ((uint8_t *)&resp->saddr)[3] = ip_addr[3];
+    resp->daddr = ip->saddr;
+
+    /* resp->check =  cksum (resp, sizeof (struct iphdr)); */
+
+    return sizeof(struct iphdr);
+}
+
+static ssize_t resolve_icmp(struct icmphdr *icmp, void *icmp_resp)
+{
+    struct icmphdr *resp = (struct icmphdr *)icmp_resp;
+    resp->type = 0x00;
+    resp->code = 0;
+    resp->un.echo.id = icmp->un.echo.id;
+    resp->un.echo.sequence = icmp->un.echo.sequence;
+
+    /*resp->checksum = cksum (resp, sizeof (struct icmphdr)); */
+
+    return sizeof(struct icmphdr);
+}
+
+static ssize_t generate_eth(struct ether_header *eh, uint8_t hw_daddr[6])
+{
+    uint8_t hw_addr[6];
+    int i;
+    for (i = 0; i < 6; i++) {
+        hw_addr[i] = 'a';
+    }
+    memcpy(eh->ether_shost, hw_addr, 6);
+    memcpy(eh->ether_dhost, hw_daddr, 6);
+
+    eh->ether_type = 0x0008;
+
+    return sizeof(struct ether_header);
+}
+
+static ssize_t generate_ip(struct iphdr *ip, uint8_t saddr[4], uint8_t daddr[4])
+{
+    ip->ihl = 5;
+    ip->version = 4;
+    ip->tos = 0;
+    /*len updated later */
+    ip->tot_len = 0x5400;
+    ip->id = 0;
+    ip->frag_off = 0;
+    ip->ttl = 0x40;
+    ip->protocol = 1;
+    /* saddr */
+    ((uint8_t *)&ip->saddr)[0] = saddr[0];
+    ((uint8_t *)&ip->saddr)[1] = saddr[1];
+    ((uint8_t *)&ip->saddr)[2] = saddr[2];
+    ((uint8_t *)&ip->saddr)[3] = saddr[3];
+    /* daddr */
+    ((uint8_t *)&ip->daddr)[0] = daddr[0];
+    ((uint8_t *)&ip->daddr)[1] = daddr[1];
+    ((uint8_t *)&ip->daddr)[2] = daddr[2];
+    ((uint8_t *)&ip->daddr)[3] = daddr[3];
+
+    ip->check = cksum(ip, sizeof(struct iphdr));
+
+    return sizeof(struct iphdr);
+}
+
+static ssize_t generate_icmp(struct icmphdr *icmp, uint32_t seq)
+{
+    icmp->type = ICMP_ECHO;
+    icmp->code = 0;
+    icmp->un.echo.id = 0;
+    icmp->un.echo.sequence = seq;
+
+    return sizeof(struct icmphdr);
+}
+
+int generate_packet(void *pck, uint32_t *size, uint8_t saddr[4], uint8_t daddr[4],
+                    uint8_t hw_daddr[6], uint32_t seq)
+{
+    struct ether_header *eh;
+    struct iphdr *ip;
+    struct icmphdr *icmp;
+
+    *size = 0;
+
+    eh = (struct ether_header *)pck;
+    *size += generate_eth(eh, hw_daddr);
+
+    ip = (struct iphdr *)(pck + *size);
+    *size += generate_ip(ip, saddr, daddr);
+
+    icmp = (struct icmphdr *)(pck + *size);
+    *size += generate_icmp(icmp, seq);
+
+    ((struct icmphdr *)(pck + *size - sizeof(struct icmphdr)))->checksum =
+        cksum(pck + *size - sizeof(struct icmphdr), sizeof(struct icmphdr));
+
+    ip->tot_len = __bswap_16(*size - sizeof(struct ether_header));
+    ip->check = 0;
+    ip->check = cksum(ip, sizeof(struct iphdr));
+
+    return 0;
+}
+
+int generate_packet2(void *pck, uint32_t *size, uint8_t saddr[4], uint8_t daddr[4],
+                     uint8_t hw_daddr[6], uint32_t seq, icmpr_flow_mode_t mode)
+{
+    struct ether_header *eh;
+    struct iphdr *ip;
+    struct icmphdr *icmp;
+
+    *size = 0;
+
+    if (mode == ICMPR_FLOW_MODE_ETH) {
+        eh = (struct ether_header *)pck;
+        *size += generate_eth(eh, hw_daddr);
+    }
+
+    ip = (struct iphdr *)(pck + *size);
+    *size += generate_ip(ip, saddr, daddr);
+
+    icmp = (struct icmphdr *)(pck + *size);
+    *size += generate_icmp(icmp, seq);
+
+    ((struct icmphdr *)(pck + *size - sizeof(struct icmphdr)))->checksum =
+        cksum(pck + *size - sizeof(struct icmphdr), sizeof(struct icmphdr));
+
+    ip->tot_len = __bswap_16(*size - sizeof(struct ether_header));
+    ip->check = 0;
+    ip->check = cksum(ip, sizeof(struct iphdr));
+
+    return 0;
+}
+
+#define GET_HEADER(out, hdr, src, off)                                                             \
+    do {                                                                                           \
+        out = (hdr *)(src + off);                                                                  \
+        off += sizeof(hdr);                                                                        \
+    } while (0)
+
+int resolve_packet(void *pck, uint32_t *size, uint8_t ip_addr[4], uint8_t hw_addr[6])
+{
+    struct ether_header *eh;
+    struct ether_arp *eah;
+    struct iphdr *ip;
+    struct icmphdr *icmp;
+    uint32_t offset = 0;
+
+    if (pck == NULL)
+        return 0;
 
 #ifdef ICMP_DBG
-  print_packet (pck);
+    print_packet(pck);
 #endif
 
-  GET_HEADER (eh, struct ether_header, pck, offset);
+    GET_HEADER(eh, struct ether_header, pck, offset);
 
-  memcpy (eh->ether_dhost, eh->ether_shost, 6);
-  memcpy (eh->ether_shost, hw_addr, 6);
+    memcpy(eh->ether_dhost, eh->ether_shost, 6);
+    memcpy(eh->ether_shost, hw_addr, 6);
 
-  if (eh->ether_type == 0x0608)
-    {
-      GET_HEADER (eah, struct ether_arp, pck, offset);
-      struct arphdr *arp = &eah->ea_hdr;
+    if (eh->ether_type == 0x0608) {
+        GET_HEADER(eah, struct ether_arp, pck, offset);
+        struct arphdr *arp = &eah->ea_hdr;
 
-      arp->ar_hrd = __bswap_16 (ARPHRD_ETHER);
-      arp->ar_pro = __bswap_16 (0x0800);
+        arp->ar_hrd = __bswap_16(ARPHRD_ETHER);
+        arp->ar_pro = __bswap_16(0x0800);
 
-      arp->ar_hln = 6;
-      arp->ar_pln = 4;
+        arp->ar_hln = 6;
+        arp->ar_pln = 4;
 
-      arp->ar_op = __bswap_16 (ARPOP_REPLY);
+        arp->ar_op = __bswap_16(ARPOP_REPLY);
 
-      memcpy (eah->arp_tha, eah->arp_sha, 6);
-      memcpy (eah->arp_tpa, eah->arp_spa, 4);
+        memcpy(eah->arp_tha, eah->arp_sha, 6);
+        memcpy(eah->arp_tpa, eah->arp_spa, 4);
 
-      memcpy (eah->arp_sha, eh->ether_shost, 6);
-      memcpy (eah->arp_spa, ip_addr, 4);
+        memcpy(eah->arp_sha, eh->ether_shost, 6);
+        memcpy(eah->arp_spa, ip_addr, 4);
     }
 
-  else if (eh->ether_type == 0x0008)
-    {
-      GET_HEADER (ip, struct iphdr, pck, offset);
+    else if (eh->ether_type == 0x0008) {
+        GET_HEADER(ip, struct iphdr, pck, offset);
 
-      if (ip->protocol == 1)
-	{
-	  ip->ihl = 5;
-	  ip->version = 4;
-	  ip->tos = 0;
-	  ip->tot_len = 0x0000;
-	  ip->id = 0;
-	  ip->frag_off = 0;
-	  ip->ttl = 0x40;
-	  ip->protocol = 1;
-	  ip->check = 0x0000;
-	  ip->daddr = ip->saddr;
-	  ((uint8_t *) &ip->saddr)[0] = ip_addr[0];
-	  ((uint8_t *) &ip->saddr)[1] = ip_addr[1];
-	  ((uint8_t *) &ip->saddr)[2] = ip_addr[2];
-	  ((uint8_t *) &ip->saddr)[3] = ip_addr[3];
+        if (ip->protocol == 1) {
+            ip->ihl = 5;
+            ip->version = 4;
+            ip->tos = 0;
+            ip->tot_len = 0x0000;
+            ip->id = 0;
+            ip->frag_off = 0;
+            ip->ttl = 0x40;
+            ip->protocol = 1;
+            ip->check = 0x0000;
+            ip->daddr = ip->saddr;
+            ((uint8_t *)&ip->saddr)[0] = ip_addr[0];
+            ((uint8_t *)&ip->saddr)[1] = ip_addr[1];
+            ((uint8_t *)&ip->saddr)[2] = ip_addr[2];
+            ((uint8_t *)&ip->saddr)[3] = ip_addr[3];
 
-	  GET_HEADER (icmp, struct icmphdr, pck, offset);
+            GET_HEADER(icmp, struct icmphdr, pck, offset);
 
-	  icmp->type = 0x00;
-	  icmp->code = 0;
-	  icmp->checksum = cksum (icmp, sizeof (struct icmphdr));
+            icmp->type = 0x00;
+            icmp->code = 0;
+            icmp->checksum = cksum(icmp, sizeof(struct icmphdr));
 
-	  /* rest is payload */
-	  offset = *size;
+            /* rest is payload */
+            offset = *size;
 
-	  ip->tot_len = __bswap_16 (offset - sizeof (struct ether_header));
-	  ip->check = cksum (ip, sizeof (struct iphdr));
-	}
+            ip->tot_len = __bswap_16(offset - sizeof(struct ether_header));
+            ip->check = cksum(ip, sizeof(struct iphdr));
+        }
     }
 
-  assert (offset == *size && "unsupported protocol");
-  return 0;
+    assert(offset == *size && "unsupported protocol");
+    return 0;
 }
 
-int
-resolve_packet_with_encap (void **pck_, uint32_t *size, uint8_t ip_addr[4])
+int resolve_packet_with_encap(void **pck_, uint32_t *size, uint8_t ip_addr[4])
 {
-  struct ether_header *eh;
-  struct iphdr *ip;
-  struct icmphdr *icmp;
-  int32_t offset = 0;
-  uint16_t encap_size = sizeof (struct ether_header);
-  void *pck = *pck_;
+    struct ether_header *eh;
+    struct iphdr *ip;
+    struct icmphdr *icmp;
+    int32_t offset = 0;
+    uint16_t encap_size = sizeof(struct ether_header);
+    void *pck = *pck_;
 
-  if (pck == NULL)
-    return 0;
+    if (pck == NULL)
+        return 0;
 
-  *pck_ -= encap_size;
-  offset -= encap_size;
+    *pck_ -= encap_size;
+    offset -= encap_size;
 
-  GET_HEADER (eh, struct ether_header, pck, offset);
+    GET_HEADER(eh, struct ether_header, pck, offset);
 
-  uint8_t hw_daddr[6];
-  memset (hw_daddr, 0, sizeof (uint8_t) * 6);
+    uint8_t hw_daddr[6];
+    memset(hw_daddr, 0, sizeof(uint8_t) * 6);
 
-  generate_eth (eh, hw_daddr);
+    generate_eth(eh, hw_daddr);
 
-  if (eh->ether_type == 0x0008)
-    {
-      GET_HEADER (ip, struct iphdr, pck, offset);
+    if (eh->ether_type == 0x0008) {
+        GET_HEADER(ip, struct iphdr, pck, offset);
 
-      if (ip->protocol == 1)
-	{
-	  ip->ihl = 5;
-	  ip->version = 4;
-	  ip->tos = 0;
-	  ip->tot_len = 0x0000;
-	  ip->id = 0;
-	  ip->frag_off = 0;
-	  ip->ttl = 0x40;
-	  ip->protocol = 1;
-	  ip->check = 0x0000;
-	  ip->daddr = ip->saddr;
-	  ((uint8_t *) &ip->saddr)[0] = ip_addr[0];
-	  ((uint8_t *) &ip->saddr)[1] = ip_addr[1];
-	  ((uint8_t *) &ip->saddr)[2] = ip_addr[2];
-	  ((uint8_t *) &ip->saddr)[3] = ip_addr[3];
+        if (ip->protocol == 1) {
+            ip->ihl = 5;
+            ip->version = 4;
+            ip->tos = 0;
+            ip->tot_len = 0x0000;
+            ip->id = 0;
+            ip->frag_off = 0;
+            ip->ttl = 0x40;
+            ip->protocol = 1;
+            ip->check = 0x0000;
+            ip->daddr = ip->saddr;
+            ((uint8_t *)&ip->saddr)[0] = ip_addr[0];
+            ((uint8_t *)&ip->saddr)[1] = ip_addr[1];
+            ((uint8_t *)&ip->saddr)[2] = ip_addr[2];
+            ((uint8_t *)&ip->saddr)[3] = ip_addr[3];
 
-	  GET_HEADER (icmp, struct icmphdr, pck, offset);
+            GET_HEADER(icmp, struct icmphdr, pck, offset);
 
-	  icmp->type = 0x00;
-	  icmp->code = 0;
-	  icmp->checksum = cksum (icmp, sizeof (struct icmphdr));
+            icmp->type = 0x00;
+            icmp->code = 0;
+            icmp->checksum = cksum(icmp, sizeof(struct icmphdr));
 
-	  /* rest is payload */
-	  offset = *size;
+            /* rest is payload */
+            offset = *size;
 
-	  ip->tot_len = __bswap_16 (offset - sizeof (struct ether_header));
-	  ip->check = cksum (ip, sizeof (struct iphdr));
-	}
+            ip->tot_len = __bswap_16(offset - sizeof(struct ether_header));
+            ip->check = cksum(ip, sizeof(struct iphdr));
+        }
     }
 
-  offset += encap_size;
+    offset += encap_size;
 
-  assert (offset != *size &&
-	  "new packet length must be increased by encap size");
+    assert(offset != *size && "new packet length must be increased by encap size");
 
-  /* overwrite packet size */
-  *size = offset;
+    /* overwrite packet size */
+    *size = offset;
 
-  return 0;
+    return 0;
 }

--- a/sdk/3rdparty/libmemif/examples/common/icmp_proto.h
+++ b/sdk/3rdparty/libmemif/examples/common/icmp_proto.h
@@ -18,26 +18,23 @@
 #ifndef _ICMP_PROTO_H_
 #define _ICMP_PROTO_H_
 
-typedef enum
-{
-  ICMPR_FLOW_MODE_ETH = 0,
-  ICMPR_FLOW_MODE_IP,
+typedef enum {
+    ICMPR_FLOW_MODE_ETH = 0,
+    ICMPR_FLOW_MODE_IP,
 } icmpr_flow_mode_t;
 
 /* resolve packet in place */
-int resolve_packet (void *pck, uint32_t *size, uint8_t ip_addr[4],
-		    uint8_t hw_addr[6]);
+int resolve_packet(void *pck, uint32_t *size, uint8_t ip_addr[4], uint8_t hw_addr[6]);
 
 /* resolve packet in place and add eth encap */
-int resolve_packet_with_encap (void **pck, uint32_t *size, uint8_t ip_addr[4]);
+int resolve_packet_with_encap(void **pck, uint32_t *size, uint8_t ip_addr[4]);
 
-int generate_packet (void *pck, uint32_t *size, uint8_t saddr[4],
-		     uint8_t daddr[4], uint8_t hw_daddr[6], uint32_t seq);
+int generate_packet(void *pck, uint32_t *size, uint8_t saddr[4], uint8_t daddr[4],
+                    uint8_t hw_daddr[6], uint32_t seq);
 
-int generate_packet2 (void *pck, uint32_t *size, uint8_t saddr[4],
-		      uint8_t daddr[4], uint8_t hw_daddr[6], uint32_t seq,
-		      icmpr_flow_mode_t);
+int generate_packet2(void *pck, uint32_t *size, uint8_t saddr[4], uint8_t daddr[4],
+                     uint8_t hw_daddr[6], uint32_t seq, icmpr_flow_mode_t);
 
-int print_packet (void *pck);
+int print_packet(void *pck);
 
 #endif /* _ICMP_PROTO_H_ */

--- a/sdk/3rdparty/libmemif/examples/common/responder.c
+++ b/sdk/3rdparty/libmemif/examples/common/responder.c
@@ -1,174 +1,153 @@
 #include <common.h>
 
-int
-responder (memif_conn_handle_t conn, void *private_ctx, uint16_t qid)
+int responder(memif_conn_handle_t conn, void *private_ctx, uint16_t qid)
 {
-  memif_connection_t *c = (memif_connection_t *) private_ctx;
-  int err, i;
-  uint16_t tx;
+    memif_connection_t *c = (memif_connection_t *)private_ctx;
+    int err, i;
+    uint16_t tx;
 
-  /* receive packets from the shared memory */
-  err = memif_rx_burst (conn, qid, c->rx_bufs, MAX_MEMIF_BUFS, &c->rx_buf_num);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("memif_rx_burst: %s", memif_strerror (err));
-      return err;
+    /* receive packets from the shared memory */
+    err = memif_rx_burst(conn, qid, c->rx_bufs, MAX_MEMIF_BUFS, &c->rx_buf_num);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("memif_rx_burst: %s", memif_strerror(err));
+        return err;
     }
 
-  do
-    {
-      /* allocate tx buffers */
-      err = memif_buffer_alloc (conn, qid, c->tx_bufs, c->rx_buf_num,
-				&c->tx_buf_num, c->buffer_size);
-      /* suppress full ring error MEMIF_ERR_NOBUF_RING */
-      if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_NOBUF_RING)
-	{
-	  INFO ("memif_buffer_alloc: %s", memif_strerror (err));
-	  goto error;
-	}
+    do {
+        /* allocate tx buffers */
+        err = memif_buffer_alloc(conn, qid, c->tx_bufs, c->rx_buf_num, &c->tx_buf_num,
+                                 c->buffer_size);
+        /* suppress full ring error MEMIF_ERR_NOBUF_RING */
+        if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_NOBUF_RING) {
+            INFO("memif_buffer_alloc: %s", memif_strerror(err));
+            goto error;
+        }
 
-  /* Process the packets */
-  if (c->packet_handler == NULL)
-	{
-	  INFO ("Missing packet handler");
-	  goto error;
-	}
+        /* Process the packets */
+        if (c->packet_handler == NULL) {
+            INFO("Missing packet handler");
+            goto error;
+        }
 
-  err = c->packet_handler (c);
-  if (err != 0)
-	{
-	  INFO ("packet handler error: %d", err);
-	  goto error;
-	}
-  /* Done processing packets */
+        err = c->packet_handler(c);
+        if (err != 0) {
+            INFO("packet handler error: %d", err);
+            goto error;
+        }
+        /* Done processing packets */
 
-  /* refill the queue */
-  err = memif_refill_queue (conn, qid, c->tx_buf_num, c->headroom_size);
-  if (err != MEMIF_ERR_SUCCESS)
-	{
-	  INFO ("memif_refill_queue: %s", memif_strerror (err));
-	  goto error;
-	}
-  c->rx_buf_num -= c->tx_buf_num;
+        /* refill the queue */
+        err = memif_refill_queue(conn, qid, c->tx_buf_num, c->headroom_size);
+        if (err != MEMIF_ERR_SUCCESS) {
+            INFO("memif_refill_queue: %s", memif_strerror(err));
+            goto error;
+        }
+        c->rx_buf_num -= c->tx_buf_num;
 
-  err = memif_tx_burst (conn, qid, c->tx_bufs, c->tx_buf_num, &tx);
-  if (err != MEMIF_ERR_SUCCESS)
-	{
-	  INFO ("memif_tx_burst: %s", memif_strerror (err));
-	  goto error;
-	}
-      c->tx_buf_num -= tx;
+        err = memif_tx_burst(conn, qid, c->tx_bufs, c->tx_buf_num, &tx);
+        if (err != MEMIF_ERR_SUCCESS) {
+            INFO("memif_tx_burst: %s", memif_strerror(err));
+            goto error;
+        }
+        c->tx_buf_num -= tx;
 
-      /* This should never happen */
-      if (c->tx_buf_num != 0)
-	{
-	  INFO ("memif_tx_burst failed to send all allocated buffers.");
-	  goto error;
-	}
-    }
-  while (c->rx_buf_num > 0);
+        /* This should never happen */
+        if (c->tx_buf_num != 0) {
+            INFO("memif_tx_burst failed to send all allocated buffers.");
+            goto error;
+        }
+    } while (c->rx_buf_num > 0);
 
-  return 0;
+    return 0;
 
 error:
-  err = memif_refill_queue (conn, qid, c->rx_buf_num, c->headroom_size);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("memif_refill_queue: %s", memif_strerror (err));
-      return err;
+    err = memif_refill_queue(conn, qid, c->rx_buf_num, c->headroom_size);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("memif_refill_queue: %s", memif_strerror(err));
+        return err;
     }
-  c->rx_buf_num = 0;
+    c->rx_buf_num = 0;
 
-  return -1;
+    return -1;
 }
 
-int
-responder_zero_copy (memif_conn_handle_t conn, void *private_ctx, uint16_t qid)
+int responder_zero_copy(memif_conn_handle_t conn, void *private_ctx, uint16_t qid)
 {
-  memif_connection_t *c = (memif_connection_t *) private_ctx;
-  int err, i;
-  uint16_t tx, tx2;
+    memif_connection_t *c = (memif_connection_t *)private_ctx;
+    int err, i;
+    uint16_t tx, tx2;
 
-  /* receive packets from the shared memory */
-  err = memif_rx_burst (conn, qid, c->rx_bufs, MAX_MEMIF_BUFS, &c->rx_buf_num);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("memif_rx_burst: %s", memif_strerror (err));
-      return err;
+    /* receive packets from the shared memory */
+    err = memif_rx_burst(conn, qid, c->rx_bufs, MAX_MEMIF_BUFS, &c->rx_buf_num);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("memif_rx_burst: %s", memif_strerror(err));
+        return err;
     }
 
-  do {
+    do {
 
-/* Note that in zero copy memif_buffer_alloc is not part of respond process,
-*  instead rx buffers are used directly using memif_buffer_enq_tx.
-*
-*      Process the packets
-*/
+        /* Note that in zero copy memif_buffer_alloc is not part of respond process,
+         *  instead rx buffers are used directly using memif_buffer_enq_tx.
+         *
+         *      Process the packets
+         */
 
-  if (c->packet_handler == NULL)
-	{
-	  INFO ("Missing packet handler");
-	  goto error;
-	}
+        if (c->packet_handler == NULL) {
+            INFO("Missing packet handler");
+            goto error;
+        }
 
-  err = c->packet_handler (c);
-  if (err != 0)
-	{
-	  INFO ("packet handler error: %d", err);
-	  goto error;
-	}
-    /* Done processing packets */
+        err = c->packet_handler(c);
+        if (err != 0) {
+            INFO("packet handler error: %d", err);
+            goto error;
+        }
+        /* Done processing packets */
 
-      /* Swap rx and tx buffers, swapped tx buffers are considered allocated
-       * and are ready to be transmitted. Notice that the buffers are swapped
-       * only in memif driver and locally remain in rx_bufs queue.
-       */
-      err = memif_buffer_enq_tx (conn, qid, c->rx_bufs, c->rx_buf_num, &tx);
-      /* suppress full ring error MEMIF_ERR_NOBUF_RING */
-      if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_NOBUF_RING)
-	{
-	  INFO ("memif_buffer_alloc: %s", memif_strerror (err));
-	  goto error;
-	}
+        /* Swap rx and tx buffers, swapped tx buffers are considered allocated
+         * and are ready to be transmitted. Notice that the buffers are swapped
+         * only in memif driver and locally remain in rx_bufs queue.
+         */
+        err = memif_buffer_enq_tx(conn, qid, c->rx_bufs, c->rx_buf_num, &tx);
+        /* suppress full ring error MEMIF_ERR_NOBUF_RING */
+        if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_NOBUF_RING) {
+            INFO("memif_buffer_alloc: %s", memif_strerror(err));
+            goto error;
+        }
 
-      /* refill the queue */
-      err = memif_refill_queue (conn, qid, tx, c->headroom_size);
-      if (err != MEMIF_ERR_SUCCESS)
-	{
-	  INFO ("memif_refill_queue: %s", memif_strerror (err));
-	  goto error;
-	}
-      c->rx_buf_num -= tx;
+        /* refill the queue */
+        err = memif_refill_queue(conn, qid, tx, c->headroom_size);
+        if (err != MEMIF_ERR_SUCCESS) {
+            INFO("memif_refill_queue: %s", memif_strerror(err));
+            goto error;
+        }
+        c->rx_buf_num -= tx;
 
-      /* Notice that we send from rx_bufs as the buffers were only swapped
-       * internally in memif driver */
-      err = memif_tx_burst (conn, qid, c->rx_bufs, tx, &tx2);
-      if (err != MEMIF_ERR_SUCCESS)
-	{
-	  INFO ("memif_tx_burst: %s", memif_strerror (err));
-	  goto error;
-	}
-      tx -= tx2;
+        /* Notice that we send from rx_bufs as the buffers were only swapped
+         * internally in memif driver */
+        err = memif_tx_burst(conn, qid, c->rx_bufs, tx, &tx2);
+        if (err != MEMIF_ERR_SUCCESS) {
+            INFO("memif_tx_burst: %s", memif_strerror(err));
+            goto error;
+        }
+        tx -= tx2;
 
-      /* This should never happen */
-      if (tx != 0)
-	{
-	  INFO ("memif_tx_burst failed to send all allocated buffers.");
-	  goto error;
-	}
-    }
-  while (c->rx_buf_num > 0);
+        /* This should never happen */
+        if (tx != 0) {
+            INFO("memif_tx_burst failed to send all allocated buffers.");
+            goto error;
+        }
+    } while (c->rx_buf_num > 0);
 
-  return 0;
+    return 0;
 
 error:
-  err = memif_refill_queue (conn, qid, c->rx_buf_num, c->headroom_size);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("memif_refill_queue: %s", memif_strerror (err));
-      return err;
+    err = memif_refill_queue(conn, qid, c->rx_buf_num, c->headroom_size);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("memif_refill_queue: %s", memif_strerror(err));
+        return err;
     }
-  c->rx_buf_num = 0;
+    c->rx_buf_num = 0;
 
-  return -1;
+    return -1;
 }

--- a/sdk/3rdparty/libmemif/examples/common/sender.c
+++ b/sdk/3rdparty/libmemif/examples/common/sender.c
@@ -1,55 +1,46 @@
 #include <common.h>
 
-int
-send_packets (memif_connection_t *c, uint16_t qid,
-	      packet_generator_t *generator, uint32_t num_pkts,
-	      uint16_t max_pkt_size)
+int send_packets(memif_connection_t *c, uint16_t qid, packet_generator_t *generator,
+                 uint32_t num_pkts, uint16_t max_pkt_size)
 {
-  int err, i;
-  uint16_t tx;
+    int err, i;
+    uint16_t tx;
 
-  do
-    {
-      err = memif_buffer_alloc (c->conn, qid, c->tx_bufs,
-				num_pkts > MAX_MEMIF_BUFS ? MAX_MEMIF_BUFS :
-								  num_pkts,
-				&c->tx_buf_num, max_pkt_size);
-      /* suppress full ring error MEMIF_ERR_NOBUF_RING */
-      if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_NOBUF_RING)
-	{
-	  INFO ("memif_buffer_alloc: %s", memif_strerror (err));
-	  goto error;
-	}
+    do {
+        err = memif_buffer_alloc(c->conn, qid, c->tx_bufs,
+                                 num_pkts > MAX_MEMIF_BUFS ? MAX_MEMIF_BUFS : num_pkts,
+                                 &c->tx_buf_num, max_pkt_size);
+        /* suppress full ring error MEMIF_ERR_NOBUF_RING */
+        if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_NOBUF_RING) {
+            INFO("memif_buffer_alloc: %s", memif_strerror(err));
+            goto error;
+        }
 
-      /* generate packet inside allocated buffers */
-      err = generator (c, num_pkts);
-      if (err != 0)
-	{
-	  INFO ("paclet generator error: %d", err);
-	  goto error;
-	}
+        /* generate packet inside allocated buffers */
+        err = generator(c, num_pkts);
+        if (err != 0) {
+            INFO("paclet generator error: %d", err);
+            goto error;
+        }
 
-      err = memif_tx_burst (c->conn, qid, c->tx_bufs, c->tx_buf_num, &tx);
-      if (err != MEMIF_ERR_SUCCESS)
-	{
-	  INFO ("memif_tx_burst: %s", memif_strerror (err));
-	  goto error;
-	}
-      c->tx_buf_num -= tx;
+        err = memif_tx_burst(c->conn, qid, c->tx_bufs, c->tx_buf_num, &tx);
+        if (err != MEMIF_ERR_SUCCESS) {
+            INFO("memif_tx_burst: %s", memif_strerror(err));
+            goto error;
+        }
+        c->tx_buf_num -= tx;
 
-      /* Should never happen... */
-      if (c->tx_buf_num > 0)
-	{
-	  INFO ("Failed to send allocated packets");
-	  goto error;
-	}
-      num_pkts -= tx;
-    }
-  while (num_pkts > 0);
+        /* Should never happen... */
+        if (c->tx_buf_num > 0) {
+            INFO("Failed to send allocated packets");
+            goto error;
+        }
+        num_pkts -= tx;
+    } while (num_pkts > 0);
 
-  return 0;
+    return 0;
 
 error:
-  /* TODO: free alloocated tx buffers */
-  return -1;
+    /* TODO: free alloocated tx buffers */
+    return -1;
 }

--- a/sdk/3rdparty/libmemif/examples/icmp_responder/main.c
+++ b/sdk/3rdparty/libmemif/examples/icmp_responder/main.c
@@ -31,221 +31,202 @@
 
 #define APP_NAME "icmp_responder_example"
 
-#define IF_NAME	    "libmemif0"
-#define IF_ID	    0
+#define IF_NAME "libmemif0"
+#define IF_ID 0
 #define SOCKET_PATH "/run/vpp/memif.sock"
-const uint8_t HW_ADDR[6] = { 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa };
-const uint8_t IP_ADDR[4] = { 192, 168, 1, 1 };
+const uint8_t HW_ADDR[6] = {0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa};
+const uint8_t IP_ADDR[4] = {192, 168, 1, 1};
 
 memif_connection_t intf;
 int epfd;
 
 /* informs user about connected status. private_ctx is used by user to identify
  * connection */
-int
-on_connect (memif_conn_handle_t conn, void *private_ctx)
+int on_connect(memif_conn_handle_t conn, void *private_ctx)
 {
-  INFO ("memif connected!");
-  int err;
+    INFO("memif connected!");
+    int err;
 
-  memif_connection_t *c = (memif_connection_t *) private_ctx;
+    memif_connection_t *c = (memif_connection_t *)private_ctx;
 
-  c->is_connected = 1;
-  alloc_memif_buffers (c);
+    c->is_connected = 1;
+    alloc_memif_buffers(c);
 
-  err = memif_refill_queue (conn, 0, -1, c->headroom_size);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("memif_refill_queue: %s", memif_strerror (err));
-      return err;
+    err = memif_refill_queue(conn, 0, -1, c->headroom_size);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("memif_refill_queue: %s", memif_strerror(err));
+        return err;
     }
 
-  print_memif_details (c);
+    print_memif_details(c);
 
-  return 0;
+    return 0;
 }
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int
-on_disconnect (memif_conn_handle_t conn, void *private_ctx)
+int on_disconnect(memif_conn_handle_t conn, void *private_ctx)
 {
-  INFO ("memif disconnected!");
+    INFO("memif disconnected!");
 
-  memif_connection_t *c = (memif_connection_t *) private_ctx;
+    memif_connection_t *c = (memif_connection_t *)private_ctx;
 
-  c->is_connected = 0;
-  free_memif_buffers (c);
+    c->is_connected = 0;
+    free_memif_buffers(c);
 
-  /* stop event polling thread */
-  int err = memif_cancel_poll_event (memif_get_socket_handle (conn));
-  if (err != MEMIF_ERR_SUCCESS)
-    INFO ("We are doomed...");
+    /* stop event polling thread */
+    int err = memif_cancel_poll_event(memif_get_socket_handle(conn));
+    if (err != MEMIF_ERR_SUCCESS)
+        INFO("We are doomed...");
 
-  return 0;
+    return 0;
 }
 
-void
-print_help ()
+void print_help()
 {
-  printf ("LIBMEMIF EXAMPLE APP: %s", APP_NAME);
+    printf("LIBMEMIF EXAMPLE APP: %s", APP_NAME);
 #ifdef ICMP_DBG
-  printf (" (debug)");
+    printf(" (debug)");
 #endif
-  printf ("\n");
-  printf ("==============================\n");
-  print_version ();
-  printf ("==============================\n");
-  printf (
-    "In this example, memif endpoint connects to an external application.\n");
-  printf (
-    "The example application can resolve ARP and reply to ICMPv4 packets.\n");
-  printf ("The program will exit once the interface is disconnected.\n");
-  printf ("==============================\n");
-  printf ("Usage: icmp_responder [OPTIONS]\n\n");
-  printf ("Options:\n");
-  printf ("\t-r\tInterface role <slave|master>. Default: slave\n");
-  printf ("\t-s\tSocket path. Supports abstract socket using @ before the "
-	  "path. Default: /run/vpp/memif.sock\n");
-  printf ("\t-b\tBuffer Size. Default: 2048\n");
-  printf ("\t-h\tHeadroom Size. Default: 0\n");
-  printf ("\t-i\tInterface id. Default: 0\n");
-  printf ("\t-a\tIPv4 address. Default: 192.168.1.1\n");
-  printf ("\t-m\tMac address. Default: aa:aa:aa:aa:aa:aa\n");
-  printf ("\t-?\tShow help and exit.\n");
-  printf ("\t-v\tShow libmemif and memif version information and exit.\n");
+    printf("\n");
+    printf("==============================\n");
+    print_version();
+    printf("==============================\n");
+    printf("In this example, memif endpoint connects to an external application.\n");
+    printf("The example application can resolve ARP and reply to ICMPv4 packets.\n");
+    printf("The program will exit once the interface is disconnected.\n");
+    printf("==============================\n");
+    printf("Usage: icmp_responder [OPTIONS]\n\n");
+    printf("Options:\n");
+    printf("\t-r\tInterface role <slave|master>. Default: slave\n");
+    printf("\t-s\tSocket path. Supports abstract socket using @ before the "
+           "path. Default: /run/vpp/memif.sock\n");
+    printf("\t-b\tBuffer Size. Default: 2048\n");
+    printf("\t-h\tHeadroom Size. Default: 0\n");
+    printf("\t-i\tInterface id. Default: 0\n");
+    printf("\t-a\tIPv4 address. Default: 192.168.1.1\n");
+    printf("\t-m\tMac address. Default: aa:aa:aa:aa:aa:aa\n");
+    printf("\t-?\tShow help and exit.\n");
+    printf("\t-v\tShow libmemif and memif version information and exit.\n");
 }
 
-int
-main (int argc, char *argv[])
+int main(int argc, char *argv[])
 {
-  memif_socket_args_t memif_socket_args = { 0 };
-  memif_socket_handle_t memif_socket;
-  memif_conn_args_t memif_conn_args = { 0 };
-  int opt, err, ret = 0;
-  uint8_t is_master = 0;
-  char socket_path[108];
-  char role_string[16];
-  int id = IF_ID;
+    memif_socket_args_t memif_socket_args = {0};
+    memif_socket_handle_t memif_socket;
+    memif_conn_args_t memif_conn_args = {0};
+    int opt, err, ret = 0;
+    uint8_t is_master = 0;
+    char socket_path[108];
+    char role_string[16];
+    int id = IF_ID;
 
-  strlcpy (socket_path, SOCKET_PATH, sizeof (SOCKET_PATH));
+    strlcpy(socket_path, SOCKET_PATH, sizeof(SOCKET_PATH));
 
-  /* prepare the private data */
-  memset (&intf, 0, sizeof (intf));
-  intf.packet_handler = icmp_packet_handler;
-  memcpy (intf.ip_addr, IP_ADDR, 4);
-  memcpy (intf.hw_addr, HW_ADDR, 6);
-  while ((opt = getopt (argc, argv, "r:s:b:h:i:a:m:?v")) != -1)
-  {
-    switch (opt)
-	  {
-	    case 'r':
-        strlcpy(role_string, optarg, sizeof(role_string));
-	      if (strncmp (role_string, "master", sizeof (role_string)) == 0) {
-	          is_master = 1;
-	      } else if (strncmp (role_string, "slave", sizeof (role_string)) == 0) {
-	          is_master = 0;
-	      }
-	      else {
-	          INFO ("Invalid role value: '%s'", role_string);
-	          return -1;
-	      }
-	      break;
-	    case 's':
-	      sprintf (socket_path, "%s", optarg);
-	      break;
-	    case 'b':
-	      intf.buffer_size = atoi (optarg);
-	      break;
-	    case 'h':
-	      intf.headroom_size = atoi (optarg);
-	      break;
-	    case 'i':
-	      id = atoi (optarg);
-	      break;
-	    case 'a':
-	      if (parse_ip4 (optarg, intf.ip_addr) != 0)
-	        {
-	          INFO ("Invalid ipv4 address: %s", optarg);
-	          return -1;
-	        }
-	      break;
-	    case 'm':
-	      if (parse_mac (optarg, intf.hw_addr) != 0)
-	        {
-	          INFO ("Invalid mac address: %s", optarg);
-	          return -1;
-	        }
-	      break;
-	    case '?':
-	      print_help ();
-	      return 0;
-	    case 'v':
-	      print_version ();
-	      return 0;
-	  }
-  }
-
-  /** Create memif socket
-   *
-   * Interfaces are internally stored in a database referenced by memif socket.
-   */
-  sprintf (memif_socket_args.path, "%s", socket_path);
-  /* Set application name */
-  strlcpy (memif_socket_args.app_name, APP_NAME, sizeof (APP_NAME));
-
-  /* configure autoconnect timer */
-  if (is_master == 0)
-    {
-      memif_socket_args.connection_request_timer.it_value.tv_sec = 2;
-      memif_socket_args.connection_request_timer.it_value.tv_nsec = 0;
-      memif_socket_args.connection_request_timer.it_interval.tv_sec = 2;
-      memif_socket_args.connection_request_timer.it_interval.tv_nsec = 0;
+    /* prepare the private data */
+    memset(&intf, 0, sizeof(intf));
+    intf.packet_handler = icmp_packet_handler;
+    memcpy(intf.ip_addr, IP_ADDR, 4);
+    memcpy(intf.hw_addr, HW_ADDR, 6);
+    while ((opt = getopt(argc, argv, "r:s:b:h:i:a:m:?v")) != -1) {
+        switch (opt) {
+        case 'r':
+            strlcpy(role_string, optarg, sizeof(role_string));
+            if (strncmp(role_string, "master", sizeof(role_string)) == 0) {
+                is_master = 1;
+            } else if (strncmp(role_string, "slave", sizeof(role_string)) == 0) {
+                is_master = 0;
+            } else {
+                INFO("Invalid role value: '%s'", role_string);
+                return -1;
+            }
+            break;
+        case 's':
+            sprintf(socket_path, "%s", optarg);
+            break;
+        case 'b':
+            intf.buffer_size = atoi(optarg);
+            break;
+        case 'h':
+            intf.headroom_size = atoi(optarg);
+            break;
+        case 'i':
+            id = atoi(optarg);
+            break;
+        case 'a':
+            if (parse_ip4(optarg, intf.ip_addr) != 0) {
+                INFO("Invalid ipv4 address: %s", optarg);
+                return -1;
+            }
+            break;
+        case 'm':
+            if (parse_mac(optarg, intf.hw_addr) != 0) {
+                INFO("Invalid mac address: %s", optarg);
+                return -1;
+            }
+            break;
+        case '?':
+            print_help();
+            return 0;
+        case 'v':
+            print_version();
+            return 0;
+        }
     }
 
-  err = memif_create_socket (&memif_socket, &memif_socket_args, NULL);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("memif_create_socket: %s", memif_strerror (err));
-      goto error;
+    /** Create memif socket
+     *
+     * Interfaces are internally stored in a database referenced by memif socket.
+     */
+    sprintf(memif_socket_args.path, "%s", socket_path);
+    /* Set application name */
+    strlcpy(memif_socket_args.app_name, APP_NAME, sizeof(APP_NAME));
+
+    /* configure autoconnect timer */
+    if (is_master == 0) {
+        memif_socket_args.connection_request_timer.it_value.tv_sec = 2;
+        memif_socket_args.connection_request_timer.it_value.tv_nsec = 0;
+        memif_socket_args.connection_request_timer.it_interval.tv_sec = 2;
+        memif_socket_args.connection_request_timer.it_interval.tv_nsec = 0;
     }
 
-  /** Create memif interfaces
-   *
-   * Both interfaces are assigned the same socket and same id to create a
-   * loopback.
-   */
-  if (intf.buffer_size)
-    memif_conn_args.buffer_size = intf.buffer_size;
-
-  memif_conn_args.socket = memif_socket;
-  memif_conn_args.interface_id = id;
-  strlcpy (memif_conn_args.interface_name, IF_NAME,
-	   sizeof (memif_conn_args.interface_name));
-  memif_conn_args.is_master = is_master;
-
-  err =
-    memif_create (&intf.conn, &memif_conn_args, on_connect, on_disconnect,
-		  is_master ? responder : responder_zero_copy, (void *) &intf);
-  if (err != MEMIF_ERR_SUCCESS)
-    {
-      INFO ("memif_create_socket: %s", memif_strerror (err));
-      return err;
+    err = memif_create_socket(&memif_socket, &memif_socket_args, NULL);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("memif_create_socket: %s", memif_strerror(err));
+        goto error;
     }
 
-  do
-    {
-      err = memif_poll_event (memif_socket, -1);
-    }
-  while (err == MEMIF_ERR_SUCCESS);
+    /** Create memif interfaces
+     *
+     * Both interfaces are assigned the same socket and same id to create a
+     * loopback.
+     */
+    if (intf.buffer_size)
+        memif_conn_args.buffer_size = intf.buffer_size;
 
-  return 0;
+    memif_conn_args.socket = memif_socket;
+    memif_conn_args.interface_id = id;
+    strlcpy(memif_conn_args.interface_name, IF_NAME, sizeof(memif_conn_args.interface_name));
+    memif_conn_args.is_master = is_master;
+
+    err = memif_create(&intf.conn, &memif_conn_args, on_connect, on_disconnect,
+                       is_master ? responder : responder_zero_copy, (void *)&intf);
+    if (err != MEMIF_ERR_SUCCESS) {
+        INFO("memif_create_socket: %s", memif_strerror(err));
+        return err;
+    }
+
+    do {
+        err = memif_poll_event(memif_socket, -1);
+    } while (err == MEMIF_ERR_SUCCESS);
+
+    return 0;
 
 error:
-  ret = -1;
+    ret = -1;
 done:
-  free_memif_buffers (&intf);
-  memif_delete (&intf.conn);
-  memif_delete_socket (&memif_socket);
-  return ret;
+    free_memif_buffers(&intf);
+    memif_delete(&intf.conn);
+    memif_delete_socket(&memif_socket);
+    return ret;
 }

--- a/sdk/3rdparty/libmemif/src/libmemif.h
+++ b/sdk/3rdparty/libmemif/src/libmemif.h
@@ -33,53 +33,52 @@
 #include <sys/types.h>
 
 /*! Error codes */
-typedef enum
-{
-  MEMIF_ERR_SUCCESS = 0,     /*!< success */
-			     /* SYSCALL ERRORS */
-  MEMIF_ERR_SYSCALL,	     /*!< other syscall error */
-  MEMIF_ERR_CONNREFUSED,     /*!< connection refused */
-  MEMIF_ERR_ACCES,	     /*!< permission denied */
-  MEMIF_ERR_NO_FILE,	     /*!< file does not exist */
-  MEMIF_ERR_FILE_LIMIT,	     /*!< system open file limit */
-  MEMIF_ERR_PROC_FILE_LIMIT, /*!< process open file limit */
-  MEMIF_ERR_ALREADY,	     /*!< connection already requested */
-  MEMIF_ERR_AGAIN,	     /*!< fd is not socket, or operation would block */
-  MEMIF_ERR_BAD_FD,	     /*!< invalid fd */
-  MEMIF_ERR_NOMEM,	     /*!< out of memory */
-			     /* LIBMEMIF ERRORS */
-  MEMIF_ERR_INVAL_ARG,	     /*!< invalid argument */
-  MEMIF_ERR_NOCONN,	     /*!< handle points to no connection */
-  MEMIF_ERR_CONN,	     /*!< handle points to existing connection */
-  MEMIF_ERR_CB_FDUPDATE,   /*!< user defined callback memif_control_fd_update_t
-			      error */
-  MEMIF_ERR_FILE_NOT_SOCK, /*!< file specified by socket path
-			      exists, but it's not socket */
-  MEMIF_ERR_NO_SHMFD,	   /*!< missing shm fd */
-  MEMIF_ERR_COOKIE,	   /*!< wrong cookie on ring */
-  MEMIF_ERR_NOBUF_RING,	   /*!< ring buffer full */
-  MEMIF_ERR_NOBUF,	   /*!< not enough memif buffers */
-  MEMIF_ERR_NOBUF_DET,	   /*!< memif details needs larger buffer */
-  MEMIF_ERR_INT_WRITE,	   /*!< send interrupt error */
-  MEMIF_ERR_MFMSG,	   /*!< malformed msg received */
-  MEMIF_ERR_QID,	   /*!< invalid queue id */
-			   /* MEMIF PROTO ERRORS */
-  MEMIF_ERR_PROTO,	   /*!< incompatible protocol version */
-  MEMIF_ERR_ID,		   /*!< unmatched interface id */
-  MEMIF_ERR_ACCSLAVE,	   /*!< slave cannot accept connection requests */
-  MEMIF_ERR_ALRCONN,	   /*!< memif is already connected */
-  MEMIF_ERR_MODE,	   /*!< mode mismatch */
-  MEMIF_ERR_SECRET,	   /*!< secret mismatch */
-  MEMIF_ERR_NOSECRET,	   /*!< secret required */
-  MEMIF_ERR_MAXREG,	   /*!< max region limit reached */
-  MEMIF_ERR_MAXRING,	   /*!< max ring limit reached */
-  MEMIF_ERR_NO_INTFD,	   /*!< missing interrupt fd */
-  MEMIF_ERR_DISCONNECT,	   /*!< disconnect received */
-  MEMIF_ERR_DISCONNECTED,  /*!< peer interface disconnected */
-  MEMIF_ERR_UNKNOWN_MSG,   /*!< unknown message type */
-  MEMIF_ERR_POLL_CANCEL,   /*!< memif_poll_event() was cancelled */
-  MEMIF_ERR_MAX_RING,	   /*!< too large ring size */
-  MEMIF_ERR_PRIVHDR,	   /*!< private hdrs not supported */
+typedef enum {
+    MEMIF_ERR_SUCCESS = 0,     /*!< success */
+                               /* SYSCALL ERRORS */
+    MEMIF_ERR_SYSCALL,         /*!< other syscall error */
+    MEMIF_ERR_CONNREFUSED,     /*!< connection refused */
+    MEMIF_ERR_ACCES,           /*!< permission denied */
+    MEMIF_ERR_NO_FILE,         /*!< file does not exist */
+    MEMIF_ERR_FILE_LIMIT,      /*!< system open file limit */
+    MEMIF_ERR_PROC_FILE_LIMIT, /*!< process open file limit */
+    MEMIF_ERR_ALREADY,         /*!< connection already requested */
+    MEMIF_ERR_AGAIN,           /*!< fd is not socket, or operation would block */
+    MEMIF_ERR_BAD_FD,          /*!< invalid fd */
+    MEMIF_ERR_NOMEM,           /*!< out of memory */
+                               /* LIBMEMIF ERRORS */
+    MEMIF_ERR_INVAL_ARG,       /*!< invalid argument */
+    MEMIF_ERR_NOCONN,          /*!< handle points to no connection */
+    MEMIF_ERR_CONN,            /*!< handle points to existing connection */
+    MEMIF_ERR_CB_FDUPDATE,     /*!< user defined callback memif_control_fd_update_t
+                                  error */
+    MEMIF_ERR_FILE_NOT_SOCK,   /*!< file specified by socket path
+                                  exists, but it's not socket */
+    MEMIF_ERR_NO_SHMFD,        /*!< missing shm fd */
+    MEMIF_ERR_COOKIE,          /*!< wrong cookie on ring */
+    MEMIF_ERR_NOBUF_RING,      /*!< ring buffer full */
+    MEMIF_ERR_NOBUF,           /*!< not enough memif buffers */
+    MEMIF_ERR_NOBUF_DET,       /*!< memif details needs larger buffer */
+    MEMIF_ERR_INT_WRITE,       /*!< send interrupt error */
+    MEMIF_ERR_MFMSG,           /*!< malformed msg received */
+    MEMIF_ERR_QID,             /*!< invalid queue id */
+    /* MEMIF PROTO ERRORS */
+    MEMIF_ERR_PROTO,        /*!< incompatible protocol version */
+    MEMIF_ERR_ID,           /*!< unmatched interface id */
+    MEMIF_ERR_ACCSLAVE,     /*!< slave cannot accept connection requests */
+    MEMIF_ERR_ALRCONN,      /*!< memif is already connected */
+    MEMIF_ERR_MODE,         /*!< mode mismatch */
+    MEMIF_ERR_SECRET,       /*!< secret mismatch */
+    MEMIF_ERR_NOSECRET,     /*!< secret required */
+    MEMIF_ERR_MAXREG,       /*!< max region limit reached */
+    MEMIF_ERR_MAXRING,      /*!< max ring limit reached */
+    MEMIF_ERR_NO_INTFD,     /*!< missing interrupt fd */
+    MEMIF_ERR_DISCONNECT,   /*!< disconnect received */
+    MEMIF_ERR_DISCONNECTED, /*!< peer interface disconnected */
+    MEMIF_ERR_UNKNOWN_MSG,  /*!< unknown message type */
+    MEMIF_ERR_POLL_CANCEL,  /*!< memif_poll_event() was cancelled */
+    MEMIF_ERR_MAX_RING,     /*!< too large ring size */
+    MEMIF_ERR_PRIVHDR,      /*!< private hdrs not supported */
 } memif_err_t;
 
 /**
@@ -92,17 +91,16 @@ typedef enum
  * User needs to set events that occurred on fd and pass them to
  * memif_control_fd_handler
  */
-typedef enum memif_fd_event_type
-{
-  MEMIF_FD_EVENT_READ = 1,  /* 00001 */
-  MEMIF_FD_EVENT_WRITE = 2, /* 00010 */
-  /** inform libmemif that error occurred on fd */
-  MEMIF_FD_EVENT_ERROR = 4, /* 00100 */
-  /** if set, informs that fd is going to be closed (user may want to stop
-     watching for events on this fd) */
-  MEMIF_FD_EVENT_DEL = 8, /* 01000 */
-  /** update events */
-  MEMIF_FD_EVENT_MOD = 16 /* 10000 */
+typedef enum memif_fd_event_type {
+    MEMIF_FD_EVENT_READ = 1,  /* 00001 */
+    MEMIF_FD_EVENT_WRITE = 2, /* 00010 */
+    /** inform libmemif that error occurred on fd */
+    MEMIF_FD_EVENT_ERROR = 4, /* 00100 */
+    /** if set, informs that fd is going to be closed (user may want to stop
+       watching for events on this fd) */
+    MEMIF_FD_EVENT_DEL = 8, /* 01000 */
+    /** update events */
+    MEMIF_FD_EVENT_MOD = 16 /* 10000 */
 } memif_fd_event_type_t;
 /** @} */
 
@@ -121,8 +119,7 @@ typedef void *memif_socket_handle_t;
 
     custom memory allocator: alloc function template
 */
-typedef void *(memif_alloc_t) (size_t size);
-
+typedef void *(memif_alloc_t)(size_t size);
 
 /** \brief Memif realloc
     @param ptr - pointer to memory block
@@ -130,14 +127,14 @@ typedef void *(memif_alloc_t) (size_t size);
 
     custom memory reallocation
 */
-typedef void *(memif_realloc_t) (void *ptr, size_t size);
+typedef void *(memif_realloc_t)(void *ptr, size_t size);
 
 /** \brief Memif allocator free
     @param size - requested allocation size
 
     custom memory allocator: free function template
 */
-typedef void (memif_free_t) (void *ptr);
+typedef void(memif_free_t)(void *ptr);
 
 /**
  * @defgroup CALLBACKS Callback functions definitions
@@ -151,11 +148,10 @@ typedef void (memif_free_t) (void *ptr);
     @param type - memif fd event type
     @param private_ctx - private event data
 */
-typedef struct memif_fd_event
-{
-  int fd;
-  memif_fd_event_type_t type;
-  void *private_ctx;
+typedef struct memif_fd_event {
+    int fd;
+    memif_fd_event_type_t type;
+    void *private_ctx;
 } memif_fd_event_t;
 
 /** \brief Memif control file descriptor update (callback function)
@@ -168,8 +164,7 @@ typedef struct memif_fd_event
    on this fd). Private context is taken from libmemif_main, 'private_ctx'
    passed to memif_per_thread_init() or NULL in case of memif_init()
 */
-typedef int (memif_control_fd_update_t) (memif_fd_event_t fde,
-					 void *private_ctx);
+typedef int(memif_control_fd_update_t)(memif_fd_event_t fde, void *private_ctx);
 
 /** \brief Memif connection status update (callback function)
     @param conn - memif connection handle
@@ -178,8 +173,7 @@ typedef int (memif_control_fd_update_t) (memif_fd_event_t fde,
     Informs user about connection status connected/disconnected.
     On connected -> start watching for events on interrupt fd (optional).
 */
-typedef int (memif_connection_update_t) (memif_conn_handle_t conn,
-					 void *private_ctx);
+typedef int(memif_connection_update_t)(memif_conn_handle_t conn, void *private_ctx);
 
 /** \brief Memif interrupt occurred (callback function)
     @param conn - memif connection handle
@@ -188,8 +182,7 @@ typedef int (memif_connection_update_t) (memif_conn_handle_t conn,
 
     Called when event is received on interrupt fd.
 */
-typedef int (memif_on_interrupt_t) (memif_conn_handle_t conn,
-				    void *private_ctx, uint16_t qid);
+typedef int(memif_on_interrupt_t)(memif_conn_handle_t conn, void *private_ctx, uint16_t qid);
 
 /** @} */
 
@@ -205,7 +198,7 @@ typedef int (memif_on_interrupt_t) (memif_conn_handle_t conn,
 
     Find unallocated external buffer and return its offset.
 */
-typedef uint32_t (memif_get_external_buffer_offset_t) (void *private_ctx);
+typedef uint32_t(memif_get_external_buffer_offset_t)(void *private_ctx);
 
 /** \brief Add external region
     @param[out] addr - region address
@@ -215,8 +208,7 @@ typedef uint32_t (memif_get_external_buffer_offset_t) (void *private_ctx);
 
     Called by slave. Add external region created by client.
 */
-typedef int (memif_add_external_region_t) (void * *addr, uint32_t size,
-					   int *fd, void *private_ctx);
+typedef int(memif_add_external_region_t)(void **addr, uint32_t size, int *fd, void *private_ctx);
 
 /** \brief Get external region address
     @param size - requested region size
@@ -227,8 +219,7 @@ typedef int (memif_add_external_region_t) (void * *addr, uint32_t size,
 
    \return region address
 */
-typedef void *(memif_get_external_region_addr_t) (uint32_t size, int fd,
-						  void *private_ctx);
+typedef void *(memif_get_external_region_addr_t)(uint32_t size, int fd, void *private_ctx);
 
 /** \brief Delete external region
     @param addr - region address
@@ -238,8 +229,7 @@ typedef void *(memif_get_external_region_addr_t) (uint32_t size, int fd,
 
     Delete external region.
 */
-typedef int (memif_del_external_region_t) (void *addr, uint32_t size, int fd,
-					   void *private_ctx);
+typedef int(memif_del_external_region_t)(void *addr, uint32_t size, int fd, void *private_ctx);
 
 /** \brief Register external region
     @param ar - add external region callback
@@ -247,11 +237,10 @@ typedef int (memif_del_external_region_t) (void *addr, uint32_t size, int fd,
     @param dr - delete external region callback
     @param go - get external buffer offset callback (optional)
 */
-void memif_register_external_region (memif_socket_handle_t sock,
-				     memif_add_external_region_t *ar,
-				     memif_get_external_region_addr_t *gr,
-				     memif_del_external_region_t *dr,
-				     memif_get_external_buffer_offset_t *go);
+void memif_register_external_region(memif_socket_handle_t sock, memif_add_external_region_t *ar,
+                                    memif_get_external_region_addr_t *gr,
+                                    memif_del_external_region_t *dr,
+                                    memif_get_external_buffer_offset_t *go);
 
 /** \brief Register external region
     @param pt_main - per thread main handle
@@ -261,15 +250,15 @@ void memif_register_external_region (memif_socket_handle_t sock,
     @param go - get external buffer offset callback (optional)
 
 void memif_per_thread_register_external_region (memif_per_thread_main_handle_t
-						pt_main,
-						memif_add_external_region_t *
-						ar,
-						memif_get_external_region_addr_t
-						* gr,
-						memif_del_external_region_t *
-						dr,
-						memif_get_external_buffer_offset_t
-						* go);
+                                                pt_main,
+                                                memif_add_external_region_t *
+                                                ar,
+                                                memif_get_external_region_addr_t
+                                                * gr,
+                                                memif_del_external_region_t *
+                                                dr,
+                                                memif_get_external_buffer_offset_t
+                                                * go);
 
  @} */
 
@@ -281,11 +270,10 @@ void memif_per_thread_register_external_region (memif_per_thread_main_handle_t
  */
 
 #ifndef _MEMIF_H_
-typedef enum
-{
-  MEMIF_INTERFACE_MODE_ETHERNET = 0,
-  MEMIF_INTERFACE_MODE_IP = 1,
-  MEMIF_INTERFACE_MODE_PUNT_INJECT = 2,
+typedef enum {
+    MEMIF_INTERFACE_MODE_ETHERNET = 0,
+    MEMIF_INTERFACE_MODE_IP = 1,
+    MEMIF_INTERFACE_MODE_PUNT_INJECT = 2,
 } memif_interface_mode_t;
 #endif /* _MEMIF_H_ */
 
@@ -307,25 +295,24 @@ typedef enum
    by user application, all file descriptors and event types will be passed in
     this callback to user application
 */
-typedef struct memif_socket_args
-{
-  char path[108];
-  char app_name[32];
+typedef struct memif_socket_args {
+    char path[108];
+    char app_name[32];
 
-  struct itimerspec connection_request_timer;
+    struct itimerspec connection_request_timer;
 
-  memif_control_fd_update_t *on_control_fd_update;
-  memif_alloc_t *alloc;
-  memif_realloc_t *realloc;
-  memif_free_t *free;
+    memif_control_fd_update_t *on_control_fd_update;
+    memif_alloc_t *alloc;
+    memif_realloc_t *realloc;
+    memif_free_t *free;
 } memif_socket_args_t;
 
 /** \brief Memif connection arguments
     @param socket - Memif socket handle, if NULL default socket will be used.
-		    Default socket is only supported in global database (see memif_init).
-		    Custom database does not create a default socket
-		    (see memif_per_thread_init).
-		    Memif connection is stored in the same database as the socket.
+                    Default socket is only supported in global database (see memif_init).
+                    Custom database does not create a default socket
+                    (see memif_per_thread_init).
+                    Memif connection is stored in the same database as the socket.
     @param secret - optional parameter used as interface authentication
     @param num_s2m_rings - number of slave to master rings
     @param num_m2s_rings - number of master to slave rings
@@ -336,27 +323,25 @@ typedef struct memif_socket_args
     @param interface_name - interface name
     @param mode - 0 == ethernet, 1 == ip , 2 == punt/inject
 */
-typedef struct
-{
-  memif_socket_handle_t socket;	/*!< default = /run/vpp/memif.sock */
-  uint8_t secret[24];		/*!< optional (interface authentication) */
+typedef struct {
+    memif_socket_handle_t socket; /*!< default = /run/vpp/memif.sock */
+    uint8_t secret[24];           /*!< optional (interface authentication) */
 
-  uint8_t num_s2m_rings;	/*!< default = 1 */
-  uint8_t num_m2s_rings;	/*!< default = 1 */
-  uint32_t buffer_size;		/*!< default = 2048 */
-  uint8_t log2_ring_size;	/*!< default = 10 (1024) */
-  uint8_t is_master;
+    uint8_t num_s2m_rings;  /*!< default = 1 */
+    uint8_t num_m2s_rings;  /*!< default = 1 */
+    uint32_t buffer_size;   /*!< default = 2048 */
+    uint8_t log2_ring_size; /*!< default = 10 (1024) */
+    uint8_t is_master;
 
-  uint32_t interface_id;
-  uint8_t interface_name[32];
-  memif_interface_mode_t mode:8;
+    uint32_t interface_id;
+    uint8_t interface_name[32];
+    memif_interface_mode_t mode : 8;
 } memif_conn_args_t;
 
 /*! memif receive mode */
-typedef enum
-{
-  MEMIF_RX_MODE_INTERRUPT = 0,	/*!< interrupt mode */
-  MEMIF_RX_MODE_POLLING		/*!< polling mode */
+typedef enum {
+    MEMIF_RX_MODE_INTERRUPT = 0, /*!< interrupt mode */
+    MEMIF_RX_MODE_POLLING        /*!< polling mode */
 } memif_rx_mode_t;
 
 /** \brief Memif buffer
@@ -366,15 +351,14 @@ typedef enum
     @param flags - memif buffer flags
     @param data - pointer to shared memory data
 */
-typedef struct
-{
-  uint16_t desc_index;
-  void *queue;
-  uint32_t len;
+typedef struct {
+    uint16_t desc_index;
+    void *queue;
+    uint32_t len;
 /** next buffer present (chained buffers) */
 #define MEMIF_BUFFER_FLAG_NEXT (1 << 0)
-  uint8_t flags;
-  void *data;
+    uint8_t flags;
+    void *data;
 } memif_buffer_t;
 /** @} */
 
@@ -394,17 +378,16 @@ typedef struct
     @param tail - ring tail pointer
     @param buffer_size - buffer size on shared memory
 */
-typedef struct
-{
-  uint8_t region;
-  uint16_t qid;
-  uint32_t ring_size;
+typedef struct {
+    uint8_t region;
+    uint16_t qid;
+    uint32_t ring_size;
 /** if set queue is in polling mode, else in interrupt mode */
 #define MEMIF_QUEUE_FLAG_POLLING 1
-  uint16_t flags;
-  uint16_t head;
-  uint16_t tail;
-  uint32_t buffer_size;
+    uint16_t flags;
+    uint16_t head;
+    uint16_t tail;
+    uint32_t buffer_size;
 } memif_queue_details_t;
 
 /** \brief Memif region details
@@ -414,13 +397,12 @@ typedef struct
     @param fd - file descriptor
     @param is_external - if not zero then region is defined by client
 */
-typedef struct
-{
-  uint8_t index;
-  void *addr;
-  uint32_t size;
-  int fd;
-  uint8_t is_external;
+typedef struct {
+    uint8_t index;
+    void *addr;
+    uint32_t size;
+    int fd;
+    uint8_t is_external;
 } memif_region_details_t;
 
 /** \brief Memif details
@@ -442,27 +424,26 @@ typedef struct
     @param error - error string
     @param link_up_down - 1 = up (connected), 2 = down (disconnected)
 */
-typedef struct
-{
-  uint8_t *if_name;
-  uint8_t *inst_name;
-  uint8_t *remote_if_name;
-  uint8_t *remote_inst_name;
+typedef struct {
+    uint8_t *if_name;
+    uint8_t *inst_name;
+    uint8_t *remote_if_name;
+    uint8_t *remote_inst_name;
 
-  uint32_t id;
-  uint8_t *secret;		/* optional */
-  uint8_t role;			/* 0 = master, 1 = slave */
-  uint8_t mode;			/* 0 = ethernet, 1 = ip, 2 = punt/inject */
-  uint8_t *socket_path;
-  uint8_t regions_num;
-  memif_region_details_t *regions;
-  uint8_t rx_queues_num;
-  uint8_t tx_queues_num;
-  memif_queue_details_t *rx_queues;
-  memif_queue_details_t *tx_queues;
+    uint32_t id;
+    uint8_t *secret; /* optional */
+    uint8_t role;    /* 0 = master, 1 = slave */
+    uint8_t mode;    /* 0 = ethernet, 1 = ip, 2 = punt/inject */
+    uint8_t *socket_path;
+    uint8_t regions_num;
+    memif_region_details_t *regions;
+    uint8_t rx_queues_num;
+    uint8_t tx_queues_num;
+    memif_queue_details_t *rx_queues;
+    memif_queue_details_t *tx_queues;
 
-  uint8_t *error;
-  uint8_t link_up_down;		/* 1 = up, 0 = down */
+    uint8_t *error;
+    uint8_t link_up_down; /* 1 = up, 0 = down */
 } memif_details_t;
 /** @} */
 
@@ -477,12 +458,12 @@ typedef struct
 
     \return ((MEMIF_VERSION_MAJOR << 8) | MEMIF_VERSION_MINOR)
 */
-uint16_t memif_get_version (void);
+uint16_t memif_get_version(void);
 
 /** \brief Get memif version as string
     \return major.minor
 */
-const char *memif_get_version_str (void);
+const char *memif_get_version_str(void);
 
 /** \brief Memif get queue event file descriptor
     @param conn - memif connection handle
@@ -492,7 +473,7 @@ const char *memif_get_version_str (void);
     \return memif_err_t
 */
 
-int memif_get_queue_efd (memif_conn_handle_t conn, uint16_t qid, int *fd);
+int memif_get_queue_efd(memif_conn_handle_t conn, uint16_t qid, int *fd);
 
 /** \brief Memif set rx mode
     @param conn - memif connection handle
@@ -501,8 +482,7 @@ int memif_get_queue_efd (memif_conn_handle_t conn, uint16_t qid, int *fd);
 
     \return memif_err_t
 */
-int memif_set_rx_mode (memif_conn_handle_t conn, memif_rx_mode_t rx_mode,
-		       uint16_t qid);
+int memif_set_rx_mode(memif_conn_handle_t conn, memif_rx_mode_t rx_mode, uint16_t qid);
 
 /** \brief Memif strerror
     @param err_code - error code
@@ -511,7 +491,7 @@ int memif_set_rx_mode (memif_conn_handle_t conn, memif_rx_mode_t rx_mode,
 
     \return Error string
 */
-char *memif_strerror (int err_code);
+char *memif_strerror(int err_code);
 
 /** \brief Memif get details
     @param conn - memif connection handle
@@ -521,23 +501,23 @@ char *memif_strerror (int err_code);
 
     \return memif_err_t
 */
-int memif_get_details (memif_conn_handle_t conn, memif_details_t * md,
-		       char *buf, ssize_t buflen);
+int memif_get_details(memif_conn_handle_t conn, memif_details_t *md, char *buf, ssize_t buflen);
 
 /** \brief Memory interface create function
     @param conn - connection handle for client app
     @param args - memory interface connection arguments
     @param on_connect - inform user about connected status
     @param on_disconnect - inform user about disconnected status
-    @param on_interrupt - informs user about interrupt, if set to null user will not be notified about interrupt, user can use memif_get_queue_efd call to get interrupt fd to poll for events
+    @param on_interrupt - informs user about interrupt, if set to null user will not be notified
+   about interrupt, user can use memif_get_queue_efd call to get interrupt fd to poll for events
     @param private_ctx - private context passed back to user with callback
 
     Creates memory interface.
 
     SLAVE-MODE -
-        Start timer that will send events to timerfd. If this fd is passed to memif_control_fd_handler
-        every disconnected memif in slave mode will send connection request.
-        On success new fd is passed to user with memif_control_fd_update_t.
+        Start timer that will send events to timerfd. If this fd is passed to
+   memif_control_fd_handler every disconnected memif in slave mode will send connection request. On
+   success new fd is passed to user with memif_control_fd_update_t.
 
     MASTER-MODE -
         Create listener socket and pass fd to user with memif_control_fd_update_t.
@@ -547,10 +527,9 @@ int memif_get_details (memif_conn_handle_t conn, memif_details_t * md,
 
     \return memif_err_t
 */
-int memif_create (memif_conn_handle_t *conn, memif_conn_args_t *args,
-		  memif_connection_update_t *on_connect,
-		  memif_connection_update_t *on_disconnect,
-		  memif_on_interrupt_t *on_interrupt, void *private_ctx);
+int memif_create(memif_conn_handle_t *conn, memif_conn_args_t *args,
+                 memif_connection_update_t *on_connect, memif_connection_update_t *on_disconnect,
+                 memif_on_interrupt_t *on_interrupt, void *private_ctx);
 
 /** \brief Memif control file descriptor handler
     @param ptr - pointer to event data
@@ -559,7 +538,7 @@ int memif_create (memif_conn_handle_t *conn, memif_conn_args_t *args,
     \return memif_err_t
 
 */
-int memif_control_fd_handler (void *ptr, memif_fd_event_type_t events);
+int memif_control_fd_handler(void *ptr, memif_fd_event_type_t events);
 
 /** \brief Memif delete
     @param conn - pointer to memif connection handle
@@ -570,7 +549,7 @@ int memif_control_fd_handler (void *ptr, memif_fd_event_type_t events);
 
     \return memif_err_t
 */
-int memif_delete (memif_conn_handle_t * conn);
+int memif_delete(memif_conn_handle_t *conn);
 
 /** \brief Memif buffer enq tx
     @param conn - memif connection handle
@@ -585,9 +564,8 @@ int memif_delete (memif_conn_handle_t * conn);
 
     \return memif_err_t
 */
-int memif_buffer_enq_tx (memif_conn_handle_t conn, uint16_t qid,
-			 memif_buffer_t * bufs, uint16_t count,
-			 uint16_t * count_out);
+int memif_buffer_enq_tx(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs,
+                        uint16_t count, uint16_t *count_out);
 
 /** \brief Memif buffer enq tx at idx
     @param conn - memif connection handle
@@ -596,8 +574,7 @@ int memif_buffer_enq_tx (memif_conn_handle_t conn, uint16_t qid,
 
     Swap descriptors for provided buffers and update the buffers
 */
-int memif_buffer_requeue (memif_conn_handle_t conn, memif_buffer_t *buf_a,
-			  memif_buffer_t *buf_b);
+int memif_buffer_requeue(memif_conn_handle_t conn, memif_buffer_t *buf_a, memif_buffer_t *buf_b);
 
 /** \brief Memif buffer alloc
     @param conn - memif connection handle
@@ -609,9 +586,8 @@ int memif_buffer_requeue (memif_conn_handle_t conn, memif_buffer_t *buf_a,
 
     \return memif_err_t
 */
-int memif_buffer_alloc (memif_conn_handle_t conn, uint16_t qid,
-			memif_buffer_t * bufs, uint16_t count,
-			uint16_t * count_out, uint32_t size);
+int memif_buffer_alloc(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs, uint16_t count,
+                       uint16_t *count_out, uint32_t size);
 
 /** \brief Memif set next free buffer
     @param conn - memif connection handle
@@ -621,8 +597,7 @@ int memif_buffer_alloc (memif_conn_handle_t conn, uint16_t qid,
     Sets next free descriptor pointer for specified tx queue.
     The next allocation will happen at this buffer.
 */
-int memif_set_next_free_buffer (memif_conn_handle_t conn, uint16_t qid,
-				memif_buffer_t *buf);
+int memif_set_next_free_buffer(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *buf);
 
 /** \brief Memif refill queue
     @param conn - memif connection handle
@@ -632,8 +607,7 @@ int memif_set_next_free_buffer (memif_conn_handle_t conn, uint16_t qid,
 
     \return memif_err_t
 */
-int memif_refill_queue (memif_conn_handle_t conn, uint16_t qid,
-			uint16_t count, uint16_t headroom);
+int memif_refill_queue(memif_conn_handle_t conn, uint16_t qid, uint16_t count, uint16_t headroom);
 
 /** \brief Memif transmit buffer burst
     @param conn - memif connection handle
@@ -644,8 +618,8 @@ int memif_refill_queue (memif_conn_handle_t conn, uint16_t qid,
 
     \return memif_err_t
 */
-int memif_tx_burst (memif_conn_handle_t conn, uint16_t qid,
-		    memif_buffer_t * bufs, uint16_t count, uint16_t * tx);
+int memif_tx_burst(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs, uint16_t count,
+                   uint16_t *tx);
 
 /** \brief Memif receive buffer burst
     @param conn - memif connection handle
@@ -659,8 +633,8 @@ int memif_tx_burst (memif_conn_handle_t conn, uint16_t qid,
 
     \return memif_err_t
 */
-int memif_rx_burst (memif_conn_handle_t conn, uint16_t qid,
-		    memif_buffer_t * bufs, uint16_t count, uint16_t * rx);
+int memif_rx_burst(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs, uint16_t count,
+                   uint16_t *rx);
 
 /** \brief Memif poll event
     @param sock - socket to poll events on
@@ -672,7 +646,7 @@ int memif_rx_burst (memif_conn_handle_t conn, uint16_t qid,
 
     \return memif_err_t
 */
-int memif_poll_event (memif_socket_handle_t sock, int timeout);
+int memif_poll_event(memif_socket_handle_t sock, int timeout);
 
 /** \brief Send signal to stop concurrently running memif_poll_event().
     @param sock - stop polling on this socket
@@ -688,7 +662,7 @@ int memif_poll_event (memif_socket_handle_t sock, int timeout);
     \return memif_err_t
 */
 #define MEMIF_HAVE_CANCEL_POLL_EVENT 1
-int memif_cancel_poll_event (memif_socket_handle_t sock);
+int memif_cancel_poll_event(memif_socket_handle_t sock);
 
 /** \brief Send connection request
     @param conn - memif connection handle
@@ -697,7 +671,7 @@ int memif_cancel_poll_event (memif_socket_handle_t sock);
 
     \return memif_err_t
 */
-int memif_request_connection (memif_conn_handle_t conn);
+int memif_request_connection(memif_conn_handle_t conn);
 
 /** \brief Create memif socket
     @param sock - socket handle for client app
@@ -713,15 +687,14 @@ int memif_request_connection (memif_conn_handle_t conn);
 
     \return memif_err_t
 */
-int memif_create_socket (memif_socket_handle_t *sock,
-			 memif_socket_args_t *args, void *private_ctx);
+int memif_create_socket(memif_socket_handle_t *sock, memif_socket_args_t *args, void *private_ctx);
 
 /** \brief Get memif socket handle from connection
     @param conn - memif connection handle
 
     \return memif_socket_handle_t
 */
-memif_socket_handle_t memif_get_socket_handle (memif_conn_handle_t conn);
+memif_socket_handle_t memif_get_socket_handle(memif_conn_handle_t conn);
 
 /** \brief Delete memif socket
     @param sock - socket handle for client app
@@ -731,7 +704,7 @@ memif_socket_handle_t memif_get_socket_handle (memif_conn_handle_t conn);
 
     \return memif_err_t
 */
-int memif_delete_socket (memif_socket_handle_t * sock);
+int memif_delete_socket(memif_socket_handle_t *sock);
 
 /** \brief Get socket path
     @param sock - socket handle for client app
@@ -740,14 +713,14 @@ int memif_delete_socket (memif_socket_handle_t * sock);
 
     \return const char *
 */
-const char *memif_get_socket_path (memif_socket_handle_t sock);
+const char *memif_get_socket_path(memif_socket_handle_t sock);
 
 /** \brief Get listener file descriptor
     @param sock - memif socket handle
 
     \return listener fd
 */
-int memif_get_listener_fd (memif_socket_handle_t sock);
+int memif_get_listener_fd(memif_socket_handle_t sock);
 
 /** \brief Set listener file descriptor
     @param sock - memif socket handle
@@ -755,7 +728,7 @@ int memif_get_listener_fd (memif_socket_handle_t sock);
 
     \return memif_err_t
 */
-int memif_set_listener_fd (memif_socket_handle_t sock, int fd);
+int memif_set_listener_fd(memif_socket_handle_t sock, int fd);
 
 /** \brief Set connection request timer value
     @param sock - memif socket handle
@@ -766,8 +739,7 @@ int memif_set_listener_fd (memif_socket_handle_t sock, int fd);
     See system call 'timer_settime' man-page.
     \return memif_err_t
 */
-int memif_set_connection_request_timer (memif_socket_handle_t sock,
-					struct itimerspec timer);
+int memif_set_connection_request_timer(memif_socket_handle_t sock, struct itimerspec timer);
 
 /** @} */
 

--- a/sdk/3rdparty/libmemif/src/main.c
+++ b/sdk/3rdparty/libmemif/src/main.c
@@ -60,124 +60,115 @@
 #define MAX_ERRBUF_LEN 256
 
 #if __x86_x64__
-#define MEMIF_MEMORY_BARRIER() __builtin_ia32_sfence ()
+#define MEMIF_MEMORY_BARRIER() __builtin_ia32_sfence()
 #else
-#define MEMIF_MEMORY_BARRIER() __sync_synchronize ()
+#define MEMIF_MEMORY_BARRIER() __sync_synchronize()
 #endif /* __x86_x64__ */
 
 static char memif_buf[MAX_ERRBUF_LEN];
 
-const char *memif_errlist[ERRLIST_LEN] = {	/* MEMIF_ERR_SUCCESS */
-  "Success.",
-  /* MEMIF_ERR_SYSCALL */
-  "Unspecified syscall error (build with -DMEMIF_DBG or make debug).",
-  /* MEMIF_ERR_CONNREFUSED */
-  "Connection refused",
-  /* MEMIF_ERR_ACCES */
-  "Permission to resource denied.",
-  /* MEMIF_ERR_NO_FILE */
-  "Socket file does not exist",
-  /* MEMIF_ERR_FILE_LIMIT */
-  "System limit on total numer of open files reached.",
-  /* MEMIF_ERR_PROC_FILE_LIMIT */
-  "Per-process limit on total number of open files reached.",
-  /* MEMIF_ERR_ALREADY */
-  "Connection already requested.",
-  /* MEMIF_ERR_AGAIN */
-  "File descriptor refers to file other than socket, or operation would block.",
-  /* MEMIF_ERR_BAD_FD */
-  "Bad file descriptor.",
-  /* MEMIF_ERR_NOMEM */
-  "Out of memory.",
-  /* MEMIF_ERR_INVAL_ARG */
-  "Invalid argument.",
-  /* MEMIF_ERR_NOCONN */
-  "Memif connection handle does not point to existing connection",
-  /* MEMIF_ERR_CONN */
-  "Memif connection handle points to existing connection",
-  /* MEMIF_ERR_CB_FDUPDATE */
-  "Callback memif_control_fd_update_t returned error",
-  /* MEMIF_ERR_FILE_NOT_SOCK */
-  "File specified by socket filename exists and is not socket.",
-  /* MEMIF_ERR_NO_SHMFD */
-  "Missing shared memory file descriptor. (internal error)",
-  /* MEMIF_ERR_COOKIE */
-  "Invalid cookie on ring. (internal error)",
-  /* MEMIF_ERR_NOBUF_RING */
-  "Ring buffer full.",
-  /* MEMIF_ERR_NOBUF */
-  "Not enough memif buffers. There are unreceived data in shared memory.",
-  /* MEMIF_ERR_NOBUF_DET */
-  "Not enough space for memif details in supplied buffer. String data might be malformed.",
-  /* MEMIF_ERR_INT_WRITE */
-  "Send interrupt error.",
-  /* MEMIF_ERR_MFMSG */
-  "Malformed message received on control channel.",
-  /* MEMIF_ERR_QID */
-  "Invalid queue id",
-  /* MEMIF_ERR_PROTO */
-  "Incompatible memory interface protocol version.",
-  /* MEMIF_ERR_ID */
-  "Unmatched interface id.",
-  /* MEMIF_ERR_ACCSLAVE */
-  "Slave cannot accept connection request.",
-  /* MEMIF_ERR_ALRCONN */
-  "Interface is already connected.",
-  /* MEMIF_ERR_MODE */
-  "Mode mismatch.",
-  /* MEMIF_ERR_SECRET */
-  "Secret mismatch.",
-  /* MEMIF_ERR_NOSECRET */
-  "Secret required.",
-  /* MEMIF_ERR_MAXREG */
-  "Limit on total number of regions reached.",
-  /* MEMIF_ERR_MAXRING */
-  "Limit on total number of ring reached.",
-  /* MEMIF_ERR_NO_INTFD */
-  "Missing interrupt file descriptor. (internal error)",
-  /* MEMIF_ERR_DISCONNECT */
-  "Interface received disconnect request.",
-  /* MEMIF_ERR_DISCONNECTED */
-  "Interface is disconnected.",
-  /* MEMIF_ERR_UNKNOWN_MSG */
-  "Unknown message type received on control channel. (internal error)",
-  /* MEMIF_ERR_POLL_CANCEL */
-  "Memif event polling was canceled.",
-  /* MEMIF_ERR_MAX_RING */
-  "Maximum log2 ring size is 15",
-  /* MEMIF_ERR_PRIVHDR */
-  "Private headers not supported."
-};
+const char *memif_errlist[ERRLIST_LEN] =
+    {/* MEMIF_ERR_SUCCESS */
+     "Success.",
+     /* MEMIF_ERR_SYSCALL */
+     "Unspecified syscall error (build with -DMEMIF_DBG or make debug).",
+     /* MEMIF_ERR_CONNREFUSED */
+     "Connection refused",
+     /* MEMIF_ERR_ACCES */
+     "Permission to resource denied.",
+     /* MEMIF_ERR_NO_FILE */
+     "Socket file does not exist",
+     /* MEMIF_ERR_FILE_LIMIT */
+     "System limit on total numer of open files reached.",
+     /* MEMIF_ERR_PROC_FILE_LIMIT */
+     "Per-process limit on total number of open files reached.",
+     /* MEMIF_ERR_ALREADY */
+     "Connection already requested.",
+     /* MEMIF_ERR_AGAIN */
+     "File descriptor refers to file other than socket, or operation would block.",
+     /* MEMIF_ERR_BAD_FD */
+     "Bad file descriptor.",
+     /* MEMIF_ERR_NOMEM */
+     "Out of memory.",
+     /* MEMIF_ERR_INVAL_ARG */
+     "Invalid argument.",
+     /* MEMIF_ERR_NOCONN */
+     "Memif connection handle does not point to existing connection",
+     /* MEMIF_ERR_CONN */
+     "Memif connection handle points to existing connection",
+     /* MEMIF_ERR_CB_FDUPDATE */
+     "Callback memif_control_fd_update_t returned error",
+     /* MEMIF_ERR_FILE_NOT_SOCK */
+     "File specified by socket filename exists and is not socket.",
+     /* MEMIF_ERR_NO_SHMFD */
+     "Missing shared memory file descriptor. (internal error)",
+     /* MEMIF_ERR_COOKIE */
+     "Invalid cookie on ring. (internal error)",
+     /* MEMIF_ERR_NOBUF_RING */
+     "Ring buffer full.",
+     /* MEMIF_ERR_NOBUF */
+     "Not enough memif buffers. There are unreceived data in shared memory.",
+     /* MEMIF_ERR_NOBUF_DET */
+     "Not enough space for memif details in supplied buffer. String data might be malformed.",
+     /* MEMIF_ERR_INT_WRITE */
+     "Send interrupt error.",
+     /* MEMIF_ERR_MFMSG */
+     "Malformed message received on control channel.",
+     /* MEMIF_ERR_QID */
+     "Invalid queue id",
+     /* MEMIF_ERR_PROTO */
+     "Incompatible memory interface protocol version.",
+     /* MEMIF_ERR_ID */
+     "Unmatched interface id.",
+     /* MEMIF_ERR_ACCSLAVE */
+     "Slave cannot accept connection request.",
+     /* MEMIF_ERR_ALRCONN */
+     "Interface is already connected.",
+     /* MEMIF_ERR_MODE */
+     "Mode mismatch.",
+     /* MEMIF_ERR_SECRET */
+     "Secret mismatch.",
+     /* MEMIF_ERR_NOSECRET */
+     "Secret required.",
+     /* MEMIF_ERR_MAXREG */
+     "Limit on total number of regions reached.",
+     /* MEMIF_ERR_MAXRING */
+     "Limit on total number of ring reached.",
+     /* MEMIF_ERR_NO_INTFD */
+     "Missing interrupt file descriptor. (internal error)",
+     /* MEMIF_ERR_DISCONNECT */
+     "Interface received disconnect request.",
+     /* MEMIF_ERR_DISCONNECTED */
+     "Interface is disconnected.",
+     /* MEMIF_ERR_UNKNOWN_MSG */
+     "Unknown message type received on control channel. (internal error)",
+     /* MEMIF_ERR_POLL_CANCEL */
+     "Memif event polling was canceled.",
+     /* MEMIF_ERR_MAX_RING */
+     "Maximum log2 ring size is 15",
+     /* MEMIF_ERR_PRIVHDR */
+     "Private headers not supported."};
 
 #define MEMIF_ERR_UNDEFINED "undefined error"
 
-char *
-memif_strerror (int err_code)
+char *memif_strerror(int err_code)
 {
-  if (err_code >= ERRLIST_LEN)
-    {
-      strlcpy (memif_buf, MEMIF_ERR_UNDEFINED, sizeof (memif_buf));
+    if (err_code >= ERRLIST_LEN) {
+        strlcpy(memif_buf, MEMIF_ERR_UNDEFINED, sizeof(memif_buf));
+    } else {
+        strlcpy(memif_buf, memif_errlist[err_code], sizeof(memif_buf));
+        memif_buf[strlen(memif_errlist[err_code])] = '\0';
     }
-  else
-    {
-      strlcpy (memif_buf, memif_errlist[err_code], sizeof (memif_buf));
-      memif_buf[strlen (memif_errlist[err_code])] = '\0';
-    }
-  return memif_buf;
+    return memif_buf;
 }
 
-uint16_t
-memif_get_version ()
-{
-  return MEMIF_VERSION;
-}
+uint16_t memif_get_version() { return MEMIF_VERSION; }
 
-const char *
-memif_get_version_str ()
+const char *memif_get_version_str()
 {
 #define __STR_HELPER(x) #x
-#define __STR(x)	__STR_HELPER (x)
-  return __STR (MEMIF_VERSION_MAJOR) "." __STR (MEMIF_VERSION_MINOR);
+#define __STR(x) __STR_HELPER(x)
+    return __STR(MEMIF_VERSION_MAJOR) "." __STR(MEMIF_VERSION_MINOR);
 #undef __STR
 #undef __STR_HELPER
 }
@@ -186,1901 +177,1668 @@ memif_get_version_str ()
 #define DBG_RX_BUF (1)
 
 #ifdef MEMIF_DBG_SHM
-static void
-print_bytes (void *data, uint32_t len, uint8_t q)
+static void print_bytes(void *data, uint32_t len, uint8_t q)
 {
-  if (q == DBG_TX_BUF)
-    printf ("\nTX:\n\t");
-  else
-    printf ("\nRX:\n\t");
-  int i;
-  for (i = 0; i < len; i++)
-    {
-      if (i % 8 == 0)
-	printf ("\n%d:\t", i);
-      printf ("%02X ", ((uint8_t *) (data))[i]);
+    if (q == DBG_TX_BUF)
+        printf("\nTX:\n\t");
+    else
+        printf("\nRX:\n\t");
+    int i;
+    for (i = 0; i < len; i++) {
+        if (i % 8 == 0)
+            printf("\n%d:\t", i);
+        printf("%02X ", ((uint8_t *)(data))[i]);
     }
-  printf ("\n\n");
+    printf("\n\n");
 }
 #endif /* MEMIF_DBG_SHM */
 
-int
-memif_syscall_error_handler (int err_code)
+int memif_syscall_error_handler(int err_code)
 {
-  DBG ("%s", strerror (err_code));
+    DBG("%s", strerror(err_code));
 
-  if (err_code == 0)
+    if (err_code == 0)
+        return MEMIF_ERR_SUCCESS;
+    if (err_code == EACCES)
+        return MEMIF_ERR_ACCES;
+    if (err_code == ENFILE)
+        return MEMIF_ERR_FILE_LIMIT;
+    if (err_code == EMFILE)
+        return MEMIF_ERR_PROC_FILE_LIMIT;
+    if (err_code == ENOMEM)
+        return MEMIF_ERR_NOMEM;
+    /* connection refused if master does not exist
+        this error would spam the user until master was created */
+    /*
+      if (err_code == ECONNREFUSED)
+        return MEMIF_ERR_SUCCESS;
+    */
+    if (err_code == ECONNREFUSED)
+        return MEMIF_ERR_CONNREFUSED;
+    if (err_code == EALREADY)
+        return MEMIF_ERR_ALREADY;
+    if (err_code == EAGAIN)
+        return MEMIF_ERR_AGAIN;
+    if (err_code == EBADF)
+        return MEMIF_ERR_BAD_FD;
+    if (err_code == ENOENT)
+        return MEMIF_ERR_NO_FILE;
+
+    /* other syscall errors */
+    return MEMIF_ERR_SYSCALL;
+}
+
+static int memif_add_epoll_fd(memif_socket_t *ms, memif_fd_event_t fde, uint32_t events)
+{
+    if (fde.fd < 0) {
+        DBG("invalid fd %d", fde.fd);
+        return -1;
+    }
+    struct epoll_event evt;
+    memset(&evt, 0, sizeof(evt));
+    evt.events = events;
+    evt.data.ptr = fde.private_ctx;
+    if (epoll_ctl(ms->epfd, EPOLL_CTL_ADD, fde.fd, &evt) < 0) {
+        DBG("epoll_ctl: %s fd %d", strerror(errno), fde.fd);
+        return -1;
+    }
+    DBG("fd %d added to epoll", fde.fd);
+    return 0;
+}
+
+static int memif_mod_epoll_fd(memif_socket_t *ms, memif_fd_event_t fde, uint32_t events)
+{
+    if (fde.fd < 0) {
+        DBG("invalid fd %d", fde.fd);
+        return -1;
+    }
+    struct epoll_event evt;
+    memset(&evt, 0, sizeof(evt));
+    evt.events = events;
+    evt.data.ptr = fde.private_ctx;
+    if (epoll_ctl(ms->epfd, EPOLL_CTL_MOD, fde.fd, &evt) < 0) {
+        DBG("epoll_ctl: %s fd %d", strerror(errno), fde.fd);
+        return -1;
+    }
+    DBG("fd %d modified on epoll", fde.fd);
+    return 0;
+}
+
+static int memif_del_epoll_fd(memif_socket_t *ms, memif_fd_event_t fde)
+{
+    if (fde.fd < 0) {
+        DBG("invalid fd %d", fde.fd);
+        return -1;
+    }
+    struct epoll_event evt;
+    memset(&evt, 0, sizeof(evt));
+    if (epoll_ctl(ms->epfd, EPOLL_CTL_DEL, fde.fd, &evt) < 0) {
+        DBG("epoll_ctl: %s fd %d", strerror(errno), fde.fd);
+        return -1;
+    }
+    DBG("fd %d removed from epoll", fde.fd);
+    return 0;
+}
+
+int memif_control_fd_update(memif_fd_event_t fde, void *private_ctx)
+{
+    memif_socket_t *ms = (memif_socket_t *)private_ctx;
+    int fd;
+
+    if (ms == NULL)
+        return MEMIF_ERR_INVAL_ARG;
+
+    if (fde.type & MEMIF_FD_EVENT_DEL)
+        return memif_del_epoll_fd(ms, fde);
+
+    uint32_t evt = 0;
+    if (fde.type & MEMIF_FD_EVENT_READ)
+        evt |= EPOLLIN;
+    if (fde.type & MEMIF_FD_EVENT_WRITE)
+        evt |= EPOLLOUT;
+
+    if (fde.type & MEMIF_FD_EVENT_MOD)
+        return memif_mod_epoll_fd(ms, fde, evt);
+
+    return memif_add_epoll_fd(ms, fde, evt);
+}
+
+static void memif_control_fd_update_register(memif_socket_t *ms, memif_control_fd_update_t *cb)
+{
+    ms->args.on_control_fd_update = cb;
+}
+
+void memif_register_external_region(memif_socket_handle_t sock, memif_add_external_region_t *ar,
+                                    memif_get_external_region_addr_t *gr,
+                                    memif_del_external_region_t *dr,
+                                    memif_get_external_buffer_offset_t *go)
+{
+    memif_socket_t *ms = (memif_socket_t *)sock;
+    ms->add_external_region = ar;
+    ms->get_external_region_addr = gr;
+    ms->del_external_region = dr;
+    ms->get_external_buffer_offset = go;
+}
+
+static void memif_alloc_register(memif_socket_t *ms, memif_alloc_t *ma) { ms->args.alloc = ma; }
+
+static void memif_realloc_register(memif_socket_t *ms, memif_realloc_t *mr)
+{
+    ms->args.realloc = mr;
+}
+
+static void memif_free_register(memif_socket_t *ms, memif_free_t *mf) { ms->args.free = mf; }
+
+static inline memif_ring_t *memif_get_ring(memif_connection_t *conn, memif_ring_type_t type,
+                                           uint16_t ring_num)
+{
+    if (&conn->regions[0] == NULL)
+        return NULL;
+    void *p = conn->regions[0].addr;
+    int ring_size =
+        sizeof(memif_ring_t) + sizeof(memif_desc_t) * (1 << conn->run_args.log2_ring_size);
+    p += (ring_num + type * conn->run_args.num_s2m_rings) * ring_size;
+
+    return (memif_ring_t *)p;
+}
+
+int memif_set_rx_mode(memif_conn_handle_t c, memif_rx_mode_t rx_mode, uint16_t qid)
+{
+    memif_connection_t *conn = (memif_connection_t *)c;
+    if (conn == NULL)
+        return MEMIF_ERR_NOCONN;
+    uint8_t num =
+        (conn->args.is_master) ? conn->run_args.num_s2m_rings : conn->run_args.num_m2s_rings;
+    if (qid >= num)
+        return MEMIF_ERR_QID;
+
+    conn->rx_queues[qid].ring->flags = rx_mode;
+    DBG("rx_mode flag: %u", conn->rx_queues[qid].ring->flags);
     return MEMIF_ERR_SUCCESS;
-  if (err_code == EACCES)
-    return MEMIF_ERR_ACCES;
-  if (err_code == ENFILE)
-    return MEMIF_ERR_FILE_LIMIT;
-  if (err_code == EMFILE)
-    return MEMIF_ERR_PROC_FILE_LIMIT;
-  if (err_code == ENOMEM)
-    return MEMIF_ERR_NOMEM;
-/* connection refused if master does not exist
-    this error would spam the user until master was created */
-/*
-  if (err_code == ECONNREFUSED)
+}
+
+int memif_poll_cancel_handler(memif_fd_event_type_t type, void *private_ctx)
+{
+    return MEMIF_ERR_POLL_CANCEL;
+}
+
+int memif_connect_handler(memif_fd_event_type_t type, void *private_ctx)
+{
+    memif_socket_t *ms = (memif_socket_t *)private_ctx;
+    memif_connection_t *c;
+
+    if (ms->timer_fd >= 0) {
+        uint64_t u64;
+        ssize_t __attribute__((unused)) r;
+        /*
+          Have to read the timer fd else it stays read-ready
+          and makes epoll_pwait() return without sleeping
+        */
+        r = read(ms->timer_fd, &u64, sizeof(u64));
+    }
+
+    /* loop ms->slave_interfaces and request connection for disconnected ones */
+    TAILQ_FOREACH(c, &ms->slave_interfaces, next)
+    {
+        /* connected or connecting */
+        if (c->control_channel != NULL)
+            continue;
+
+        /* ignore errors */
+        memif_request_connection(c);
+    }
+
     return MEMIF_ERR_SUCCESS;
-*/
-  if (err_code == ECONNREFUSED)
-    return MEMIF_ERR_CONNREFUSED;
-  if (err_code == EALREADY)
-    return MEMIF_ERR_ALREADY;
-  if (err_code == EAGAIN)
-    return MEMIF_ERR_AGAIN;
-  if (err_code == EBADF)
-    return MEMIF_ERR_BAD_FD;
-  if (err_code == ENOENT)
-    return MEMIF_ERR_NO_FILE;
-
-  /* other syscall errors */
-  return MEMIF_ERR_SYSCALL;
 }
 
-static int
-memif_add_epoll_fd (memif_socket_t *ms, memif_fd_event_t fde, uint32_t events)
+int memif_set_connection_request_timer(memif_socket_handle_t sock, struct itimerspec timer)
 {
-  if (fde.fd < 0)
-    {
-      DBG ("invalid fd %d", fde.fd);
-      return -1;
-    }
-  struct epoll_event evt;
-  memset (&evt, 0, sizeof (evt));
-  evt.events = events;
-  evt.data.ptr = fde.private_ctx;
-  if (epoll_ctl (ms->epfd, EPOLL_CTL_ADD, fde.fd, &evt) < 0)
-    {
-      DBG ("epoll_ctl: %s fd %d", strerror (errno), fde.fd);
-      return -1;
-    }
-  DBG ("fd %d added to epoll", fde.fd);
-  return 0;
-}
+    memif_socket_t *ms = (memif_socket_t *)sock;
+    memif_fd_event_t fde;
+    memif_fd_event_data_t *fdata;
+    void *ctx;
 
-static int
-memif_mod_epoll_fd (memif_socket_t *ms, memif_fd_event_t fde, uint32_t events)
-{
-  if (fde.fd < 0)
-    {
-      DBG ("invalid fd %d", fde.fd);
-      return -1;
-    }
-  struct epoll_event evt;
-  memset (&evt, 0, sizeof (evt));
-  evt.events = events;
-  evt.data.ptr = fde.private_ctx;
-  if (epoll_ctl (ms->epfd, EPOLL_CTL_MOD, fde.fd, &evt) < 0)
-    {
-      DBG ("epoll_ctl: %s fd %d", strerror (errno), fde.fd);
-      return -1;
-    }
-  DBG ("fd %d modified on epoll", fde.fd);
-  return 0;
-}
+    if (ms == NULL)
+        return MEMIF_ERR_INVAL_ARG;
 
-static int
-memif_del_epoll_fd (memif_socket_t *ms, memif_fd_event_t fde)
-{
-  if (fde.fd < 0)
-    {
-      DBG ("invalid fd %d", fde.fd);
-      return -1;
-    }
-  struct epoll_event evt;
-  memset (&evt, 0, sizeof (evt));
-  if (epoll_ctl (ms->epfd, EPOLL_CTL_DEL, fde.fd, &evt) < 0)
-    {
-      DBG ("epoll_ctl: %s fd %d", strerror (errno), fde.fd);
-      return -1;
-    }
-  DBG ("fd %d removed from epoll", fde.fd);
-  return 0;
-}
+    if (ms->timer_fd < 0) {
+        /* only create new timer if there is a valid interval */
+        if (timer.it_interval.tv_sec == 0 && timer.it_interval.tv_nsec == 0)
+            return MEMIF_ERR_SUCCESS;
 
-int
-memif_control_fd_update (memif_fd_event_t fde, void *private_ctx)
-{
-  memif_socket_t *ms = (memif_socket_t *) private_ctx;
-  int fd;
+        /* create timerfd */
+        ms->timer_fd = timerfd_create(CLOCK_REALTIME, TFD_NONBLOCK);
+        if (ms->timer_fd < 0)
+            return memif_syscall_error_handler(errno);
 
-  if (ms == NULL)
-    return MEMIF_ERR_INVAL_ARG;
+        /* start listening for events */
+        fdata = ms->args.alloc(sizeof(*fdata));
+        fdata->event_handler = memif_connect_handler;
+        fdata->private_ctx = ms;
 
-  if (fde.type & MEMIF_FD_EVENT_DEL)
-    return memif_del_epoll_fd (ms, fde);
+        fde.fd = ms->timer_fd;
+        fde.type = MEMIF_FD_EVENT_READ;
+        fde.private_ctx = fdata;
 
-  uint32_t evt = 0;
-  if (fde.type & MEMIF_FD_EVENT_READ)
-    evt |= EPOLLIN;
-  if (fde.type & MEMIF_FD_EVENT_WRITE)
-    evt |= EPOLLOUT;
-
-  if (fde.type & MEMIF_FD_EVENT_MOD)
-    return memif_mod_epoll_fd (ms, fde, evt);
-
-  return memif_add_epoll_fd (ms, fde, evt);
-}
-
-static void
-memif_control_fd_update_register (memif_socket_t *ms,
-				  memif_control_fd_update_t *cb)
-{
-  ms->args.on_control_fd_update = cb;
-}
-
-void
-memif_register_external_region (memif_socket_handle_t sock,
-				memif_add_external_region_t *ar,
-				memif_get_external_region_addr_t *gr,
-				memif_del_external_region_t *dr,
-				memif_get_external_buffer_offset_t *go)
-{
-  memif_socket_t *ms = (memif_socket_t *) sock;
-  ms->add_external_region = ar;
-  ms->get_external_region_addr = gr;
-  ms->del_external_region = dr;
-  ms->get_external_buffer_offset = go;
-}
-
-static void
-memif_alloc_register (memif_socket_t *ms, memif_alloc_t *ma)
-{
-  ms->args.alloc = ma;
-}
-
-static void
-memif_realloc_register (memif_socket_t *ms, memif_realloc_t *mr)
-{
-  ms->args.realloc = mr;
-}
-
-static void
-memif_free_register (memif_socket_t *ms, memif_free_t *mf)
-{
-  ms->args.free = mf;
-}
-
-static inline memif_ring_t *
-memif_get_ring (memif_connection_t * conn, memif_ring_type_t type,
-		uint16_t ring_num)
-{
-  if (&conn->regions[0] == NULL)
-    return NULL;
-  void *p = conn->regions[0].addr;
-  int ring_size =
-    sizeof (memif_ring_t) +
-    sizeof (memif_desc_t) * (1 << conn->run_args.log2_ring_size);
-  p += (ring_num + type * conn->run_args.num_s2m_rings) * ring_size;
-
-  return (memif_ring_t *) p;
-}
-
-int
-memif_set_rx_mode (memif_conn_handle_t c, memif_rx_mode_t rx_mode,
-		   uint16_t qid)
-{
-  memif_connection_t *conn = (memif_connection_t *) c;
-  if (conn == NULL)
-    return MEMIF_ERR_NOCONN;
-  uint8_t num =
-    (conn->args.is_master) ? conn->run_args.num_s2m_rings : conn->
-    run_args.num_m2s_rings;
-  if (qid >= num)
-    return MEMIF_ERR_QID;
-
-  conn->rx_queues[qid].ring->flags = rx_mode;
-  DBG ("rx_mode flag: %u", conn->rx_queues[qid].ring->flags);
-  return MEMIF_ERR_SUCCESS;
-}
-
-int
-memif_poll_cancel_handler (memif_fd_event_type_t type, void *private_ctx)
-{
-  return MEMIF_ERR_POLL_CANCEL;
-}
-
-int
-memif_connect_handler (memif_fd_event_type_t type, void *private_ctx)
-{
-  memif_socket_t *ms = (memif_socket_t *) private_ctx;
-  memif_connection_t *c;
-
-  if (ms->timer_fd >= 0)
-    {
-      uint64_t u64;
-      ssize_t __attribute__ ((unused)) r;
-      /*
-	Have to read the timer fd else it stays read-ready
-	and makes epoll_pwait() return without sleeping
-      */
-      r = read (ms->timer_fd, &u64, sizeof (u64));
+        ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+        ms->args.on_control_fd_update(fde, ctx);
     }
 
-  /* loop ms->slave_interfaces and request connection for disconnected ones */
-  TAILQ_FOREACH (c, &ms->slave_interfaces, next)
-  {
-    /* connected or connecting */
-    if (c->control_channel != NULL)
-      continue;
+    ms->args.connection_request_timer = timer;
 
-    /* ignore errors */
-    memif_request_connection (c);
-  }
+    /* arm the timer */
+    if (timerfd_settime(ms->timer_fd, 0, &ms->args.connection_request_timer, NULL) < 0)
+        return memif_syscall_error_handler(errno);
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 }
 
-int
-memif_set_connection_request_timer (memif_socket_handle_t sock,
-				    struct itimerspec timer)
+int memif_create_socket(memif_socket_handle_t *sock, memif_socket_args_t *args, void *private_ctx)
 {
-  memif_socket_t *ms = (memif_socket_t *) sock;
-  memif_fd_event_t fde;
-  memif_fd_event_data_t *fdata;
-  void *ctx;
+    memif_socket_t *ms = (memif_socket_t *)*sock;
+    memif_fd_event_t fde;
+    memif_fd_event_data_t *fdata;
+    int i, err = MEMIF_ERR_SUCCESS;
+    void *ctx;
 
-  if (ms == NULL)
-    return MEMIF_ERR_INVAL_ARG;
-
-  if (ms->timer_fd < 0)
-    {
-      /* only create new timer if there is a valid interval */
-      if (timer.it_interval.tv_sec == 0 && timer.it_interval.tv_nsec == 0)
-	return MEMIF_ERR_SUCCESS;
-
-      /* create timerfd */
-      ms->timer_fd = timerfd_create (CLOCK_REALTIME, TFD_NONBLOCK);
-      if (ms->timer_fd < 0)
-	return memif_syscall_error_handler (errno);
-
-      /* start listening for events */
-      fdata = ms->args.alloc (sizeof (*fdata));
-      fdata->event_handler = memif_connect_handler;
-      fdata->private_ctx = ms;
-
-      fde.fd = ms->timer_fd;
-      fde.type = MEMIF_FD_EVENT_READ;
-      fde.private_ctx = fdata;
-
-      ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-      ms->args.on_control_fd_update (fde, ctx);
-    }
-
-  ms->args.connection_request_timer = timer;
-
-  /* arm the timer */
-  if (timerfd_settime (ms->timer_fd, 0, &ms->args.connection_request_timer,
-		       NULL) < 0)
-    return memif_syscall_error_handler (errno);
-
-  return MEMIF_ERR_SUCCESS;
-}
-
-int
-memif_create_socket (memif_socket_handle_t *sock, memif_socket_args_t *args,
-		     void *private_ctx)
-{
-  memif_socket_t *ms = (memif_socket_t *) * sock;
-  memif_fd_event_t fde;
-  memif_fd_event_data_t *fdata;
-  int i, err = MEMIF_ERR_SUCCESS;
-  void *ctx;
-
-  /* allocate memif_socket_t */
-  ms = NULL;
-  if (args->alloc != NULL)
-    ms = args->alloc (sizeof (memif_socket_t));
-  else
-    ms = malloc (sizeof (memif_socket_t));
-  if (ms == NULL)
-    {
-      err = MEMIF_ERR_NOMEM;
-      goto error;
-    }
-
-  /* default values */
-  memset (ms, 0, sizeof (memif_socket_t));
-  ms->epfd = -1;
-  ms->listener_fd = -1;
-  ms->poll_cancel_fd = -1;
-  ms->timer_fd = -1;
-
-  /* copy arguments to internal struct */
-  memcpy (&ms->args, args, sizeof (*args));
-  ms->private_ctx = private_ctx;
-
-  if (ms->args.alloc == NULL)
-    memif_alloc_register (ms, malloc);
-  if (ms->args.realloc == NULL)
-    memif_realloc_register (ms, realloc);
-  if (ms->args.free == NULL)
-    memif_free_register (ms, free);
-
-  TAILQ_INIT (&ms->master_interfaces);
-  TAILQ_INIT (&ms->slave_interfaces);
-
-  /* FIXME: implement connection request timer */
-
-  /* initialize internal epoll */
-  if (ms->args.on_control_fd_update == NULL)
-    {
-      ms->epfd = epoll_create (1);
-      /* register default fd update callback */
-      memif_control_fd_update_register (ms, memif_control_fd_update);
-      ms->poll_cancel_fd = eventfd (0, EFD_NONBLOCK);
-      if (ms->poll_cancel_fd < 0)
-  {
-    err = errno;
-    DBG ("eventfd: %s", strerror (err));
-    if (args->free != NULL)
-      args->free(ms);
+    /* allocate memif_socket_t */
+    ms = NULL;
+    if (args->alloc != NULL)
+        ms = args->alloc(sizeof(memif_socket_t));
     else
-      free(ms);
-    return memif_syscall_error_handler (err);
-  }
-      /* add interrupt fd to epfd */
-      fdata = ms->args.alloc (sizeof (*fdata));
-      fdata->event_handler = memif_poll_cancel_handler;
-      fdata->private_ctx = ms;
-
-      fde.fd = ms->poll_cancel_fd;
-      fde.type = MEMIF_FD_EVENT_READ;
-      fde.private_ctx = fdata;
-
-      ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-      ms->args.on_control_fd_update (fde, ctx);
+        ms = malloc(sizeof(memif_socket_t));
+    if (ms == NULL) {
+        err = MEMIF_ERR_NOMEM;
+        goto error;
     }
 
-  err =
-    memif_set_connection_request_timer (ms, ms->args.connection_request_timer);
-  if (err != MEMIF_ERR_SUCCESS)
-    goto error;
+    /* default values */
+    memset(ms, 0, sizeof(memif_socket_t));
+    ms->epfd = -1;
+    ms->listener_fd = -1;
+    ms->poll_cancel_fd = -1;
+    ms->timer_fd = -1;
 
-  *sock = ms;
+    /* copy arguments to internal struct */
+    memcpy(&ms->args, args, sizeof(*args));
+    ms->private_ctx = private_ctx;
 
-  return err;
+    if (ms->args.alloc == NULL)
+        memif_alloc_register(ms, malloc);
+    if (ms->args.realloc == NULL)
+        memif_realloc_register(ms, realloc);
+    if (ms->args.free == NULL)
+        memif_free_register(ms, free);
+
+    TAILQ_INIT(&ms->master_interfaces);
+    TAILQ_INIT(&ms->slave_interfaces);
+
+    /* FIXME: implement connection request timer */
+
+    /* initialize internal epoll */
+    if (ms->args.on_control_fd_update == NULL) {
+        ms->epfd = epoll_create(1);
+        /* register default fd update callback */
+        memif_control_fd_update_register(ms, memif_control_fd_update);
+        ms->poll_cancel_fd = eventfd(0, EFD_NONBLOCK);
+        if (ms->poll_cancel_fd < 0) {
+            err = errno;
+            DBG("eventfd: %s", strerror(err));
+            if (args->free != NULL)
+                args->free(ms);
+            else
+                free(ms);
+            return memif_syscall_error_handler(err);
+        }
+        /* add interrupt fd to epfd */
+        fdata = ms->args.alloc(sizeof(*fdata));
+        fdata->event_handler = memif_poll_cancel_handler;
+        fdata->private_ctx = ms;
+
+        fde.fd = ms->poll_cancel_fd;
+        fde.type = MEMIF_FD_EVENT_READ;
+        fde.private_ctx = fdata;
+
+        ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+        ms->args.on_control_fd_update(fde, ctx);
+    }
+
+    err = memif_set_connection_request_timer(ms, ms->args.connection_request_timer);
+    if (err != MEMIF_ERR_SUCCESS)
+        goto error;
+
+    *sock = ms;
+
+    return err;
 
 error:
-  if (ms != NULL)
-    {
-      ms->args.free (ms);
-      if (ms->epfd != -1)
-	close (ms->epfd);
-      if (ms->poll_cancel_fd != -1)
-	close (ms->poll_cancel_fd);
+    if (ms != NULL) {
+        ms->args.free(ms);
+        if (ms->epfd != -1)
+            close(ms->epfd);
+        if (ms->poll_cancel_fd != -1)
+            close(ms->poll_cancel_fd);
     }
-  return err;
+    return err;
 }
 
-memif_socket_handle_t
-memif_get_socket_handle (memif_conn_handle_t conn)
+memif_socket_handle_t memif_get_socket_handle(memif_conn_handle_t conn)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
+    memif_connection_t *c = (memif_connection_t *)conn;
 
-  if (c == NULL)
-    return NULL;
+    if (c == NULL)
+        return NULL;
 
-  return c->args.socket;
+    return c->args.socket;
 }
 
-const char *
-memif_get_socket_path (memif_socket_handle_t sock)
+const char *memif_get_socket_path(memif_socket_handle_t sock)
 {
-  memif_socket_t *ms = (memif_socket_t *) sock;
+    memif_socket_t *ms = (memif_socket_t *)sock;
 
-  if (ms == NULL)
-    return NULL;
+    if (ms == NULL)
+        return NULL;
 
-  return ms->args.path;
+    return ms->args.path;
 }
 
-int
-memif_get_listener_fd (memif_socket_handle_t sock)
+int memif_get_listener_fd(memif_socket_handle_t sock)
 {
-  memif_socket_t *ms = (memif_socket_t *) sock;
+    memif_socket_t *ms = (memif_socket_t *)sock;
 
-  if (ms == NULL)
-    return -1;
+    if (ms == NULL)
+        return -1;
 
-  return ms->listener_fd;
+    return ms->listener_fd;
 }
 
-int
-memif_set_listener_fd (memif_socket_handle_t sock, int fd)
+int memif_set_listener_fd(memif_socket_handle_t sock, int fd)
 {
-  memif_socket_t *ms = (memif_socket_t *) sock;
-  memif_fd_event_t fde;
-  memif_fd_event_data_t *fdata;
-  void *ctx;
+    memif_socket_t *ms = (memif_socket_t *)sock;
+    memif_fd_event_t fde;
+    memif_fd_event_data_t *fdata;
+    void *ctx;
 
-  if ((ms == NULL) || (fd < 0))
-    return MEMIF_ERR_INVAL_ARG;
+    if ((ms == NULL) || (fd < 0))
+        return MEMIF_ERR_INVAL_ARG;
 
-  fdata = ms->args.alloc (sizeof (*fdata));
-  if (fdata == NULL)
-    return MEMIF_ERR_NOMEM;
+    fdata = ms->args.alloc(sizeof(*fdata));
+    if (fdata == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  ms->listener_fd = fd;
+    ms->listener_fd = fd;
 
-  fdata->event_handler = memif_listener_handler;
-  fdata->private_ctx = ms;
-  ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-  /* send fd to epoll */
-  fde.fd = ms->listener_fd;
-  fde.type = MEMIF_FD_EVENT_READ;
-  fde.private_ctx = fdata;
-  ms->args.on_control_fd_update (fde, ctx);
+    fdata->event_handler = memif_listener_handler;
+    fdata->private_ctx = ms;
+    ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+    /* send fd to epoll */
+    fde.fd = ms->listener_fd;
+    fde.type = MEMIF_FD_EVENT_READ;
+    fde.private_ctx = fdata;
+    ms->args.on_control_fd_update(fde, ctx);
 
-  return MEMIF_ERR_SUCCESS;
-}
-
-int
-memif_create (memif_conn_handle_t *c, memif_conn_args_t *args,
-	      memif_connection_update_t *on_connect,
-	      memif_connection_update_t *on_disconnect,
-	      memif_on_interrupt_t *on_interrupt, void *private_ctx)
-{
-  int err, index = 0;
-  memif_connection_t *conn = (memif_connection_t *) * c;
-  memif_socket_t *ms = (memif_socket_t *) args->socket;
-
-  if (conn != NULL)
-    {
-      DBG ("This handle already points to existing memif.");
-      return MEMIF_ERR_CONN;
-    }
-
-  if (ms == NULL)
-    {
-      DBG ("Missing memif socket");
-      return MEMIF_ERR_INVAL_ARG;
-    }
-
-  conn = (memif_connection_t *) ms->args.alloc (sizeof (*conn));
-  if (conn == NULL)
-    {
-      err = MEMIF_ERR_NOMEM;
-      goto error;
-    }
-  memset (conn, 0, sizeof (memif_connection_t));
-
-  conn->args.interface_id = args->interface_id;
-
-  if (args->log2_ring_size == 0)
-    args->log2_ring_size = MEMIF_DEFAULT_LOG2_RING_SIZE;
-  else if (args->log2_ring_size > MEMIF_MAX_LOG2_RING_SIZE)
-    {
-      err = MEMIF_ERR_MAX_RING;
-      goto error;
-    }
-  if (args->buffer_size == 0)
-    args->buffer_size = MEMIF_DEFAULT_BUFFER_SIZE;
-  if (args->num_s2m_rings == 0)
-    args->num_s2m_rings = MEMIF_DEFAULT_TX_QUEUES;
-  if (args->num_m2s_rings == 0)
-    args->num_m2s_rings = MEMIF_DEFAULT_RX_QUEUES;
-
-  conn->args.num_s2m_rings = args->num_s2m_rings;
-  conn->args.num_m2s_rings = args->num_m2s_rings;
-  conn->args.buffer_size = args->buffer_size;
-  conn->args.log2_ring_size = args->log2_ring_size;
-  conn->args.is_master = args->is_master;
-  conn->args.mode = args->mode;
-  conn->args.socket = args->socket;
-  conn->regions = NULL;
-  conn->tx_queues = NULL;
-  conn->rx_queues = NULL;
-  conn->control_channel = NULL;
-  conn->on_connect = on_connect;
-  conn->on_disconnect = on_disconnect;
-  conn->on_interrupt = on_interrupt;
-  conn->private_ctx = private_ctx;
-  memset (&conn->run_args, 0, sizeof (memif_conn_run_args_t));
-
-  uint8_t l = sizeof (conn->args.interface_name);
-  strlcpy ((char *) conn->args.interface_name, (char *) args->interface_name,
-	   l);
-
-  if ((l = strlen ((char *) args->secret)) > 0)
-    strlcpy ((char *) conn->args.secret, (char *) args->secret,
-	     sizeof (conn->args.secret));
-
-  if (args->is_master)
-    TAILQ_INSERT_TAIL (&ms->master_interfaces, conn, next);
-  else
-    TAILQ_INSERT_TAIL (&ms->slave_interfaces, conn, next);
-
-  err = memif_request_connection (conn);
-  if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_CONNREFUSED)
-    {
-      if (args->is_master)
-	TAILQ_REMOVE (&ms->master_interfaces, conn, next);
-      else
-	TAILQ_REMOVE (&ms->slave_interfaces, conn, next);
-      goto error;
-    }
-
-  *c = conn;
-
-  return 0;
-
-error:
-  if (conn != NULL)
-    ms->args.free (conn);
-  *c = conn = NULL;
-  return err;
-}
-
-static inline int
-memif_path_is_abstract (const char *filename)
-{
-  return (filename[0] == '@');
-}
-
-int
-memif_request_connection (memif_conn_handle_t c)
-{
-  memif_connection_t *conn = (memif_connection_t *) c;
-  memif_socket_t *ms;
-  int err = MEMIF_ERR_SUCCESS;
-  int sockfd = -1;
-  struct sockaddr_un un = { 0 };
-  struct stat file_stat;
-  int on = 1;
-  memif_control_channel_t *cc = NULL;
-  memif_fd_event_t fde;
-  memif_fd_event_data_t *fdata = NULL;
-  int sunlen = sizeof (un);
-  void *ctx;
-
-  if (conn == NULL)
-    return MEMIF_ERR_NOCONN;
-
-  ms = (memif_socket_t *) conn->args.socket;
-
-  /* if control channel is assigned, the interface is either connected or
-   * connecting */
-  if (conn->control_channel != NULL)
-    return MEMIF_ERR_ALRCONN;
-  /* if interface is master and the socket is already listener we are done */
-  if (conn->args.is_master && (ms->listener_fd != -1))
     return MEMIF_ERR_SUCCESS;
+}
 
-  sockfd = socket (AF_UNIX, SOCK_SEQPACKET, 0);
-  if (sockfd < 0)
-    {
-      err = memif_syscall_error_handler (errno);
-      goto error;
+int memif_create(memif_conn_handle_t *c, memif_conn_args_t *args,
+                 memif_connection_update_t *on_connect, memif_connection_update_t *on_disconnect,
+                 memif_on_interrupt_t *on_interrupt, void *private_ctx)
+{
+    int err, index = 0;
+    memif_connection_t *conn = (memif_connection_t *)*c;
+    memif_socket_t *ms = (memif_socket_t *)args->socket;
+
+    if (conn != NULL) {
+        DBG("This handle already points to existing memif.");
+        return MEMIF_ERR_CONN;
     }
 
-  un.sun_family = AF_UNIX;
-
-  /* use memcpy to support abstract socket
-   * ms->args.path is already a valid socket path
-   */
-  memcpy (un.sun_path, ms->args.path, sizeof (un.sun_path) - 1);
-
-  /* allocate fd event data */
-  fdata = ms->args.alloc (sizeof (*fdata));
-  if (fdata == NULL)
-    {
-      err = MEMIF_ERR_NOMEM;
-      goto error;
+    if (ms == NULL) {
+        DBG("Missing memif socket");
+        return MEMIF_ERR_INVAL_ARG;
     }
 
-  if (memif_path_is_abstract (ms->args.path))
-    {
-      /* Ensure the string is NULL terminated */
-      un.sun_path[sizeof (un.sun_path) - 1] = '\0';
-      /* sunlen is strlen(un.sun_path) + sizeof(un.sun_family) */
-      sunlen = strlen (un.sun_path) + (sizeof (un) - sizeof (un.sun_path));
-      /* Handle abstract socket by converting '@' -> '\0' */
-      un.sun_path[0] = '\0';
+    conn = (memif_connection_t *)ms->args.alloc(sizeof(*conn));
+    if (conn == NULL) {
+        err = MEMIF_ERR_NOMEM;
+        goto error;
+    }
+    memset(conn, 0, sizeof(memif_connection_t));
+
+    conn->args.interface_id = args->interface_id;
+
+    if (args->log2_ring_size == 0)
+        args->log2_ring_size = MEMIF_DEFAULT_LOG2_RING_SIZE;
+    else if (args->log2_ring_size > MEMIF_MAX_LOG2_RING_SIZE) {
+        err = MEMIF_ERR_MAX_RING;
+        goto error;
+    }
+    if (args->buffer_size == 0)
+        args->buffer_size = MEMIF_DEFAULT_BUFFER_SIZE;
+    if (args->num_s2m_rings == 0)
+        args->num_s2m_rings = MEMIF_DEFAULT_TX_QUEUES;
+    if (args->num_m2s_rings == 0)
+        args->num_m2s_rings = MEMIF_DEFAULT_RX_QUEUES;
+
+    conn->args.num_s2m_rings = args->num_s2m_rings;
+    conn->args.num_m2s_rings = args->num_m2s_rings;
+    conn->args.buffer_size = args->buffer_size;
+    conn->args.log2_ring_size = args->log2_ring_size;
+    conn->args.is_master = args->is_master;
+    conn->args.mode = args->mode;
+    conn->args.socket = args->socket;
+    conn->regions = NULL;
+    conn->tx_queues = NULL;
+    conn->rx_queues = NULL;
+    conn->control_channel = NULL;
+    conn->on_connect = on_connect;
+    conn->on_disconnect = on_disconnect;
+    conn->on_interrupt = on_interrupt;
+    conn->private_ctx = private_ctx;
+    memset(&conn->run_args, 0, sizeof(memif_conn_run_args_t));
+
+    uint8_t l = sizeof(conn->args.interface_name);
+    strlcpy((char *)conn->args.interface_name, (char *)args->interface_name, l);
+
+    if ((l = strlen((char *)args->secret)) > 0)
+        strlcpy((char *)conn->args.secret, (char *)args->secret, sizeof(conn->args.secret));
+
+    if (args->is_master)
+        TAILQ_INSERT_TAIL(&ms->master_interfaces, conn, next);
+    else
+        TAILQ_INSERT_TAIL(&ms->slave_interfaces, conn, next);
+
+    err = memif_request_connection(conn);
+    if (err != MEMIF_ERR_SUCCESS && err != MEMIF_ERR_CONNREFUSED) {
+        if (args->is_master)
+            TAILQ_REMOVE(&ms->master_interfaces, conn, next);
+        else
+            TAILQ_REMOVE(&ms->slave_interfaces, conn, next);
+        goto error;
     }
 
-  if (conn->args.is_master != 0)
-    {
-      /* Configure socket optins */
-      if (setsockopt (sockfd, SOL_SOCKET, SO_PASSCRED, &on, sizeof (on)) < 0)
-	{
-	  err = memif_syscall_error_handler (errno);
-	  goto error;
-	}
-      if (bind (sockfd, (struct sockaddr *) &un, sunlen) < 0)
-	{
-	  err = memif_syscall_error_handler (errno);
-	  goto error;
-	}
-      if (listen (sockfd, 1) < 0)
-	{
-	  err = memif_syscall_error_handler (errno);
-	  goto error;
-	}
-      if (!memif_path_is_abstract (ms->args.path))
-	{
-	  /* Verify that the socket was created */
-	  if (stat ((char *) ms->args.path, &file_stat) < 0)
-	    {
-	      err = memif_syscall_error_handler (errno);
-	      goto error;
-	    }
-	}
+    *c = conn;
 
-      /* assign listener fd */
-      ms->listener_fd = sockfd;
-
-      fdata->event_handler = memif_listener_handler;
-      fdata->private_ctx = ms;
-    }
-  else
-    {
-      cc = ms->args.alloc (sizeof (*cc));
-      if (cc == NULL)
-	{
-	  err = MEMIF_ERR_NOMEM;
-	  goto error;
-	}
-      if (connect (sockfd, (struct sockaddr *) &un, sunlen) != 0)
-	{
-	  err = MEMIF_ERR_CONNREFUSED;
-	  goto error;
-	}
-
-      /* Create control channel */
-      cc->fd = sockfd;
-      cc->sock = ms;
-      cc->conn = conn;
-      TAILQ_INIT (&cc->msg_queue);
-
-      /* assign control channel to endpoint */
-      conn->control_channel = cc;
-
-      fdata->event_handler = memif_control_channel_handler;
-      fdata->private_ctx = cc;
-    }
-
-  /* if event polling is done internally, send memif socket as context */
-  ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-  /* send fd to epoll */
-  fde.fd = sockfd;
-  fde.type = MEMIF_FD_EVENT_READ;
-  fde.private_ctx = fdata;
-  ms->args.on_control_fd_update (fde, ctx);
-
-  return err;
+    return 0;
 
 error:
-  if (sockfd >= 0)
-    close (sockfd);
-  sockfd = -1;
-  if (fdata != NULL)
-    ms->args.free (fdata);
-  fdata = NULL;
-  if (cc != NULL)
-    ms->args.free (cc);
-  conn->control_channel = cc = NULL;
-  return err;
+    if (conn != NULL)
+        ms->args.free(conn);
+    *c = conn = NULL;
+    return err;
 }
 
-int
-memif_control_fd_handler (void *ptr, memif_fd_event_type_t events)
+static inline int memif_path_is_abstract(const char *filename) { return (filename[0] == '@'); }
+
+int memif_request_connection(memif_conn_handle_t c)
 {
-  memif_fd_event_data_t *fdata = (memif_fd_event_data_t *) ptr;
+    memif_connection_t *conn = (memif_connection_t *)c;
+    memif_socket_t *ms;
+    int err = MEMIF_ERR_SUCCESS;
+    int sockfd = -1;
+    struct sockaddr_un un = {0};
+    struct stat file_stat;
+    int on = 1;
+    memif_control_channel_t *cc = NULL;
+    memif_fd_event_t fde;
+    memif_fd_event_data_t *fdata = NULL;
+    int sunlen = sizeof(un);
+    void *ctx;
 
-  if (fdata == NULL)
-    return MEMIF_ERR_INVAL_ARG;
+    if (conn == NULL)
+        return MEMIF_ERR_NOCONN;
 
-  return fdata->event_handler (events, fdata->private_ctx);
-}
+    ms = (memif_socket_t *)conn->args.socket;
 
-int
-memif_interrupt_handler (memif_fd_event_type_t type, void *private_ctx)
-{
-  memif_interrupt_t *idata = (memif_interrupt_t *) private_ctx;
+    /* if control channel is assigned, the interface is either connected or
+     * connecting */
+    if (conn->control_channel != NULL)
+        return MEMIF_ERR_ALRCONN;
+    /* if interface is master and the socket is already listener we are done */
+    if (conn->args.is_master && (ms->listener_fd != -1))
+        return MEMIF_ERR_SUCCESS;
 
-  if (idata == NULL)
-    return MEMIF_ERR_INVAL_ARG;
-
-  return idata->c->on_interrupt (idata->c, idata->c->private_ctx, idata->qid);
-}
-
-int
-memif_poll_event (memif_socket_handle_t sock, int timeout)
-{
-  memif_socket_t *ms = (memif_socket_t *) sock;
-  struct epoll_event evt;
-  int en = 0, err = MEMIF_ERR_SUCCESS;	/* 0 */
-  memif_fd_event_type_t events = 0;
-  uint64_t counter = 0;
-  ssize_t r = 0;
-  sigset_t sigset;
-
-  if (ms == NULL)
-    return MEMIF_ERR_INVAL_ARG;
-
-  memset (&evt, 0, sizeof (evt));
-  evt.events = EPOLLIN | EPOLLOUT;
-  sigemptyset (&sigset);
-  en = epoll_pwait (ms->epfd, &evt, 1, timeout, &sigset);
-  if (en < 0)
-    {
-      err = errno;
-      DBG ("epoll_pwait: %s", strerror (err));
-      return memif_syscall_error_handler (err);
+    sockfd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (sockfd < 0) {
+        err = memif_syscall_error_handler(errno);
+        goto error;
     }
-  if (en > 0)
-    {
-      if (evt.events & EPOLLIN)
-	events |= MEMIF_FD_EVENT_READ;
-      if (evt.events & EPOLLOUT)
-	events |= MEMIF_FD_EVENT_WRITE;
-      if (evt.events & EPOLLERR)
-	events |= MEMIF_FD_EVENT_ERROR;
-      return memif_control_fd_handler (evt.data.ptr, events);
+
+    un.sun_family = AF_UNIX;
+
+    /* use memcpy to support abstract socket
+     * ms->args.path is already a valid socket path
+     */
+    memcpy(un.sun_path, ms->args.path, sizeof(un.sun_path) - 1);
+
+    /* allocate fd event data */
+    fdata = ms->args.alloc(sizeof(*fdata));
+    if (fdata == NULL) {
+        err = MEMIF_ERR_NOMEM;
+        goto error;
     }
-  return MEMIF_ERR_SUCCESS;
+
+    if (memif_path_is_abstract(ms->args.path)) {
+        /* Ensure the string is NULL terminated */
+        un.sun_path[sizeof(un.sun_path) - 1] = '\0';
+        /* sunlen is strlen(un.sun_path) + sizeof(un.sun_family) */
+        sunlen = strlen(un.sun_path) + (sizeof(un) - sizeof(un.sun_path));
+        /* Handle abstract socket by converting '@' -> '\0' */
+        un.sun_path[0] = '\0';
+    }
+
+    if (conn->args.is_master != 0) {
+        /* Configure socket optins */
+        if (setsockopt(sockfd, SOL_SOCKET, SO_PASSCRED, &on, sizeof(on)) < 0) {
+            err = memif_syscall_error_handler(errno);
+            goto error;
+        }
+        if (bind(sockfd, (struct sockaddr *)&un, sunlen) < 0) {
+            err = memif_syscall_error_handler(errno);
+            goto error;
+        }
+        if (listen(sockfd, 1) < 0) {
+            err = memif_syscall_error_handler(errno);
+            goto error;
+        }
+        if (!memif_path_is_abstract(ms->args.path)) {
+            /* Verify that the socket was created */
+            if (stat((char *)ms->args.path, &file_stat) < 0) {
+                err = memif_syscall_error_handler(errno);
+                goto error;
+            }
+        }
+
+        /* assign listener fd */
+        ms->listener_fd = sockfd;
+
+        fdata->event_handler = memif_listener_handler;
+        fdata->private_ctx = ms;
+    } else {
+        cc = ms->args.alloc(sizeof(*cc));
+        if (cc == NULL) {
+            err = MEMIF_ERR_NOMEM;
+            goto error;
+        }
+        if (connect(sockfd, (struct sockaddr *)&un, sunlen) != 0) {
+            err = MEMIF_ERR_CONNREFUSED;
+            goto error;
+        }
+
+        /* Create control channel */
+        cc->fd = sockfd;
+        cc->sock = ms;
+        cc->conn = conn;
+        TAILQ_INIT(&cc->msg_queue);
+
+        /* assign control channel to endpoint */
+        conn->control_channel = cc;
+
+        fdata->event_handler = memif_control_channel_handler;
+        fdata->private_ctx = cc;
+    }
+
+    /* if event polling is done internally, send memif socket as context */
+    ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+    /* send fd to epoll */
+    fde.fd = sockfd;
+    fde.type = MEMIF_FD_EVENT_READ;
+    fde.private_ctx = fdata;
+    ms->args.on_control_fd_update(fde, ctx);
+
+    return err;
+
+error:
+    if (sockfd >= 0)
+        close(sockfd);
+    sockfd = -1;
+    if (fdata != NULL)
+        ms->args.free(fdata);
+    fdata = NULL;
+    if (cc != NULL)
+        ms->args.free(cc);
+    conn->control_channel = cc = NULL;
+    return err;
 }
 
-int
-memif_cancel_poll_event (memif_socket_handle_t sock)
+int memif_control_fd_handler(void *ptr, memif_fd_event_type_t events)
 {
-  memif_socket_t *ms = (memif_socket_t *) sock;
-  uint64_t counter = 1;
-  ssize_t w = 0;
+    memif_fd_event_data_t *fdata = (memif_fd_event_data_t *)ptr;
 
-  if (ms->poll_cancel_fd == -1)
-    return MEMIF_ERR_INVAL_ARG;
-  w = write (ms->poll_cancel_fd, &counter, sizeof (counter));
-  if (w < sizeof (counter))
-    return MEMIF_ERR_INT_WRITE;
+    if (fdata == NULL)
+        return MEMIF_ERR_INVAL_ARG;
 
-  return MEMIF_ERR_SUCCESS;
+    return fdata->event_handler(events, fdata->private_ctx);
 }
 
-void
-memif_close_queues (memif_socket_t *ms, memif_queue_t *queues, int nqueues)
+int memif_interrupt_handler(memif_fd_event_type_t type, void *private_ctx)
 {
-  memif_fd_event_t fde = {};
-  memif_queue_t *mq;
-  void *ctx;
+    memif_interrupt_t *idata = (memif_interrupt_t *)private_ctx;
 
-  int i;
-  for (i = 0; i < nqueues; i++)
-    {
-      mq = &queues[i];
-      if (mq != NULL)
-	{
-	  if (mq->int_fd > 0)
-	    {
-	      /* Stop listening for events */
-	      fde.fd = mq->int_fd;
-	      fde.type = MEMIF_FD_EVENT_DEL;
-	      ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-	      ms->args.on_control_fd_update (fde, ctx);
-	      close (mq->int_fd);
-	    }
-	  mq->int_fd = -1;
-	}
+    if (idata == NULL)
+        return MEMIF_ERR_INVAL_ARG;
+
+    return idata->c->on_interrupt(idata->c, idata->c->private_ctx, idata->qid);
+}
+
+int memif_poll_event(memif_socket_handle_t sock, int timeout)
+{
+    memif_socket_t *ms = (memif_socket_t *)sock;
+    struct epoll_event evt;
+    int en = 0, err = MEMIF_ERR_SUCCESS; /* 0 */
+    memif_fd_event_type_t events = 0;
+    uint64_t counter = 0;
+    ssize_t r = 0;
+    sigset_t sigset;
+
+    if (ms == NULL)
+        return MEMIF_ERR_INVAL_ARG;
+
+    memset(&evt, 0, sizeof(evt));
+    evt.events = EPOLLIN | EPOLLOUT;
+    sigemptyset(&sigset);
+    en = epoll_pwait(ms->epfd, &evt, 1, timeout, &sigset);
+    if (en < 0) {
+        err = errno;
+        DBG("epoll_pwait: %s", strerror(err));
+        return memif_syscall_error_handler(err);
+    }
+    if (en > 0) {
+        if (evt.events & EPOLLIN)
+            events |= MEMIF_FD_EVENT_READ;
+        if (evt.events & EPOLLOUT)
+            events |= MEMIF_FD_EVENT_WRITE;
+        if (evt.events & EPOLLERR)
+            events |= MEMIF_FD_EVENT_ERROR;
+        return memif_control_fd_handler(evt.data.ptr, events);
+    }
+    return MEMIF_ERR_SUCCESS;
+}
+
+int memif_cancel_poll_event(memif_socket_handle_t sock)
+{
+    memif_socket_t *ms = (memif_socket_t *)sock;
+    uint64_t counter = 1;
+    ssize_t w = 0;
+
+    if (ms->poll_cancel_fd == -1)
+        return MEMIF_ERR_INVAL_ARG;
+    w = write(ms->poll_cancel_fd, &counter, sizeof(counter));
+    if (w < sizeof(counter))
+        return MEMIF_ERR_INT_WRITE;
+
+    return MEMIF_ERR_SUCCESS;
+}
+
+void memif_close_queues(memif_socket_t *ms, memif_queue_t *queues, int nqueues)
+{
+    memif_fd_event_t fde = {};
+    memif_queue_t *mq;
+    void *ctx;
+
+    int i;
+    for (i = 0; i < nqueues; i++) {
+        mq = &queues[i];
+        if (mq != NULL) {
+            if (mq->int_fd > 0) {
+                /* Stop listening for events */
+                fde.fd = mq->int_fd;
+                fde.type = MEMIF_FD_EVENT_DEL;
+                ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+                ms->args.on_control_fd_update(fde, ctx);
+                close(mq->int_fd);
+            }
+            mq->int_fd = -1;
+        }
     }
 }
 
 /* send disconnect msg and close interface */
-int
-memif_disconnect_internal (memif_connection_t * c)
+int memif_disconnect_internal(memif_connection_t *c)
 {
-  int err = MEMIF_ERR_SUCCESS, i;	/* 0 */
-  memif_queue_t *mq;
-  memif_socket_t *ms = (memif_socket_t *) c->args.socket;
-  memif_fd_event_t fde;
-  void *ctx;
+    int err = MEMIF_ERR_SUCCESS, i; /* 0 */
+    memif_queue_t *mq;
+    memif_socket_t *ms = (memif_socket_t *)c->args.socket;
+    memif_fd_event_t fde;
+    void *ctx;
 
-  c->on_disconnect ((void *) c, c->private_ctx);
+    c->on_disconnect((void *)c, c->private_ctx);
 
-  /* Delete control channel */
-  if (c->control_channel != NULL)
-    memif_delete_control_channel (c->control_channel);
+    /* Delete control channel */
+    if (c->control_channel != NULL)
+        memif_delete_control_channel(c->control_channel);
 
-  if (c->tx_queues != NULL)
-    {
-      memif_close_queues (ms, c->tx_queues, c->tx_queues_num);
-      ms->args.free (c->tx_queues);
-      c->tx_queues = NULL;
+    if (c->tx_queues != NULL) {
+        memif_close_queues(ms, c->tx_queues, c->tx_queues_num);
+        ms->args.free(c->tx_queues);
+        c->tx_queues = NULL;
     }
-  c->tx_queues_num = 0;
+    c->tx_queues_num = 0;
 
-  if (c->rx_queues != NULL)
-    {
-      memif_close_queues (ms, c->rx_queues, c->rx_queues_num);
-      ms->args.free (c->rx_queues);
-      c->rx_queues = NULL;
+    if (c->rx_queues != NULL) {
+        memif_close_queues(ms, c->rx_queues, c->rx_queues_num);
+        ms->args.free(c->rx_queues);
+        c->rx_queues = NULL;
     }
-  c->rx_queues_num = 0;
+    c->rx_queues_num = 0;
 
-  /* TODO: Slave reuse regions */
+    /* TODO: Slave reuse regions */
 
-  for (i = 0; i < c->regions_num; i++)
-    {
-      if (&c->regions[i] == NULL)
-	continue;
-      if (c->regions[i].is_external != 0)
-	{
-	  ms->del_external_region (c->regions[i].addr,
-				   c->regions[i].region_size, c->regions[i].fd,
-				   c->private_ctx);
-	}
-      else
-	{
-	  if (munmap (c->regions[i].addr, c->regions[i].region_size) < 0)
-	    return memif_syscall_error_handler (errno);
-	  if (c->regions[i].fd > 0)
-	    close (c->regions[i].fd);
-	  c->regions[i].fd = -1;
-	}
+    for (i = 0; i < c->regions_num; i++) {
+        if (&c->regions[i] == NULL)
+            continue;
+        if (c->regions[i].is_external != 0) {
+            ms->del_external_region(c->regions[i].addr, c->regions[i].region_size, c->regions[i].fd,
+                                    c->private_ctx);
+        } else {
+            if (munmap(c->regions[i].addr, c->regions[i].region_size) < 0)
+                return memif_syscall_error_handler(errno);
+            if (c->regions[i].fd > 0)
+                close(c->regions[i].fd);
+            c->regions[i].fd = -1;
+        }
     }
-  ms->args.free (c->regions);
-  c->regions = NULL;
-  c->regions_num = 0;
+    ms->args.free(c->regions);
+    c->regions = NULL;
+    c->regions_num = 0;
 
-  memset (&c->run_args, 0, sizeof (memif_conn_run_args_t));
+    memset(&c->run_args, 0, sizeof(memif_conn_run_args_t));
 
-  return err;
+    return err;
 }
 
-const char *
-memif_get_socket_filename (memif_socket_handle_t sock)
+const char *memif_get_socket_filename(memif_socket_handle_t sock)
 {
-  memif_socket_t *ms = (memif_socket_t *) sock;
+    memif_socket_t *ms = (memif_socket_t *)sock;
 
-  if (ms == NULL)
-    return NULL;
+    if (ms == NULL)
+        return NULL;
 
-  return (char *) ms->args.path;
+    return (char *)ms->args.path;
 }
 
-int
-memif_delete_socket (memif_socket_handle_t * sock)
+int memif_delete_socket(memif_socket_handle_t *sock)
 {
-  memif_socket_t *ms = (memif_socket_t *) * sock;
-  memif_fd_event_t fde = {};
-  void *ctx;
+    memif_socket_t *ms = (memif_socket_t *)*sock;
+    memif_fd_event_t fde = {};
+    void *ctx;
 
-  /* check if socket is in use */
-  if (ms == NULL || !TAILQ_EMPTY (&ms->master_interfaces) ||
-      !TAILQ_EMPTY (&ms->slave_interfaces))
-    return MEMIF_ERR_INVAL_ARG;
+    /* check if socket is in use */
+    if (ms == NULL || !TAILQ_EMPTY(&ms->master_interfaces) || !TAILQ_EMPTY(&ms->slave_interfaces))
+        return MEMIF_ERR_INVAL_ARG;
 
-  if (ms->listener_fd > 0)
-    {
-      fde.fd = ms->listener_fd;
-      fde.type = MEMIF_FD_EVENT_DEL;
-      ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-      ms->args.on_control_fd_update (fde, ctx);
+    if (ms->listener_fd > 0) {
+        fde.fd = ms->listener_fd;
+        fde.type = MEMIF_FD_EVENT_DEL;
+        ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+        ms->args.on_control_fd_update(fde, ctx);
     }
-  ms->listener_fd = -1;
+    ms->listener_fd = -1;
 
-  if (ms->poll_cancel_fd > 0)
-    {
-      fde.fd = ms->poll_cancel_fd;
-      fde.type = MEMIF_FD_EVENT_DEL;
-      ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-      ms->args.on_control_fd_update (fde, ctx);
+    if (ms->poll_cancel_fd > 0) {
+        fde.fd = ms->poll_cancel_fd;
+        fde.type = MEMIF_FD_EVENT_DEL;
+        ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+        ms->args.on_control_fd_update(fde, ctx);
     }
-  ms->poll_cancel_fd = -1;
+    ms->poll_cancel_fd = -1;
 
-  if (ms->epfd > 0)
-    close (ms->epfd);
-  ms->epfd = -1;
+    if (ms->epfd > 0)
+        close(ms->epfd);
+    ms->epfd = -1;
 
-  ms->args.free (ms);
-  *sock = ms = NULL;
+    ms->args.free(ms);
+    *sock = ms = NULL;
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 }
 
-int
-memif_delete (memif_conn_handle_t * conn)
+int memif_delete(memif_conn_handle_t *conn)
 {
-  memif_connection_t *c = (memif_connection_t *) * conn;
-  memif_socket_t *ms;
-  int err = MEMIF_ERR_SUCCESS;
+    memif_connection_t *c = (memif_connection_t *)*conn;
+    memif_socket_t *ms;
+    int err = MEMIF_ERR_SUCCESS;
 
-  if (c == NULL)
-    {
-      DBG ("no connection");
-      return MEMIF_ERR_NOCONN;
+    if (c == NULL) {
+        DBG("no connection");
+        return MEMIF_ERR_NOCONN;
     }
 
-  err = memif_disconnect_internal (c);
+    err = memif_disconnect_internal(c);
 
-  ms = (memif_socket_t *) c->args.socket;
+    ms = (memif_socket_t *)c->args.socket;
 
-  if (c->args.is_master)
-    TAILQ_REMOVE (&ms->master_interfaces, c, next);
-  else
-    TAILQ_REMOVE (&ms->slave_interfaces, c, next);
-  /* TODO: don't listen with empty interface queue */
+    if (c->args.is_master)
+        TAILQ_REMOVE(&ms->master_interfaces, c, next);
+    else
+        TAILQ_REMOVE(&ms->slave_interfaces, c, next);
+    /* TODO: don't listen with empty interface queue */
 
-  ms->args.free (c);
-  c = NULL;
+    ms->args.free(c);
+    c = NULL;
 
-  *conn = c;
-  return err;
+    *conn = c;
+    return err;
 }
 
-int
-memif_connect1 (memif_connection_t * c)
+int memif_connect1(memif_connection_t *c)
 {
-  memif_socket_t *ms;
-  memif_region_t *mr;
-  memif_queue_t *mq;
-  int i;
+    memif_socket_t *ms;
+    memif_region_t *mr;
+    memif_queue_t *mq;
+    int i;
 
-  if (c == NULL)
-    return MEMIF_ERR_INVAL_ARG;
+    if (c == NULL)
+        return MEMIF_ERR_INVAL_ARG;
 
-  ms = (memif_socket_t *) c->args.socket;
+    ms = (memif_socket_t *)c->args.socket;
 
-  for (i = 0; i < c->regions_num; i++)
-    {
-      mr = &c->regions[i];
-      if (mr != NULL)
-	{
-	  if (!mr->addr)
-	    {
-	      if (mr->is_external)
-		{
-		  if (ms->get_external_region_addr == NULL)
-		    return MEMIF_ERR_INVAL_ARG;
-		  mr->addr = ms->get_external_region_addr (
-		    mr->region_size, mr->fd, c->private_ctx);
-		}
-	      else
-		{
-		  if (mr->fd < 0)
-		    return MEMIF_ERR_NO_SHMFD;
+    for (i = 0; i < c->regions_num; i++) {
+        mr = &c->regions[i];
+        if (mr != NULL) {
+            if (!mr->addr) {
+                if (mr->is_external) {
+                    if (ms->get_external_region_addr == NULL)
+                        return MEMIF_ERR_INVAL_ARG;
+                    mr->addr =
+                        ms->get_external_region_addr(mr->region_size, mr->fd, c->private_ctx);
+                } else {
+                    if (mr->fd < 0)
+                        return MEMIF_ERR_NO_SHMFD;
 
-		  if ((mr->addr =
-			 mmap (NULL, mr->region_size, PROT_READ | PROT_WRITE,
-			       MAP_SHARED, mr->fd, 0)) == MAP_FAILED)
-		    {
-		      return memif_syscall_error_handler (errno);
-		    }
-		}
-	    }
-	}
+                    if ((mr->addr = mmap(NULL, mr->region_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                                         mr->fd, 0)) == MAP_FAILED) {
+                        return memif_syscall_error_handler(errno);
+                    }
+                }
+            }
+        }
     }
 
-  for (i = 0; i < c->rx_queues_num; i++)
-    {
-      mq = &c->rx_queues[i];
-      if (mq != NULL)
-	{
-	  mq->ring = c->regions[mq->region].addr + mq->offset;
-	  if (mq->ring->cookie != MEMIF_COOKIE)
-	    {
-	      DBG ("wrong cookie on rx ring %u", i);
-	      return MEMIF_ERR_COOKIE;
-	    }
-	  mq->ring->head = mq->ring->tail = mq->last_head = mq->next_buf = 0;
-	}
+    for (i = 0; i < c->rx_queues_num; i++) {
+        mq = &c->rx_queues[i];
+        if (mq != NULL) {
+            mq->ring = c->regions[mq->region].addr + mq->offset;
+            if (mq->ring->cookie != MEMIF_COOKIE) {
+                DBG("wrong cookie on rx ring %u", i);
+                return MEMIF_ERR_COOKIE;
+            }
+            mq->ring->head = mq->ring->tail = mq->last_head = mq->next_buf = 0;
+        }
     }
 
-  for (i = 0; i < c->tx_queues_num; i++)
-    {
-      mq = &c->tx_queues[i];
-      if (mq != NULL)
-	{
-	  mq->ring = c->regions[mq->region].addr + mq->offset;
-	  if (mq->ring->cookie != MEMIF_COOKIE)
-	    {
-	      DBG ("wrong cookie on tx ring %u", i);
-	      return MEMIF_ERR_COOKIE;
-	    }
-	  mq->ring->head = mq->ring->tail = mq->last_head = mq->next_buf = 0;
-	}
+    for (i = 0; i < c->tx_queues_num; i++) {
+        mq = &c->tx_queues[i];
+        if (mq != NULL) {
+            mq->ring = c->regions[mq->region].addr + mq->offset;
+            if (mq->ring->cookie != MEMIF_COOKIE) {
+                DBG("wrong cookie on tx ring %u", i);
+                return MEMIF_ERR_COOKIE;
+            }
+            mq->ring->head = mq->ring->tail = mq->last_head = mq->next_buf = 0;
+        }
     }
 
-  return 0;
+    return 0;
 }
 
-static inline int
-memif_add_region (memif_connection_t *conn, uint8_t has_buffers)
+static inline int memif_add_region(memif_connection_t *conn, uint8_t has_buffers)
 {
-  memif_region_t *r;
-  memif_socket_t *ms = (memif_socket_t *) conn->args.socket;
+    memif_region_t *r;
+    memif_socket_t *ms = (memif_socket_t *)conn->args.socket;
 
-  r = ms->args.realloc (conn->regions,
-			sizeof (memif_region_t) * ++conn->regions_num);
-  if (r == NULL)
-    return MEMIF_ERR_NOMEM;
+    r = ms->args.realloc(conn->regions, sizeof(memif_region_t) * ++conn->regions_num);
+    if (r == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  conn->regions = r;
-  r = &conn->regions[conn->regions_num - 1];
-  memset (r, 0, sizeof (memif_region_t));
+    conn->regions = r;
+    r = &conn->regions[conn->regions_num - 1];
+    memset(r, 0, sizeof(memif_region_t));
 
-  if (has_buffers != 0)
-    {
-      r->buffer_offset = 0;
-    }
-  else
-    {
-      r->buffer_offset =
-	(conn->run_args.num_s2m_rings +
-	 conn->run_args.num_m2s_rings) * (sizeof (memif_ring_t) +
-					  sizeof (memif_desc_t) *
-					  (1 << conn->
-					   run_args.log2_ring_size));
+    if (has_buffers != 0) {
+        r->buffer_offset = 0;
+    } else {
+        r->buffer_offset =
+            (conn->run_args.num_s2m_rings + conn->run_args.num_m2s_rings) *
+            (sizeof(memif_ring_t) + sizeof(memif_desc_t) * (1 << conn->run_args.log2_ring_size));
     }
 
-  r->region_size = (has_buffers == 0) ? r->buffer_offset : r->buffer_offset +
-    conn->run_args.buffer_size * (1 << conn->run_args.log2_ring_size) *
-    (conn->run_args.num_s2m_rings + conn->run_args.num_m2s_rings);
+    r->region_size =
+        (has_buffers == 0)
+            ? r->buffer_offset
+            : r->buffer_offset + conn->run_args.buffer_size * (1 << conn->run_args.log2_ring_size) *
+                                     (conn->run_args.num_s2m_rings + conn->run_args.num_m2s_rings);
 
-  if ((r->fd = memfd_create ("memif region 0", MFD_ALLOW_SEALING)) == -1)
-    return memif_syscall_error_handler (errno);
+    if ((r->fd = memfd_create("memif region 0", MFD_ALLOW_SEALING)) == -1)
+        return memif_syscall_error_handler(errno);
 
-  if ((fcntl (r->fd, F_ADD_SEALS, F_SEAL_SHRINK)) == -1)
-    return memif_syscall_error_handler (errno);
+    if ((fcntl(r->fd, F_ADD_SEALS, F_SEAL_SHRINK)) == -1)
+        return memif_syscall_error_handler(errno);
 
-  if ((ftruncate (r->fd, r->region_size)) == -1)
-    return memif_syscall_error_handler (errno);
+    if ((ftruncate(r->fd, r->region_size)) == -1)
+        return memif_syscall_error_handler(errno);
 
-  if ((r->addr = mmap (NULL, r->region_size, PROT_READ | PROT_WRITE,
-		       MAP_SHARED, r->fd, 0)) == MAP_FAILED)
-    return memif_syscall_error_handler (errno);
+    if ((r->addr = mmap(NULL, r->region_size, PROT_READ | PROT_WRITE, MAP_SHARED, r->fd, 0)) ==
+        MAP_FAILED)
+        return memif_syscall_error_handler(errno);
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 }
 
-static inline int
-memif_init_queues (memif_connection_t *conn)
+static inline int memif_init_queues(memif_connection_t *conn)
 {
-  int i, j;
-  memif_ring_t *ring;
-  memif_socket_t *ms = (memif_socket_t *) conn->args.socket;
-  uint32_t ring_size = 1 << conn->run_args.log2_ring_size;
+    int i, j;
+    memif_ring_t *ring;
+    memif_socket_t *ms = (memif_socket_t *)conn->args.socket;
+    uint32_t ring_size = 1 << conn->run_args.log2_ring_size;
 
-  for (i = 0; i < conn->run_args.num_s2m_rings; i++)
-    {
-      ring = memif_get_ring (conn, MEMIF_RING_S2M, i);
-      DBG ("RING: %p I: %d", ring, i);
-      ring->head = ring->tail = 0;
-      ring->cookie = MEMIF_COOKIE;
-      ring->flags = 0;
-      uint32_t base = i;
-      uint32_t ring_offset = base * ring_size;
-      for (j = 0; j < ring_size; j++)
-	{
-	  uint32_t slot = ring_offset + j;
-	  ring->desc[j].region = 1;
-	  ring->desc[j].offset =
-	    conn->regions[1].buffer_offset +
-	    (uint32_t) (slot * conn->run_args.buffer_size);
-	  ring->desc[j].length = conn->run_args.buffer_size;
-	}
+    for (i = 0; i < conn->run_args.num_s2m_rings; i++) {
+        ring = memif_get_ring(conn, MEMIF_RING_S2M, i);
+        DBG("RING: %p I: %d", ring, i);
+        ring->head = ring->tail = 0;
+        ring->cookie = MEMIF_COOKIE;
+        ring->flags = 0;
+        uint32_t base = i;
+        uint32_t ring_offset = base * ring_size;
+        for (j = 0; j < ring_size; j++) {
+            uint32_t slot = ring_offset + j;
+            ring->desc[j].region = 1;
+            ring->desc[j].offset =
+                conn->regions[1].buffer_offset + (uint32_t)(slot * conn->run_args.buffer_size);
+            ring->desc[j].length = conn->run_args.buffer_size;
+        }
     }
-  for (i = 0; i < conn->run_args.num_m2s_rings; i++)
-    {
-      ring = memif_get_ring (conn, MEMIF_RING_M2S, i);
-      DBG ("RING: %p I: %d", ring, i);
-      ring->head = ring->tail = 0;
-      ring->cookie = MEMIF_COOKIE;
-      ring->flags = 0;
-      uint32_t base = conn->run_args.num_s2m_rings + i;
-      uint32_t ring_offset = base * ring_size;
-      for (j = 0; j < ring_size; j++)
-	{
-	  uint32_t slot = ring_offset + j;
-	  ring->desc[j].region = 1;
-	  ring->desc[j].offset =
-	    conn->regions[1].buffer_offset +
-	    (uint32_t) (slot * conn->run_args.buffer_size);
-	  ring->desc[j].length = conn->run_args.buffer_size;
-	}
+    for (i = 0; i < conn->run_args.num_m2s_rings; i++) {
+        ring = memif_get_ring(conn, MEMIF_RING_M2S, i);
+        DBG("RING: %p I: %d", ring, i);
+        ring->head = ring->tail = 0;
+        ring->cookie = MEMIF_COOKIE;
+        ring->flags = 0;
+        uint32_t base = conn->run_args.num_s2m_rings + i;
+        uint32_t ring_offset = base * ring_size;
+        for (j = 0; j < ring_size; j++) {
+            uint32_t slot = ring_offset + j;
+            ring->desc[j].region = 1;
+            ring->desc[j].offset =
+                conn->regions[1].buffer_offset + (uint32_t)(slot * conn->run_args.buffer_size);
+            ring->desc[j].length = conn->run_args.buffer_size;
+        }
     }
-  memif_queue_t *mq;
-  mq = (memif_queue_t *) ms->args.alloc (sizeof (memif_queue_t) *
-					 conn->run_args.num_s2m_rings);
-  if (mq == NULL)
-    return MEMIF_ERR_NOMEM;
+    memif_queue_t *mq;
+    mq = (memif_queue_t *)ms->args.alloc(sizeof(memif_queue_t) * conn->run_args.num_s2m_rings);
+    if (mq == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  int x;
+    int x;
 
-  for (x = 0; x < conn->run_args.num_s2m_rings; x++)
-    {
-      if ((mq[x].int_fd = eventfd (0, EFD_NONBLOCK)) < 0)
-	return memif_syscall_error_handler (errno);
+    for (x = 0; x < conn->run_args.num_s2m_rings; x++) {
+        if ((mq[x].int_fd = eventfd(0, EFD_NONBLOCK)) < 0)
+            return memif_syscall_error_handler(errno);
 
-      mq[x].ring = memif_get_ring (conn, MEMIF_RING_S2M, x);
-      DBG ("RING: %p I: %d", mq[x].ring, x);
-      mq[x].log2_ring_size = conn->run_args.log2_ring_size;
-      mq[x].region = 0;
-      mq[x].offset =
-	(void *) mq[x].ring - (void *) conn->regions[mq->region].addr;
-      mq[x].last_head = mq[x].last_tail = 0;
-      mq[x].next_buf = 0;
+        mq[x].ring = memif_get_ring(conn, MEMIF_RING_S2M, x);
+        DBG("RING: %p I: %d", mq[x].ring, x);
+        mq[x].log2_ring_size = conn->run_args.log2_ring_size;
+        mq[x].region = 0;
+        mq[x].offset = (void *)mq[x].ring - (void *)conn->regions[mq->region].addr;
+        mq[x].last_head = mq[x].last_tail = 0;
+        mq[x].next_buf = 0;
     }
-  conn->tx_queues = mq;
-  conn->tx_queues_num = conn->run_args.num_s2m_rings;
+    conn->tx_queues = mq;
+    conn->tx_queues_num = conn->run_args.num_s2m_rings;
 
-  mq = (memif_queue_t *) ms->args.alloc (sizeof (memif_queue_t) *
-					 conn->run_args.num_m2s_rings);
-  if (mq == NULL)
-    return MEMIF_ERR_NOMEM;
+    mq = (memif_queue_t *)ms->args.alloc(sizeof(memif_queue_t) * conn->run_args.num_m2s_rings);
+    if (mq == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  for (x = 0; x < conn->run_args.num_m2s_rings; x++)
-    {
-      if ((mq[x].int_fd = eventfd (0, EFD_NONBLOCK)) < 0)
-	return memif_syscall_error_handler (errno);
+    for (x = 0; x < conn->run_args.num_m2s_rings; x++) {
+        if ((mq[x].int_fd = eventfd(0, EFD_NONBLOCK)) < 0)
+            return memif_syscall_error_handler(errno);
 
-      mq[x].ring = memif_get_ring (conn, MEMIF_RING_M2S, x);
-      DBG ("RING: %p I: %d", mq[x].ring, x);
-      mq[x].log2_ring_size = conn->run_args.log2_ring_size;
-      mq[x].region = 0;
-      mq[x].offset =
-	(void *) mq[x].ring - (void *) conn->regions[mq->region].addr;
-      mq[x].last_head = mq[x].last_tail = 0;
-      mq[x].next_buf = 0;
+        mq[x].ring = memif_get_ring(conn, MEMIF_RING_M2S, x);
+        DBG("RING: %p I: %d", mq[x].ring, x);
+        mq[x].log2_ring_size = conn->run_args.log2_ring_size;
+        mq[x].region = 0;
+        mq[x].offset = (void *)mq[x].ring - (void *)conn->regions[mq->region].addr;
+        mq[x].last_head = mq[x].last_tail = 0;
+        mq[x].next_buf = 0;
     }
-  conn->rx_queues = mq;
-  conn->rx_queues_num = conn->run_args.num_m2s_rings;
+    conn->rx_queues = mq;
+    conn->rx_queues_num = conn->run_args.num_m2s_rings;
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 }
 
-int
-memif_init_regions_and_queues (memif_connection_t * conn)
+int memif_init_regions_and_queues(memif_connection_t *conn)
 {
-  memif_region_t *r;
-  memif_socket_t *ms = (memif_socket_t *) conn->args.socket;
+    memif_region_t *r;
+    memif_socket_t *ms = (memif_socket_t *)conn->args.socket;
 
-  /* region 0. rings */
-  memif_add_region (conn, /* has_buffers */ 0);
+    /* region 0. rings */
+    memif_add_region(conn, /* has_buffers */ 0);
 
-  /* region 1. buffers */
-  if (ms->add_external_region)
-    {
-      r = (memif_region_t *) ms->args.realloc (
-	conn->regions, sizeof (memif_region_t) * ++conn->regions_num);
-      if (r == NULL)
-	return MEMIF_ERR_NOMEM;
-      conn->regions = r;
+    /* region 1. buffers */
+    if (ms->add_external_region) {
+        r = (memif_region_t *)ms->args.realloc(conn->regions,
+                                               sizeof(memif_region_t) * ++conn->regions_num);
+        if (r == NULL)
+            return MEMIF_ERR_NOMEM;
+        conn->regions = r;
 
-      conn->regions[1].region_size =
-	conn->run_args.buffer_size * (1 << conn->run_args.log2_ring_size) *
-	(conn->run_args.num_s2m_rings + conn->run_args.num_m2s_rings);
-      conn->regions[1].buffer_offset = 0;
-      ms->add_external_region (&conn->regions[1].addr,
-			       conn->regions[1].region_size,
-			       &conn->regions[1].fd, conn->private_ctx);
-      conn->regions[1].is_external = 1;
-    }
-  else
-    {
-      memif_add_region (conn, 1);
+        conn->regions[1].region_size =
+            conn->run_args.buffer_size * (1 << conn->run_args.log2_ring_size) *
+            (conn->run_args.num_s2m_rings + conn->run_args.num_m2s_rings);
+        conn->regions[1].buffer_offset = 0;
+        ms->add_external_region(&conn->regions[1].addr, conn->regions[1].region_size,
+                                &conn->regions[1].fd, conn->private_ctx);
+        conn->regions[1].is_external = 1;
+    } else {
+        memif_add_region(conn, 1);
     }
 
-  memif_init_queues (conn);
+    memif_init_queues(conn);
 
-  return 0;
+    return 0;
 }
 
-int
-memif_set_next_free_buffer (memif_conn_handle_t conn, uint16_t qid,
-			    memif_buffer_t *buf)
+int memif_set_next_free_buffer(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *buf)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
-  if (EXPECT_FALSE (c == NULL))
-    return MEMIF_ERR_NOCONN;
-  if (EXPECT_FALSE (qid >= c->tx_queues_num))
-    return MEMIF_ERR_QID;
-  if (EXPECT_FALSE (buf == NULL))
-    return MEMIF_ERR_INVAL_ARG;
+    memif_connection_t *c = (memif_connection_t *)conn;
+    if (EXPECT_FALSE(c == NULL))
+        return MEMIF_ERR_NOCONN;
+    if (EXPECT_FALSE(qid >= c->tx_queues_num))
+        return MEMIF_ERR_QID;
+    if (EXPECT_FALSE(buf == NULL))
+        return MEMIF_ERR_INVAL_ARG;
 
-  uint16_t ring_size, ns;
-  memif_queue_t *mq = &c->tx_queues[qid];
-  memif_ring_t *ring = mq->ring;
+    uint16_t ring_size, ns;
+    memif_queue_t *mq = &c->tx_queues[qid];
+    memif_ring_t *ring = mq->ring;
 
-  ring_size = (1 << mq->log2_ring_size);
-  if (c->args.is_master)
-    ns = ring->head - mq->next_buf;
-  else
+    ring_size = (1 << mq->log2_ring_size);
+    if (c->args.is_master)
+        ns = ring->head - mq->next_buf;
+    else
+        ns = ring_size - mq->next_buf + ring->tail;
+
+    if ((mq->next_buf - buf->desc_index) > ns)
+        return MEMIF_ERR_INVAL_ARG;
+
+    mq->next_buf = buf->desc_index;
+
+    return MEMIF_ERR_SUCCESS;
+}
+
+static void memif_buffer_enq_at_idx_internal(memif_queue_t *from_q, memif_queue_t *to_q,
+                                             memif_buffer_t *buf, uint16_t slot)
+{
+    uint16_t from_mask = (1 << from_q->log2_ring_size) - 1;
+    uint16_t to_mask = (1 << to_q->log2_ring_size) - 1;
+    memif_desc_t *from_d, *to_d, tmp_d;
+
+    /* Get the descriptors */
+    from_d = &from_q->ring->desc[buf->desc_index & from_mask];
+    to_d = &to_q->ring->desc[slot & to_mask];
+
+    /* Swap descriptors */
+    tmp_d = *from_d;
+    *from_d = *to_d;
+    *to_d = tmp_d;
+
+    /* Update descriptor index and queue for clients buffer */
+    buf->desc_index = slot;
+    buf->queue = to_q;
+}
+
+int memif_buffer_requeue(memif_conn_handle_t conn, memif_buffer_t *buf_a, memif_buffer_t *buf_b)
+{
+    memif_connection_t *c = (memif_connection_t *)conn;
+    if (EXPECT_FALSE(c == NULL))
+        return MEMIF_ERR_NOCONN;
+    if (EXPECT_FALSE(c->args.is_master))
+        return MEMIF_ERR_INVAL_ARG;
+    if ((buf_a == NULL) || (buf_b == NULL))
+        return MEMIF_ERR_INVAL_ARG;
+
+    int err;
+    /* store buf_a information */
+    uint16_t index_a = buf_a->desc_index;
+    memif_queue_t *mq_a = buf_a->queue;
+
+    /* swap buffers, buf_a was updated with new desc_index and queue */
+    memif_buffer_enq_at_idx_internal((memif_queue_t *)buf_a->queue, (memif_queue_t *)buf_b->queue,
+                                     buf_a, buf_b->desc_index);
+
+    /* update buf_b desc_index and queue */
+    buf_b->desc_index = index_a;
+    buf_b->queue = mq_a;
+
+    return MEMIF_ERR_SUCCESS;
+}
+
+int memif_buffer_enq_tx(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs,
+                        uint16_t count, uint16_t *count_out)
+{
+    memif_connection_t *c = (memif_connection_t *)conn;
+    if (EXPECT_FALSE(c == NULL))
+        return MEMIF_ERR_NOCONN;
+    if (EXPECT_FALSE(c->control_channel == NULL))
+        return MEMIF_ERR_DISCONNECTED;
+    if (EXPECT_FALSE(qid >= c->tx_queues_num))
+        return MEMIF_ERR_QID;
+    if (EXPECT_FALSE(!count_out))
+        return MEMIF_ERR_INVAL_ARG;
+    if (EXPECT_FALSE(c->args.is_master))
+        return MEMIF_ERR_INVAL_ARG;
+
+    memif_queue_t *mq = &c->tx_queues[qid];
+    memif_ring_t *ring = mq->ring;
+    memif_buffer_t *b0;
+    uint16_t mask = (1 << mq->log2_ring_size) - 1;
+    uint16_t ring_size;
+    uint16_t ns;
+    memif_queue_t *bmq;
+    int err = MEMIF_ERR_SUCCESS; /* 0 */
+    *count_out = 0;
+
+    ring_size = (1 << mq->log2_ring_size);
+
+    /* can only be called by slave */
     ns = ring_size - mq->next_buf + ring->tail;
 
-  if ((mq->next_buf - buf->desc_index) > ns)
-    return MEMIF_ERR_INVAL_ARG;
+    b0 = bufs;
 
-  mq->next_buf = buf->desc_index;
+    while (count && ns) {
+        /* Swaps the descriptors, updates next_buf pointer and updates client
+         * memif buffer */
 
-  return MEMIF_ERR_SUCCESS;
-}
+        memif_buffer_enq_at_idx_internal((memif_queue_t *)b0->queue, mq, b0, mq->next_buf);
 
-static void
-memif_buffer_enq_at_idx_internal (memif_queue_t *from_q, memif_queue_t *to_q,
-				  memif_buffer_t *buf, uint16_t slot)
-{
-  uint16_t from_mask = (1 << from_q->log2_ring_size) - 1;
-  uint16_t to_mask = (1 << to_q->log2_ring_size) - 1;
-  memif_desc_t *from_d, *to_d, tmp_d;
-
-  /* Get the descriptors */
-  from_d = &from_q->ring->desc[buf->desc_index & from_mask];
-  to_d = &to_q->ring->desc[slot & to_mask];
-
-  /* Swap descriptors */
-  tmp_d = *from_d;
-  *from_d = *to_d;
-  *to_d = tmp_d;
-
-  /* Update descriptor index and queue for clients buffer */
-  buf->desc_index = slot;
-  buf->queue = to_q;
-}
-
-int
-memif_buffer_requeue (memif_conn_handle_t conn, memif_buffer_t *buf_a,
-		      memif_buffer_t *buf_b)
-{
-  memif_connection_t *c = (memif_connection_t *) conn;
-  if (EXPECT_FALSE (c == NULL))
-    return MEMIF_ERR_NOCONN;
-  if (EXPECT_FALSE (c->args.is_master))
-    return MEMIF_ERR_INVAL_ARG;
-  if ((buf_a == NULL) || (buf_b == NULL))
-    return MEMIF_ERR_INVAL_ARG;
-
-  int err;
-  /* store buf_a information */
-  uint16_t index_a = buf_a->desc_index;
-  memif_queue_t *mq_a = buf_a->queue;
-
-  /* swap buffers, buf_a was updated with new desc_index and queue */
-  memif_buffer_enq_at_idx_internal ((memif_queue_t *) buf_a->queue,
-				    (memif_queue_t *) buf_b->queue, buf_a,
-				    buf_b->desc_index);
-
-  /* update buf_b desc_index and queue */
-  buf_b->desc_index = index_a;
-  buf_b->queue = mq_a;
-
-  return MEMIF_ERR_SUCCESS;
-}
-
-int
-memif_buffer_enq_tx (memif_conn_handle_t conn, uint16_t qid,
-		     memif_buffer_t * bufs, uint16_t count,
-		     uint16_t * count_out)
-{
-  memif_connection_t *c = (memif_connection_t *) conn;
-  if (EXPECT_FALSE (c == NULL))
-    return MEMIF_ERR_NOCONN;
-  if (EXPECT_FALSE (c->control_channel == NULL))
-    return MEMIF_ERR_DISCONNECTED;
-  if (EXPECT_FALSE (qid >= c->tx_queues_num))
-    return MEMIF_ERR_QID;
-  if (EXPECT_FALSE (!count_out))
-    return MEMIF_ERR_INVAL_ARG;
-  if (EXPECT_FALSE (c->args.is_master))
-    return MEMIF_ERR_INVAL_ARG;
-
-  memif_queue_t *mq = &c->tx_queues[qid];
-  memif_ring_t *ring = mq->ring;
-  memif_buffer_t *b0;
-  uint16_t mask = (1 << mq->log2_ring_size) - 1;
-  uint16_t ring_size;
-  uint16_t ns;
-  memif_queue_t *bmq;
-  int err = MEMIF_ERR_SUCCESS;	/* 0 */
-  *count_out = 0;
-
-  ring_size = (1 << mq->log2_ring_size);
-
-  /* can only be called by slave */
-  ns = ring_size - mq->next_buf + ring->tail;
-
-  b0 = bufs;
-
-  while (count && ns)
-    {
-      /* Swaps the descriptors, updates next_buf pointer and updates client
-       * memif buffer */
-
-      memif_buffer_enq_at_idx_internal ((memif_queue_t *) b0->queue, mq, b0,
-					mq->next_buf);
-
-      mq->next_buf++; /* mark the buffer as allocated */
-      count--;
-      ns--;
-      b0++;
-      *count_out += 1;
+        mq->next_buf++; /* mark the buffer as allocated */
+        count--;
+        ns--;
+        b0++;
+        *count_out += 1;
     }
 
-  DBG ("allocated: %u/%u bufs. Next buffer pointer %d", *count_out, count,
-       mq->next_buf);
+    DBG("allocated: %u/%u bufs. Next buffer pointer %d", *count_out, count, mq->next_buf);
 
-  if (count)
-    {
-      DBG ("ring buffer full! qid: %u", qid);
-      err = MEMIF_ERR_NOBUF_RING;
+    if (count) {
+        DBG("ring buffer full! qid: %u", qid);
+        err = MEMIF_ERR_NOBUF_RING;
     }
 
-  return err;
+    return err;
 }
 
-int
-memif_buffer_alloc (memif_conn_handle_t conn, uint16_t qid,
-		    memif_buffer_t * bufs, uint16_t count,
-		    uint16_t * count_out, uint32_t size)
+int memif_buffer_alloc(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs, uint16_t count,
+                       uint16_t *count_out, uint32_t size)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
-  if (EXPECT_FALSE (c == NULL))
-    return MEMIF_ERR_NOCONN;
-  if (EXPECT_FALSE (c->control_channel == NULL))
-    return MEMIF_ERR_DISCONNECTED;
-  uint8_t num =
-    (c->args.is_master) ? c->run_args.num_m2s_rings : c->
-    run_args.num_s2m_rings;
-  if (EXPECT_FALSE (qid >= num))
-    return MEMIF_ERR_QID;
-  if (EXPECT_FALSE (!count_out))
-    return MEMIF_ERR_INVAL_ARG;
+    memif_connection_t *c = (memif_connection_t *)conn;
+    if (EXPECT_FALSE(c == NULL))
+        return MEMIF_ERR_NOCONN;
+    if (EXPECT_FALSE(c->control_channel == NULL))
+        return MEMIF_ERR_DISCONNECTED;
+    uint8_t num = (c->args.is_master) ? c->run_args.num_m2s_rings : c->run_args.num_s2m_rings;
+    if (EXPECT_FALSE(qid >= num))
+        return MEMIF_ERR_QID;
+    if (EXPECT_FALSE(!count_out))
+        return MEMIF_ERR_INVAL_ARG;
 
-  memif_socket_t *ms = (memif_socket_t *) c->args.socket;
-  memif_queue_t *mq = &c->tx_queues[qid];
-  memif_ring_t *ring = mq->ring;
-  memif_buffer_t *b0;
-  uint16_t mask = (1 << mq->log2_ring_size) - 1;
-  uint16_t ring_size;
-  uint16_t ns;
-  int err = MEMIF_ERR_SUCCESS;	/* 0 */
-  uint32_t dst_left, src_left;
-  uint16_t saved_count_out, delta_count;
-  uint16_t saved_next_buf;
-  memif_buffer_t *saved_b;
-  *count_out = 0;
+    memif_socket_t *ms = (memif_socket_t *)c->args.socket;
+    memif_queue_t *mq = &c->tx_queues[qid];
+    memif_ring_t *ring = mq->ring;
+    memif_buffer_t *b0;
+    uint16_t mask = (1 << mq->log2_ring_size) - 1;
+    uint16_t ring_size;
+    uint16_t ns;
+    int err = MEMIF_ERR_SUCCESS; /* 0 */
+    uint32_t dst_left, src_left;
+    uint16_t saved_count_out, delta_count;
+    uint16_t saved_next_buf;
+    memif_buffer_t *saved_b;
+    *count_out = 0;
 
-  ring_size = (1 << mq->log2_ring_size);
+    ring_size = (1 << mq->log2_ring_size);
 
-  if (c->args.is_master)
-    ns = ring->head - mq->next_buf;
-  else
-    ns = ring_size - mq->next_buf + ring->tail;
+    if (c->args.is_master)
+        ns = ring->head - mq->next_buf;
+    else
+        ns = ring_size - mq->next_buf + ring->tail;
 
-  while (count && ns)
-    {
-      b0 = (bufs + *count_out);
+    while (count && ns) {
+        b0 = (bufs + *count_out);
 
-      saved_b = b0;
-      saved_count_out = *count_out;
-      saved_next_buf = mq->next_buf;
+        saved_b = b0;
+        saved_count_out = *count_out;
+        saved_next_buf = mq->next_buf;
 
-      b0->desc_index = mq->next_buf;
-      ring->desc[mq->next_buf & mask].flags = 0;
-      b0->flags = 0;
+        b0->desc_index = mq->next_buf;
+        ring->desc[mq->next_buf & mask].flags = 0;
+        b0->flags = 0;
 
-      /* slave can produce buffer with original length */
-      dst_left = (c->args.is_master) ? ring->desc[mq->next_buf & mask].length :
-				       c->run_args.buffer_size;
-      src_left = size;
+        /* slave can produce buffer with original length */
+        dst_left =
+            (c->args.is_master) ? ring->desc[mq->next_buf & mask].length : c->run_args.buffer_size;
+        src_left = size;
 
-      while (src_left)
-	{
-	  if (EXPECT_FALSE (dst_left == 0))
-	    {
-	      if (ns)
-		{
-		  ring->desc[b0->desc_index & mask].flags |=
-		    MEMIF_DESC_FLAG_NEXT;
-		  b0->flags |= MEMIF_BUFFER_FLAG_NEXT;
+        while (src_left) {
+            if (EXPECT_FALSE(dst_left == 0)) {
+                if (ns) {
+                    ring->desc[b0->desc_index & mask].flags |= MEMIF_DESC_FLAG_NEXT;
+                    b0->flags |= MEMIF_BUFFER_FLAG_NEXT;
 
-		  b0 = (bufs + *count_out);
-		  b0->desc_index = mq->next_buf;
-		  dst_left = (c->args.is_master) ?
-			       ring->desc[mq->next_buf & mask].length :
-			       c->run_args.buffer_size;
-		  ring->desc[mq->next_buf & mask].flags = 0;
-		  b0->flags = 0;
-		}
-	      else
-		{
-		  /* rollback allocated chain buffers */
-		  delta_count = *count_out - saved_count_out;
-		  memset (saved_b, 0, sizeof (memif_buffer_t) * delta_count);
-		  *count_out -= delta_count;
-		  mq->next_buf = saved_next_buf;
-		  goto no_ns;
-		}
-	    }
-	  b0->len = memif_min (dst_left, src_left);
+                    b0 = (bufs + *count_out);
+                    b0->desc_index = mq->next_buf;
+                    dst_left = (c->args.is_master) ? ring->desc[mq->next_buf & mask].length
+                                                   : c->run_args.buffer_size;
+                    ring->desc[mq->next_buf & mask].flags = 0;
+                    b0->flags = 0;
+                } else {
+                    /* rollback allocated chain buffers */
+                    delta_count = *count_out - saved_count_out;
+                    memset(saved_b, 0, sizeof(memif_buffer_t) * delta_count);
+                    *count_out -= delta_count;
+                    mq->next_buf = saved_next_buf;
+                    goto no_ns;
+                }
+            }
+            b0->len = memif_min(dst_left, src_left);
 
-	  /* slave resets buffer offset */
-	  if (c->args.is_master == 0)
-	    {
-	      memif_desc_t *d = &ring->desc[mq->next_buf & mask];
-	      if (ms->get_external_buffer_offset)
-		d->offset = ms->get_external_buffer_offset (c->private_ctx);
-	      else
-		d->offset = d->offset - (d->offset % c->run_args.buffer_size);
-	    }
-	  b0->data = memif_get_buffer (c, ring, mq->next_buf & mask);
+            /* slave resets buffer offset */
+            if (c->args.is_master == 0) {
+                memif_desc_t *d = &ring->desc[mq->next_buf & mask];
+                if (ms->get_external_buffer_offset)
+                    d->offset = ms->get_external_buffer_offset(c->private_ctx);
+                else
+                    d->offset = d->offset - (d->offset % c->run_args.buffer_size);
+            }
+            b0->data = memif_get_buffer(c, ring, mq->next_buf & mask);
 
-	  src_left -= b0->len;
-	  dst_left -= b0->len;
-	  *count_out += 1;
-	  mq->next_buf++;
-	  ns--;
-	}
-      count--;
+            src_left -= b0->len;
+            dst_left -= b0->len;
+            *count_out += 1;
+            mq->next_buf++;
+            ns--;
+        }
+        count--;
     }
 
 no_ns:
 
-  DBG ("allocated: %u/%u bufs, size: %u. Next buffer pointer %d", *count_out,
-       count, size, mq->next_buf);
+    DBG("allocated: %u/%u bufs, size: %u. Next buffer pointer %d", *count_out, count, size,
+        mq->next_buf);
 
-  if (count)
-    {
-      DBG ("ring buffer full! qid: %u", qid);
-      err = MEMIF_ERR_NOBUF_RING;
+    if (count) {
+        DBG("ring buffer full! qid: %u", qid);
+        err = MEMIF_ERR_NOBUF_RING;
     }
 
-  return err;
+    return err;
 }
 
-int
-memif_refill_queue (memif_conn_handle_t conn, uint16_t qid, uint16_t count,
-		    uint16_t headroom)
+int memif_refill_queue(memif_conn_handle_t conn, uint16_t qid, uint16_t count, uint16_t headroom)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
-  if (EXPECT_FALSE (c == NULL))
-    return MEMIF_ERR_NOCONN;
-  if (EXPECT_FALSE (c->control_channel == NULL))
-    return MEMIF_ERR_DISCONNECTED;
-  uint8_t num =
-    (c->args.is_master) ? c->run_args.num_s2m_rings : c->
-    run_args.num_m2s_rings;
-  if (EXPECT_FALSE (qid >= num))
-    return MEMIF_ERR_QID;
-  memif_socket_t *ms = (memif_socket_t *) c->args.socket;
-  memif_queue_t *mq = &c->rx_queues[qid];
-  memif_ring_t *ring = mq->ring;
-  uint16_t mask = (1 << mq->log2_ring_size) - 1;
-  uint16_t slot, counter = 0;
+    memif_connection_t *c = (memif_connection_t *)conn;
+    if (EXPECT_FALSE(c == NULL))
+        return MEMIF_ERR_NOCONN;
+    if (EXPECT_FALSE(c->control_channel == NULL))
+        return MEMIF_ERR_DISCONNECTED;
+    uint8_t num = (c->args.is_master) ? c->run_args.num_s2m_rings : c->run_args.num_m2s_rings;
+    if (EXPECT_FALSE(qid >= num))
+        return MEMIF_ERR_QID;
+    memif_socket_t *ms = (memif_socket_t *)c->args.socket;
+    memif_queue_t *mq = &c->rx_queues[qid];
+    memif_ring_t *ring = mq->ring;
+    uint16_t mask = (1 << mq->log2_ring_size) - 1;
+    uint16_t slot, counter = 0;
 
-  if (c->args.is_master)
-    {
-      MEMIF_MEMORY_BARRIER ();
-      ring->tail =
-	(ring->tail + count <=
-	 mq->last_head) ? ring->tail + count : mq->last_head;
-      return MEMIF_ERR_SUCCESS;
+    if (c->args.is_master) {
+        MEMIF_MEMORY_BARRIER();
+        ring->tail = (ring->tail + count <= mq->last_head) ? ring->tail + count : mq->last_head;
+        return MEMIF_ERR_SUCCESS;
     }
 
-  uint16_t head = ring->head;
-  slot = head;
-  uint16_t ns = (1 << mq->log2_ring_size) - head + mq->last_tail;
-  count = (count < ns) ? count : ns;
+    uint16_t head = ring->head;
+    slot = head;
+    uint16_t ns = (1 << mq->log2_ring_size) - head + mq->last_tail;
+    count = (count < ns) ? count : ns;
 
-  memif_desc_t *d;
-  while (counter < count)
-    {
-      d = &ring->desc[slot & mask];
-      d->region = 1;
-      d->length = c->run_args.buffer_size - headroom;
-      if (ms->get_external_buffer_offset)
-	d->offset = ms->get_external_buffer_offset (c->private_ctx);
-      else
-	d->offset =
-	  d->offset - (d->offset % c->run_args.buffer_size) + headroom;
-      slot++;
-      counter++;
+    memif_desc_t *d;
+    while (counter < count) {
+        d = &ring->desc[slot & mask];
+        d->region = 1;
+        d->length = c->run_args.buffer_size - headroom;
+        if (ms->get_external_buffer_offset)
+            d->offset = ms->get_external_buffer_offset(c->private_ctx);
+        else
+            d->offset = d->offset - (d->offset % c->run_args.buffer_size) + headroom;
+        slot++;
+        counter++;
     }
 
-  MEMIF_MEMORY_BARRIER ();
-  ring->head = slot;
+    MEMIF_MEMORY_BARRIER();
+    ring->head = slot;
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
-int
-memif_tx_burst (memif_conn_handle_t conn, uint16_t qid,
-		memif_buffer_t * bufs, uint16_t count, uint16_t * tx)
+int memif_tx_burst(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs, uint16_t count,
+                   uint16_t *tx)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
-  if (EXPECT_FALSE (c == NULL))
-    return MEMIF_ERR_NOCONN;
-  if (EXPECT_FALSE (c->control_channel == NULL))
-    return MEMIF_ERR_DISCONNECTED;
-  uint8_t num =
-    (c->args.is_master) ? c->run_args.num_m2s_rings : c->
-    run_args.num_s2m_rings;
-  if (EXPECT_FALSE (qid >= num))
-    return MEMIF_ERR_QID;
-  if (EXPECT_FALSE (!tx))
-    return MEMIF_ERR_INVAL_ARG;
+    memif_connection_t *c = (memif_connection_t *)conn;
+    if (EXPECT_FALSE(c == NULL))
+        return MEMIF_ERR_NOCONN;
+    if (EXPECT_FALSE(c->control_channel == NULL))
+        return MEMIF_ERR_DISCONNECTED;
+    uint8_t num = (c->args.is_master) ? c->run_args.num_m2s_rings : c->run_args.num_s2m_rings;
+    if (EXPECT_FALSE(qid >= num))
+        return MEMIF_ERR_QID;
+    if (EXPECT_FALSE(!tx))
+        return MEMIF_ERR_INVAL_ARG;
 
-  memif_queue_t *mq = &c->tx_queues[qid];
-  memif_ring_t *ring = mq->ring;
-  uint16_t mask = (1 << mq->log2_ring_size) - 1;
-  memif_buffer_t *b0;
-  memif_desc_t *d;
-  int64_t data_offset;
-  *tx = 0;
-  int err = MEMIF_ERR_SUCCESS;
+    memif_queue_t *mq = &c->tx_queues[qid];
+    memif_ring_t *ring = mq->ring;
+    uint16_t mask = (1 << mq->log2_ring_size) - 1;
+    memif_buffer_t *b0;
+    memif_desc_t *d;
+    int64_t data_offset;
+    *tx = 0;
+    int err = MEMIF_ERR_SUCCESS;
 
-  if (EXPECT_FALSE (count == 0))
-    return MEMIF_ERR_SUCCESS;
+    if (EXPECT_FALSE(count == 0))
+        return MEMIF_ERR_SUCCESS;
 
-  uint16_t index;
-  if (c->args.is_master)
-    index = ring->tail;
-  else
-    index = ring->head;
+    uint16_t index;
+    if (c->args.is_master)
+        index = ring->tail;
+    else
+        index = ring->head;
 
-  while (count)
-    {
-      b0 = (bufs + *tx);
-      /* set error to MEMIF_ERR_INVAL_ARG and finish the sending process
-       */
-      if ((b0->desc_index & mask) != (index & mask))
-	{
-	  err = MEMIF_ERR_INVAL_ARG;
-	  goto done;
-	}
-      d = &ring->desc[b0->desc_index & mask];
-      d->length = b0->len;
-      d->flags =
-	((b0->flags & MEMIF_BUFFER_FLAG_NEXT) == 1) ? MEMIF_DESC_FLAG_NEXT : 0;
-      if (!c->args.is_master)
-	{
-	  // reset headroom
-	  d->offset = d->offset - (d->offset % c->run_args.buffer_size);
-	  // calculate offset from user data
-	  data_offset = b0->data - (d->offset + c->regions[d->region].addr);
-	  if (data_offset != 0)
-	    {
-	      /* verify data offset and buffer length */
-	      if ((data_offset < 0) ||
-		  ((data_offset + b0->len) > c->run_args.buffer_size))
-		{
-		  DBG ("slot: %d, data_offset: %ld, length: %d",
-		       b0->desc_index & mask, data_offset, b0->len);
-		  err = MEMIF_ERR_INVAL_ARG;
-		  goto done;
-		}
-	      d->offset += data_offset;
-	    }
-	}
+    while (count) {
+        b0 = (bufs + *tx);
+        /* set error to MEMIF_ERR_INVAL_ARG and finish the sending process
+         */
+        if ((b0->desc_index & mask) != (index & mask)) {
+            err = MEMIF_ERR_INVAL_ARG;
+            goto done;
+        }
+        d = &ring->desc[b0->desc_index & mask];
+        d->length = b0->len;
+        d->flags = ((b0->flags & MEMIF_BUFFER_FLAG_NEXT) == 1) ? MEMIF_DESC_FLAG_NEXT : 0;
+        if (!c->args.is_master) {
+            // reset headroom
+            d->offset = d->offset - (d->offset % c->run_args.buffer_size);
+            // calculate offset from user data
+            data_offset = b0->data - (d->offset + c->regions[d->region].addr);
+            if (data_offset != 0) {
+                /* verify data offset and buffer length */
+                if ((data_offset < 0) || ((data_offset + b0->len) > c->run_args.buffer_size)) {
+                    DBG("slot: %d, data_offset: %ld, length: %d", b0->desc_index & mask,
+                        data_offset, b0->len);
+                    err = MEMIF_ERR_INVAL_ARG;
+                    goto done;
+                }
+                d->offset += data_offset;
+            }
+        }
 
 #ifdef MEMIF_DBG_SHM
-      printf ("offset: %-6d\n", ring->desc[b0->desc_index & mask].offset);
-      printf ("data: %p\n",
-	      memif_get_buffer (c, ring, b0->desc_index & mask));
-      printf ("index: %u\n", b0->desc_index);
-      print_bytes (memif_get_buffer (c, ring, b0->desc_index & mask),
-		   ring->desc[b0->desc_index & mask].length, DBG_TX_BUF);
+        printf("offset: %-6d\n", ring->desc[b0->desc_index & mask].offset);
+        printf("data: %p\n", memif_get_buffer(c, ring, b0->desc_index & mask));
+        printf("index: %u\n", b0->desc_index);
+        print_bytes(memif_get_buffer(c, ring, b0->desc_index & mask),
+                    ring->desc[b0->desc_index & mask].length, DBG_TX_BUF);
 #endif /* MEMIF_DBG_SHM */
 
-      *tx += 1;
-      count--;
-      index++;
+        *tx += 1;
+        count--;
+        index++;
     }
 
 done:
-  MEMIF_MEMORY_BARRIER ();
-  if (c->args.is_master)
-    ring->tail = b0->desc_index + 1;
-  else
-    ring->head = b0->desc_index + 1;
+    MEMIF_MEMORY_BARRIER();
+    if (c->args.is_master)
+        ring->tail = b0->desc_index + 1;
+    else
+        ring->head = b0->desc_index + 1;
 
-  if ((ring->flags & MEMIF_RING_FLAG_MASK_INT) == 0)
-    {
-      uint64_t a = 1;
-      int r = write (mq->int_fd, &a, sizeof (a));
-      if (r < 0)
-	return MEMIF_ERR_INT_WRITE;
+    if ((ring->flags & MEMIF_RING_FLAG_MASK_INT) == 0) {
+        uint64_t a = 1;
+        int r = write(mq->int_fd, &a, sizeof(a));
+        if (r < 0)
+            return MEMIF_ERR_INT_WRITE;
     }
 
-  return err;
+    return err;
 }
 
-int
-memif_rx_burst (memif_conn_handle_t conn, uint16_t qid,
-		memif_buffer_t * bufs, uint16_t count, uint16_t * rx)
+int memif_rx_burst(memif_conn_handle_t conn, uint16_t qid, memif_buffer_t *bufs, uint16_t count,
+                   uint16_t *rx)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
-  if (EXPECT_FALSE (c == NULL))
-    return MEMIF_ERR_NOCONN;
-  if (EXPECT_FALSE (c->control_channel == NULL))
-    return MEMIF_ERR_DISCONNECTED;
-  uint8_t num =
-    (c->args.is_master) ? c->run_args.num_s2m_rings : c->
-    run_args.num_m2s_rings;
-  if (EXPECT_FALSE (qid >= num))
-    return MEMIF_ERR_QID;
-  if (EXPECT_FALSE (!rx))
-    return MEMIF_ERR_INVAL_ARG;
+    memif_connection_t *c = (memif_connection_t *)conn;
+    if (EXPECT_FALSE(c == NULL))
+        return MEMIF_ERR_NOCONN;
+    if (EXPECT_FALSE(c->control_channel == NULL))
+        return MEMIF_ERR_DISCONNECTED;
+    uint8_t num = (c->args.is_master) ? c->run_args.num_s2m_rings : c->run_args.num_m2s_rings;
+    if (EXPECT_FALSE(qid >= num))
+        return MEMIF_ERR_QID;
+    if (EXPECT_FALSE(!rx))
+        return MEMIF_ERR_INVAL_ARG;
 
-  memif_queue_t *mq = &c->rx_queues[qid];
-  memif_ring_t *ring = mq->ring;
-  uint16_t cur_slot, last_slot;
-  uint16_t ns;
-  uint16_t mask = (1 << mq->log2_ring_size) - 1;
-  memif_buffer_t *b0;
-  *rx = 0;
+    memif_queue_t *mq = &c->rx_queues[qid];
+    memif_ring_t *ring = mq->ring;
+    uint16_t cur_slot, last_slot;
+    uint16_t ns;
+    uint16_t mask = (1 << mq->log2_ring_size) - 1;
+    memif_buffer_t *b0;
+    *rx = 0;
 
-  uint64_t b;
-  ssize_t r;
+    uint64_t b;
+    ssize_t r;
 
-  cur_slot = (c->args.is_master) ? mq->last_head : mq->last_tail;
-  last_slot = (c->args.is_master) ? ring->head : ring->tail;
-  if (cur_slot == last_slot)
-    {
-      r = read (mq->int_fd, &b, sizeof (b));
-      if (EXPECT_FALSE ((r == -1) && (errno != EAGAIN)))
-			return memif_syscall_error_handler (errno);
+    cur_slot = (c->args.is_master) ? mq->last_head : mq->last_tail;
+    last_slot = (c->args.is_master) ? ring->head : ring->tail;
+    if (cur_slot == last_slot) {
+        r = read(mq->int_fd, &b, sizeof(b));
+        if (EXPECT_FALSE((r == -1) && (errno != EAGAIN)))
+            return memif_syscall_error_handler(errno);
 
-      return MEMIF_ERR_SUCCESS;
+        return MEMIF_ERR_SUCCESS;
     }
 
-  ns = last_slot - cur_slot;
+    ns = last_slot - cur_slot;
 
-  while (ns && count)
-    {
-      b0 = (bufs + *rx);
+    while (ns && count) {
+        b0 = (bufs + *rx);
 
-      b0->desc_index = cur_slot;
-      b0->data = memif_get_buffer (c, ring, cur_slot & mask);
-      b0->len = ring->desc[cur_slot & mask].length;
-      b0->flags = 0;
-      /* slave resets buffer length */
-      if (c->args.is_master == 0)
-	{
-	  ring->desc[cur_slot & mask].length = c->run_args.buffer_size;
-	}
+        b0->desc_index = cur_slot;
+        b0->data = memif_get_buffer(c, ring, cur_slot & mask);
+        b0->len = ring->desc[cur_slot & mask].length;
+        b0->flags = 0;
+        /* slave resets buffer length */
+        if (c->args.is_master == 0) {
+            ring->desc[cur_slot & mask].length = c->run_args.buffer_size;
+        }
 
-      if (ring->desc[cur_slot & mask].flags & MEMIF_DESC_FLAG_NEXT)
-	{
-	  b0->flags |= MEMIF_BUFFER_FLAG_NEXT;
-	  ring->desc[cur_slot & mask].flags &= ~MEMIF_DESC_FLAG_NEXT;
-	}
+        if (ring->desc[cur_slot & mask].flags & MEMIF_DESC_FLAG_NEXT) {
+            b0->flags |= MEMIF_BUFFER_FLAG_NEXT;
+            ring->desc[cur_slot & mask].flags &= ~MEMIF_DESC_FLAG_NEXT;
+        }
 
-      b0->queue = mq;
+        b0->queue = mq;
 #ifdef MEMIF_DBG_SHM
-      printf ("data: %p\n", b0->data);
-      printf ("index: %u\n", b0->desc_index);
-      printf ("queue: %p\n", b0->queue);
-      print_bytes (b0->data, b0->len, DBG_RX_BUF);
+        printf("data: %p\n", b0->data);
+        printf("index: %u\n", b0->desc_index);
+        printf("queue: %p\n", b0->queue);
+        print_bytes(b0->data, b0->len, DBG_RX_BUF);
 #endif /* MEMIF_DBG_SHM */
-      ns--;
-      *rx += 1;
+        ns--;
+        *rx += 1;
 
-      count--;
-      cur_slot++;
+        count--;
+        cur_slot++;
     }
 
-  if (c->args.is_master)
-    mq->last_head = cur_slot;
-  else
-    mq->last_tail = cur_slot;
+    if (c->args.is_master)
+        mq->last_head = cur_slot;
+    else
+        mq->last_tail = cur_slot;
 
-  if (ns)
-    {
-      DBG ("not enough buffers!");
-      return MEMIF_ERR_NOBUF;
+    if (ns) {
+        DBG("not enough buffers!");
+        return MEMIF_ERR_NOBUF;
     }
 
-  r = read (mq->int_fd, &b, sizeof (b));
-  if (EXPECT_FALSE ((r == -1) && (errno != EAGAIN)))
-    return memif_syscall_error_handler (errno);
+    r = read(mq->int_fd, &b, sizeof(b));
+    if (EXPECT_FALSE((r == -1) && (errno != EAGAIN)))
+        return memif_syscall_error_handler(errno);
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
-int
-memif_get_details (memif_conn_handle_t conn, memif_details_t * md,
-		   char *buf, ssize_t buflen)
+int memif_get_details(memif_conn_handle_t conn, memif_details_t *md, char *buf, ssize_t buflen)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
-  memif_socket_t *ms;
-  int err = MEMIF_ERR_SUCCESS, i;
-  ssize_t l0 = 0, l1;
+    memif_connection_t *c = (memif_connection_t *)conn;
+    memif_socket_t *ms;
+    int err = MEMIF_ERR_SUCCESS, i;
+    ssize_t l0 = 0, l1;
 
-  if (c == NULL)
-    return MEMIF_ERR_NOCONN;
+    if (c == NULL)
+        return MEMIF_ERR_NOCONN;
 
-  ms = (memif_socket_t *) c->args.socket;
+    ms = (memif_socket_t *)c->args.socket;
 
-  l1 = strlen ((char *) c->args.interface_name);
-  if (l0 + l1 < buflen)
-    {
-      md->if_name =
-	(uint8_t *) strcpy (buf + l0, (char *) c->args.interface_name);
-      l0 += l1 + 1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = strlen((char *)c->args.interface_name);
+    if (l0 + l1 < buflen) {
+        md->if_name = (uint8_t *)strcpy(buf + l0, (char *)c->args.interface_name);
+        l0 += l1 + 1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  l1 = strlen ((char *) ms->args.app_name);
-  if (l0 + l1 < buflen)
-    {
-      md->inst_name =
-	(uint8_t *) strcpy (buf + l0, (char *) ms->args.app_name);
-      l0 += l1 + 1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = strlen((char *)ms->args.app_name);
+    if (l0 + l1 < buflen) {
+        md->inst_name = (uint8_t *)strcpy(buf + l0, (char *)ms->args.app_name);
+        l0 += l1 + 1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  l1 = strlen ((char *) c->remote_if_name);
-  if (l0 + l1 < buflen)
-    {
-      md->remote_if_name =
-	(uint8_t *) strcpy (buf + l0, (char *) c->remote_if_name);
-      l0 += l1 + 1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = strlen((char *)c->remote_if_name);
+    if (l0 + l1 < buflen) {
+        md->remote_if_name = (uint8_t *)strcpy(buf + l0, (char *)c->remote_if_name);
+        l0 += l1 + 1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  l1 = strlen ((char *) c->remote_name);
-  if (l0 + l1 < buflen)
-    {
-      md->remote_inst_name =
-	(uint8_t *) strcpy (buf + l0, (char *) c->remote_name);
-      l0 += l1 + 1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = strlen((char *)c->remote_name);
+    if (l0 + l1 < buflen) {
+        md->remote_inst_name = (uint8_t *)strcpy(buf + l0, (char *)c->remote_name);
+        l0 += l1 + 1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  md->id = c->args.interface_id;
+    md->id = c->args.interface_id;
 
-  if (strlen ((char *) c->args.secret) > 0)
-    {
-      l1 = strlen ((char *) c->args.secret);
-      if (l0 + l1 < buflen)
-	{
-	  md->secret = (uint8_t *) strcpy (buf + l0, (char *) c->args.secret);
-	  l0 += l1 + 1;
-	}
-      else
-	err = MEMIF_ERR_NOBUF_DET;
+    if (strlen((char *)c->args.secret) > 0) {
+        l1 = strlen((char *)c->args.secret);
+        if (l0 + l1 < buflen) {
+            md->secret = (uint8_t *)strcpy(buf + l0, (char *)c->args.secret);
+            l0 += l1 + 1;
+        } else
+            err = MEMIF_ERR_NOBUF_DET;
     }
 
-  md->role = (c->args.is_master) ? 0 : 1;
-  md->mode = c->args.mode;
+    md->role = (c->args.is_master) ? 0 : 1;
+    md->mode = c->args.mode;
 
-  l1 = 108;
-  if (l0 + l1 < buflen)
-    {
-      md->socket_path = (uint8_t *) memcpy (buf + l0, ms->args.path, 108);
-      l0 += l1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = 108;
+    if (l0 + l1 < buflen) {
+        md->socket_path = (uint8_t *)memcpy(buf + l0, ms->args.path, 108);
+        l0 += l1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  l1 = strlen ((char *) c->remote_disconnect_string);
-  if (l0 + l1 < buflen)
-    {
-      md->error =
-	(uint8_t *) strcpy (buf + l0, (char *) c->remote_disconnect_string);
-      l0 += l1 + 1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = strlen((char *)c->remote_disconnect_string);
+    if (l0 + l1 < buflen) {
+        md->error = (uint8_t *)strcpy(buf + l0, (char *)c->remote_disconnect_string);
+        l0 += l1 + 1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  md->regions_num = c->regions_num;
-  l1 = sizeof (memif_region_details_t) * md->regions_num;
-  if (l0 + l1 <= buflen)
-    {
-      md->regions = (memif_region_details_t *) (buf + l0);
-      for (i = 0; i < md->regions_num; i++)
-	{
-	  md->regions[i].index = i;
-	  md->regions[i].addr = c->regions[i].addr;
-	  md->regions[i].size = c->regions[i].region_size;
-	  md->regions[i].fd = c->regions[i].fd;
-	  md->regions[i].is_external = c->regions[i].is_external;
-	}
-      l0 += l1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    md->regions_num = c->regions_num;
+    l1 = sizeof(memif_region_details_t) * md->regions_num;
+    if (l0 + l1 <= buflen) {
+        md->regions = (memif_region_details_t *)(buf + l0);
+        for (i = 0; i < md->regions_num; i++) {
+            md->regions[i].index = i;
+            md->regions[i].addr = c->regions[i].addr;
+            md->regions[i].size = c->regions[i].region_size;
+            md->regions[i].fd = c->regions[i].fd;
+            md->regions[i].is_external = c->regions[i].is_external;
+        }
+        l0 += l1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  md->rx_queues_num =
-    (c->args.is_master) ? c->run_args.num_s2m_rings : c->
-    run_args.num_m2s_rings;
+    md->rx_queues_num = (c->args.is_master) ? c->run_args.num_s2m_rings : c->run_args.num_m2s_rings;
 
-  l1 = sizeof (memif_queue_details_t) * md->rx_queues_num;
-  if (l0 + l1 <= buflen)
-    {
-      md->rx_queues = (memif_queue_details_t *) (buf + l0);
-      for (i = 0; i < md->rx_queues_num; i++)
-	{
-	  md->rx_queues[i].region = c->rx_queues[i].region;
-	  md->rx_queues[i].qid = i;
-	  md->rx_queues[i].ring_size = (1 << c->rx_queues[i].log2_ring_size);
-	  md->rx_queues[i].flags = c->rx_queues[i].ring->flags;
-	  md->rx_queues[i].head = c->rx_queues[i].ring->head;
-	  md->rx_queues[i].tail = c->rx_queues[i].ring->tail;
-	  md->rx_queues[i].buffer_size = c->run_args.buffer_size;
-	}
-      l0 += l1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = sizeof(memif_queue_details_t) * md->rx_queues_num;
+    if (l0 + l1 <= buflen) {
+        md->rx_queues = (memif_queue_details_t *)(buf + l0);
+        for (i = 0; i < md->rx_queues_num; i++) {
+            md->rx_queues[i].region = c->rx_queues[i].region;
+            md->rx_queues[i].qid = i;
+            md->rx_queues[i].ring_size = (1 << c->rx_queues[i].log2_ring_size);
+            md->rx_queues[i].flags = c->rx_queues[i].ring->flags;
+            md->rx_queues[i].head = c->rx_queues[i].ring->head;
+            md->rx_queues[i].tail = c->rx_queues[i].ring->tail;
+            md->rx_queues[i].buffer_size = c->run_args.buffer_size;
+        }
+        l0 += l1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  md->tx_queues_num =
-    (c->args.is_master) ? c->run_args.num_m2s_rings : c->
-    run_args.num_s2m_rings;
+    md->tx_queues_num = (c->args.is_master) ? c->run_args.num_m2s_rings : c->run_args.num_s2m_rings;
 
-  l1 = sizeof (memif_queue_details_t) * md->tx_queues_num;
-  if (l0 + l1 <= buflen)
-    {
-      md->tx_queues = (memif_queue_details_t *) (buf + l0);
-      for (i = 0; i < md->tx_queues_num; i++)
-	{
-	  md->tx_queues[i].region = c->tx_queues[i].region;
-	  md->tx_queues[i].qid = i;
-	  md->tx_queues[i].ring_size = (1 << c->tx_queues[i].log2_ring_size);
-	  md->tx_queues[i].flags = c->tx_queues[i].ring->flags;
-	  md->tx_queues[i].head = c->tx_queues[i].ring->head;
-	  md->tx_queues[i].tail = c->tx_queues[i].ring->tail;
-	  md->tx_queues[i].buffer_size = c->run_args.buffer_size;
-	}
-      l0 += l1;
-    }
-  else
-    err = MEMIF_ERR_NOBUF_DET;
+    l1 = sizeof(memif_queue_details_t) * md->tx_queues_num;
+    if (l0 + l1 <= buflen) {
+        md->tx_queues = (memif_queue_details_t *)(buf + l0);
+        for (i = 0; i < md->tx_queues_num; i++) {
+            md->tx_queues[i].region = c->tx_queues[i].region;
+            md->tx_queues[i].qid = i;
+            md->tx_queues[i].ring_size = (1 << c->tx_queues[i].log2_ring_size);
+            md->tx_queues[i].flags = c->tx_queues[i].ring->flags;
+            md->tx_queues[i].head = c->tx_queues[i].ring->head;
+            md->tx_queues[i].tail = c->tx_queues[i].ring->tail;
+            md->tx_queues[i].buffer_size = c->run_args.buffer_size;
+        }
+        l0 += l1;
+    } else
+        err = MEMIF_ERR_NOBUF_DET;
 
-  /* This is not completely true, clients should relay on
-   * on_connect/on_disconnect callbacks */
-  md->link_up_down = (c->control_channel != NULL) ? 1 : 0;
+    /* This is not completely true, clients should relay on
+     * on_connect/on_disconnect callbacks */
+    md->link_up_down = (c->control_channel != NULL) ? 1 : 0;
 
-  return err;			/* 0 */
+    return err; /* 0 */
 }
 
-int
-memif_get_queue_efd (memif_conn_handle_t conn, uint16_t qid, int *efd)
+int memif_get_queue_efd(memif_conn_handle_t conn, uint16_t qid, int *efd)
 {
-  memif_connection_t *c = (memif_connection_t *) conn;
-  uint8_t num;
+    memif_connection_t *c = (memif_connection_t *)conn;
+    uint8_t num;
 
-  *efd = -1;
-  if (c == NULL)
-    return MEMIF_ERR_NOCONN;
-  if (c->control_channel == NULL)
-    return MEMIF_ERR_DISCONNECTED;
+    *efd = -1;
+    if (c == NULL)
+        return MEMIF_ERR_NOCONN;
+    if (c->control_channel == NULL)
+        return MEMIF_ERR_DISCONNECTED;
 
-  num =
-    (c->args.is_master) ? c->run_args.num_s2m_rings : c->
-    run_args.num_m2s_rings;
-  if (qid >= num)
-    return MEMIF_ERR_QID;
+    num = (c->args.is_master) ? c->run_args.num_s2m_rings : c->run_args.num_m2s_rings;
+    if (qid >= num)
+        return MEMIF_ERR_QID;
 
-  *efd = c->rx_queues[qid].int_fd;
+    *efd = c->rx_queues[qid].int_fd;
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 }

--- a/sdk/3rdparty/libmemif/src/memif.h
+++ b/sdk/3rdparty/libmemif/src/memif.h
@@ -24,39 +24,33 @@
 #define MEMIF_CACHELINE_SIZE 64
 #endif
 
-#define MEMIF_COOKIE		0x3E31F20
-#define MEMIF_VERSION_MAJOR	2
-#define MEMIF_VERSION_MINOR	0
-#define MEMIF_VERSION		((MEMIF_VERSION_MAJOR << 8) | MEMIF_VERSION_MINOR)
+#define MEMIF_COOKIE 0x3E31F20
+#define MEMIF_VERSION_MAJOR 2
+#define MEMIF_VERSION_MINOR 0
+#define MEMIF_VERSION ((MEMIF_VERSION_MAJOR << 8) | MEMIF_VERSION_MINOR)
 
 /*
  *  Type definitions
  */
 
-typedef enum memif_msg_type
-{
-  MEMIF_MSG_TYPE_NONE = 0,
-  MEMIF_MSG_TYPE_ACK = 1,
-  MEMIF_MSG_TYPE_HELLO = 2,
-  MEMIF_MSG_TYPE_INIT = 3,
-  MEMIF_MSG_TYPE_ADD_REGION = 4,
-  MEMIF_MSG_TYPE_ADD_RING = 5,
-  MEMIF_MSG_TYPE_CONNECT = 6,
-  MEMIF_MSG_TYPE_CONNECTED = 7,
-  MEMIF_MSG_TYPE_DISCONNECT = 8,
+typedef enum memif_msg_type {
+    MEMIF_MSG_TYPE_NONE = 0,
+    MEMIF_MSG_TYPE_ACK = 1,
+    MEMIF_MSG_TYPE_HELLO = 2,
+    MEMIF_MSG_TYPE_INIT = 3,
+    MEMIF_MSG_TYPE_ADD_REGION = 4,
+    MEMIF_MSG_TYPE_ADD_RING = 5,
+    MEMIF_MSG_TYPE_CONNECT = 6,
+    MEMIF_MSG_TYPE_CONNECTED = 7,
+    MEMIF_MSG_TYPE_DISCONNECT = 8,
 } memif_msg_type_t;
 
-typedef enum
-{
-  MEMIF_RING_S2M = 0,
-  MEMIF_RING_M2S = 1
-} memif_ring_type_t;
+typedef enum { MEMIF_RING_S2M = 0, MEMIF_RING_M2S = 1 } memif_ring_type_t;
 
-typedef enum
-{
-  MEMIF_INTERFACE_MODE_ETHERNET = 0,
-  MEMIF_INTERFACE_MODE_IP = 1,
-  MEMIF_INTERFACE_MODE_PUNT_INJECT = 2,
+typedef enum {
+    MEMIF_INTERFACE_MODE_ETHERNET = 0,
+    MEMIF_INTERFACE_MODE_IP = 1,
+    MEMIF_INTERFACE_MODE_PUNT_INJECT = 2,
 } memif_interface_mode_t;
 
 typedef uint16_t memif_region_index_t;
@@ -71,108 +65,95 @@ typedef uint8_t memif_log2_ring_size_t;
  *  Socket messages
  */
 
-typedef struct __attribute__ ((packed))
-{
-  uint8_t name[32];
-  memif_version_t min_version;
-  memif_version_t max_version;
-  memif_region_index_t max_region;
-  memif_ring_index_t max_m2s_ring;
-  memif_ring_index_t max_s2m_ring;
-  memif_log2_ring_size_t max_log2_ring_size;
+typedef struct __attribute__((packed)) {
+    uint8_t name[32];
+    memif_version_t min_version;
+    memif_version_t max_version;
+    memif_region_index_t max_region;
+    memif_ring_index_t max_m2s_ring;
+    memif_ring_index_t max_s2m_ring;
+    memif_log2_ring_size_t max_log2_ring_size;
 } memif_msg_hello_t;
 
-typedef struct __attribute__ ((packed))
-{
-  memif_version_t version;
-  memif_interface_id_t id;
-  memif_interface_mode_t mode:8;
-  uint8_t secret[24];
-  uint8_t name[32];
+typedef struct __attribute__((packed)) {
+    memif_version_t version;
+    memif_interface_id_t id;
+    memif_interface_mode_t mode : 8;
+    uint8_t secret[24];
+    uint8_t name[32];
 } memif_msg_init_t;
 
-typedef struct __attribute__ ((packed))
-{
-  memif_region_index_t index;
-  memif_region_size_t size;
+typedef struct __attribute__((packed)) {
+    memif_region_index_t index;
+    memif_region_size_t size;
 } memif_msg_add_region_t;
 
-typedef struct __attribute__ ((packed))
-{
-  uint16_t flags;
-#define MEMIF_MSG_ADD_RING_FLAG_S2M	(1 << 0)
-  memif_ring_index_t index;
-  memif_region_index_t region;
-  memif_region_offset_t offset;
-  memif_log2_ring_size_t log2_ring_size;
-  uint16_t private_hdr_size;	/* used for private metadata */
+typedef struct __attribute__((packed)) {
+    uint16_t flags;
+#define MEMIF_MSG_ADD_RING_FLAG_S2M (1 << 0)
+    memif_ring_index_t index;
+    memif_region_index_t region;
+    memif_region_offset_t offset;
+    memif_log2_ring_size_t log2_ring_size;
+    uint16_t private_hdr_size; /* used for private metadata */
 } memif_msg_add_ring_t;
 
-typedef struct __attribute__ ((packed))
-{
-  uint8_t if_name[32];
+typedef struct __attribute__((packed)) {
+    uint8_t if_name[32];
 } memif_msg_connect_t;
 
-typedef struct __attribute__ ((packed))
-{
-  uint8_t if_name[32];
+typedef struct __attribute__((packed)) {
+    uint8_t if_name[32];
 } memif_msg_connected_t;
 
-typedef struct __attribute__ ((packed))
-{
-  uint32_t code;
-  uint8_t string[96];
+typedef struct __attribute__((packed)) {
+    uint32_t code;
+    uint8_t string[96];
 } memif_msg_disconnect_t;
 
-typedef struct __attribute__ ((packed, aligned (128)))
-{
-  memif_msg_type_t type:16;
-  union
-  {
-    memif_msg_hello_t hello;
-    memif_msg_init_t init;
-    memif_msg_add_region_t add_region;
-    memif_msg_add_ring_t add_ring;
-    memif_msg_connect_t connect;
-    memif_msg_connected_t connected;
-    memif_msg_disconnect_t disconnect;
-  };
+typedef struct __attribute__((packed, aligned(128))) {
+    memif_msg_type_t type : 16;
+    union {
+        memif_msg_hello_t hello;
+        memif_msg_init_t init;
+        memif_msg_add_region_t add_region;
+        memif_msg_add_ring_t add_ring;
+        memif_msg_connect_t connect;
+        memif_msg_connected_t connected;
+        memif_msg_disconnect_t disconnect;
+    };
 } memif_msg_t;
 
-_Static_assert (sizeof (memif_msg_t) == 128,
-		"Size of memif_msg_t must be 128");
+_Static_assert(sizeof(memif_msg_t) == 128, "Size of memif_msg_t must be 128");
 
 /*
  *  Ring and Descriptor Layout
  */
 
-typedef struct __attribute__ ((packed))
-{
-  uint16_t flags;
+typedef struct __attribute__((packed)) {
+    uint16_t flags;
 #define MEMIF_DESC_FLAG_NEXT (1 << 0)
-  memif_region_index_t region;
-  uint32_t length;
-  memif_region_offset_t offset;
-  uint32_t metadata;
+    memif_region_index_t region;
+    uint32_t length;
+    memif_region_offset_t offset;
+    uint32_t metadata;
 } memif_desc_t;
 
-_Static_assert (sizeof (memif_desc_t) == 16,
-		"Size of memif_dsct_t must be 16 bytes");
+_Static_assert(sizeof(memif_desc_t) == 16, "Size of memif_dsct_t must be 16 bytes");
 
-#define MEMIF_CACHELINE_ALIGN_MARK(mark) \
-  uint8_t mark[0] __attribute__((aligned(MEMIF_CACHELINE_SIZE)))
+#define MEMIF_CACHELINE_ALIGN_MARK(mark)                                                           \
+    uint8_t mark[0] __attribute__((aligned(MEMIF_CACHELINE_SIZE)))
 
-typedef struct
-{
-  MEMIF_CACHELINE_ALIGN_MARK (cacheline0);
-  uint32_t cookie;
-  uint16_t flags;
+typedef struct {
+    MEMIF_CACHELINE_ALIGN_MARK(cacheline0);
+    uint32_t cookie;
+    uint16_t flags;
 #define MEMIF_RING_FLAG_MASK_INT 1
-  volatile uint16_t head;
-    MEMIF_CACHELINE_ALIGN_MARK (cacheline1);
-  volatile uint16_t tail;
-    MEMIF_CACHELINE_ALIGN_MARK (cacheline2);
-  memif_desc_t desc[0];
+    volatile uint16_t head;
+    MEMIF_CACHELINE_ALIGN_MARK(cacheline1);
+    volatile uint16_t tail;
+    MEMIF_CACHELINE_ALIGN_MARK(cacheline2);
+    memif_desc_t desc[0];
 } memif_ring_t;
 
 #endif /* _MEMIF_H_ */

--- a/sdk/3rdparty/libmemif/src/memif_private.h
+++ b/sdk/3rdparty/libmemif/src/memif_private.h
@@ -15,7 +15,6 @@
  *------------------------------------------------------------------
  */
 
-
 #ifndef _MEMIF_PRIVATE_H_
 #define _MEMIF_PRIVATE_H_
 
@@ -33,8 +32,8 @@
 #include <libmemif.h>
 
 #define MEMIF_NAME_LEN 32
-_Static_assert (strlen (MEMIF_DEFAULT_APP_NAME) <= MEMIF_NAME_LEN,
-		"MEMIF_DEFAULT_APP_NAME max length is 32");
+_Static_assert(strlen(MEMIF_DEFAULT_APP_NAME) <= MEMIF_NAME_LEN,
+               "MEMIF_DEFAULT_APP_NAME max length is 32");
 
 #define MEMIF_DEFAULT_SOCKET_PATH "/run/vpp/memif.sock"
 #define MEMIF_DEFAULT_RING_SIZE 1024
@@ -45,129 +44,122 @@ _Static_assert (strlen (MEMIF_DEFAULT_APP_NAME) <= MEMIF_NAME_LEN,
 #define MEMIF_DEFAULT_RECONNECT_PERIOD_SEC 2
 #define MEMIF_DEFAULT_RECONNECT_PERIOD_NSEC 0
 
-#define MEMIF_MAX_M2S_RING		255
-#define MEMIF_MAX_S2M_RING		255
-#define MEMIF_MAX_REGION		255
-#define MEMIF_MAX_LOG2_RING_SIZE	14
+#define MEMIF_MAX_M2S_RING 255
+#define MEMIF_MAX_S2M_RING 255
+#define MEMIF_MAX_REGION 255
+#define MEMIF_MAX_LOG2_RING_SIZE 14
 
 #define MEMIF_MAX_FDS 512
 
-#define memif_min(a,b) (((a) < (b)) ? (a) : (b))
+#define memif_min(a, b) (((a) < (b)) ? (a) : (b))
 
-#define EXPECT_TRUE(x) __builtin_expect((x),1)
-#define EXPECT_FALSE(x) __builtin_expect((x),0)
+#define EXPECT_TRUE(x) __builtin_expect((x), 1)
+#define EXPECT_FALSE(x) __builtin_expect((x), 0)
 
 #ifdef MEMIF_DBG
-#define DBG(...) do {                                                             \
-                        printf("MEMIF_DEBUG:%s:%s:%d: ", __FILE__, __func__, __LINE__);  \
-                        printf(__VA_ARGS__);                                            \
-                        printf("\n");                                                   \
-                        } while (0)
+#define DBG(...)                                                                                   \
+    do {                                                                                           \
+        printf("MEMIF_DEBUG:%s:%s:%d: ", __FILE__, __func__, __LINE__);                            \
+        printf(__VA_ARGS__);                                                                       \
+        printf("\n");                                                                              \
+    } while (0)
 #else
 #define DBG(...)
 #endif /* MEMIF_DBG */
 
 #ifndef HAS_LIB_BSD
-static inline size_t
-strlcpy (char *dest, const char *src, size_t len)
+static inline size_t strlcpy(char *dest, const char *src, size_t len)
 {
-  const char *s = src;
-  size_t n = len;
+    const char *s = src;
+    size_t n = len;
 
-  while (--n > 0)
-    {
-      if ((*dest++ = *s++) == '\0')
-	break;
+    while (--n > 0) {
+        if ((*dest++ = *s++) == '\0')
+            break;
     }
 
-  if (n == 0)
-    {
-      if (len != 0)
-	*dest = '\0';
-      while (*s++)
-	;
+    if (n == 0) {
+        if (len != 0)
+            *dest = '\0';
+        while (*s++)
+            ;
     }
 
-  return (s - src - 1);
+    return (s - src - 1);
 }
 #else
 #include <bsd/string.h>
 #endif
 
-typedef enum
-{
-  MEMIF_SOCKET_TYPE_NONE = 0,	/* unassigned, not used by any interface */
-  MEMIF_SOCKET_TYPE_LISTENER,	/* listener socket, master interface assigned */
-  MEMIF_SOCKET_TYPE_CLIENT	/* client socket, slave interface assigned */
+typedef enum {
+    MEMIF_SOCKET_TYPE_NONE = 0, /* unassigned, not used by any interface */
+    MEMIF_SOCKET_TYPE_LISTENER, /* listener socket, master interface assigned */
+    MEMIF_SOCKET_TYPE_CLIENT    /* client socket, slave interface assigned */
 } memif_socket_type_t;
 
-typedef struct
-{
-  void *addr;
-  memif_region_size_t region_size;
-  uint32_t buffer_offset;
-  int fd;
-  uint8_t is_external;
+typedef struct {
+    void *addr;
+    memif_region_size_t region_size;
+    uint32_t buffer_offset;
+    int fd;
+    uint8_t is_external;
 } memif_region_t;
 
-typedef struct
-{
-  memif_ring_t *ring;
-  uint8_t log2_ring_size;
-  uint8_t region;
-  uint32_t offset;
+typedef struct {
+    memif_ring_t *ring;
+    uint8_t log2_ring_size;
+    uint8_t region;
+    uint32_t offset;
 
-  uint16_t last_head;
-  uint16_t last_tail;
+    uint16_t last_head;
+    uint16_t last_tail;
 
-  int int_fd;
+    int int_fd;
 
-  uint64_t int_count;
-  uint32_t next_buf; /* points to next free buffer */
+    uint64_t int_count;
+    uint32_t next_buf; /* points to next free buffer */
 } memif_queue_t;
 
 struct memif_connection;
 
 typedef struct memif_connection memif_connection_t;
 
-typedef struct
-{
-  uint8_t num_s2m_rings;
-  uint8_t num_m2s_rings;
-  uint32_t buffer_size;
-  memif_log2_ring_size_t log2_ring_size;
+typedef struct {
+    uint8_t num_s2m_rings;
+    uint8_t num_m2s_rings;
+    uint32_t buffer_size;
+    memif_log2_ring_size_t log2_ring_size;
 } memif_conn_run_args_t;
 
 struct memif_control_channel;
 
-typedef struct memif_connection
-{
-  uint16_t index;
-  memif_conn_args_t args;
-  memif_conn_run_args_t run_args;
+typedef struct memif_connection {
+    uint16_t index;
+    memif_conn_args_t args;
+    memif_conn_run_args_t run_args;
 
-  struct memif_control_channel *control_channel;
+    struct memif_control_channel *control_channel;
 
-  memif_connection_update_t *on_connect, *on_disconnect;
-  memif_on_interrupt_t *on_interrupt;
-  void *private_ctx;
+    memif_connection_update_t *on_connect, *on_disconnect;
+    memif_on_interrupt_t *on_interrupt;
+    void *private_ctx;
 
-  uint8_t remote_if_name[MEMIF_NAME_LEN];
-  uint8_t remote_name[MEMIF_NAME_LEN];
-  uint8_t remote_disconnect_string[96];
+    uint8_t remote_if_name[MEMIF_NAME_LEN];
+    uint8_t remote_name[MEMIF_NAME_LEN];
+    uint8_t remote_disconnect_string[96];
 
-  uint8_t regions_num;
-  memif_region_t *regions;
+    uint8_t regions_num;
+    memif_region_t *regions;
 
-  uint8_t rx_queues_num;
-  uint8_t tx_queues_num;
-  memif_queue_t *rx_queues;
-  memif_queue_t *tx_queues;
+    uint8_t rx_queues_num;
+    uint8_t tx_queues_num;
+    memif_queue_t *rx_queues;
+    memif_queue_t *tx_queues;
 
-  uint16_t flags;
+    uint16_t flags;
 #define MEMIF_CONNECTION_FLAG_WRITE (1 << 0)
 
-  TAILQ_ENTRY (memif_connection) next;
+    TAILQ_ENTRY(memif_connection) next;
 } memif_connection_t;
 
 /** \brief Memif message queue element
@@ -175,11 +167,10 @@ typedef struct memif_connection
  * @param nex - tailq entry
  * @param fd - File descriptor to be shared with peer endpoint
  */
-typedef struct memif_msg_queue_elt
-{
-  memif_msg_t msg;
-  TAILQ_ENTRY (memif_msg_queue_elt) next;
-  int fd;
+typedef struct memif_msg_queue_elt {
+    memif_msg_t msg;
+    TAILQ_ENTRY(memif_msg_queue_elt) next;
+    int fd;
 } memif_msg_queue_elt_t;
 
 struct memif_socket;
@@ -194,12 +185,11 @@ struct memif_socket;
  * endpoints. The controll channel is responsible for receiving and
  * transmitting memif control messages via UNIX domain socket.
  */
-typedef struct memif_control_channel
-{
-  int fd;
-  TAILQ_HEAD (, memif_msg_queue_elt) msg_queue;
-  memif_connection_t *conn;
-  struct memif_socket *sock;
+typedef struct memif_control_channel {
+    int fd;
+    TAILQ_HEAD(, memif_msg_queue_elt) msg_queue;
+    memif_connection_t *conn;
+    struct memif_socket *sock;
 } memif_control_channel_t;
 
 /** \brief Memif socket
@@ -212,54 +202,50 @@ typedef struct memif_control_channel
  * @param slave_interfaces - slave interface queue
  * @param control_channels - controll channel queue
  */
-typedef struct memif_socket
-{
-  memif_socket_args_t args;
-  int epfd;
-  int poll_cancel_fd;
-  int listener_fd;
-  int timer_fd;
-  struct itimerspec timer;
-  void *private_ctx;
-  TAILQ_HEAD (, memif_connection) master_interfaces;
-  TAILQ_HEAD (, memif_connection) slave_interfaces;
+typedef struct memif_socket {
+    memif_socket_args_t args;
+    int epfd;
+    int poll_cancel_fd;
+    int listener_fd;
+    int timer_fd;
+    struct itimerspec timer;
+    void *private_ctx;
+    TAILQ_HEAD(, memif_connection) master_interfaces;
+    TAILQ_HEAD(, memif_connection) slave_interfaces;
 
-  /* External region callbacks */
-  memif_add_external_region_t *add_external_region;
-  memif_get_external_region_addr_t *get_external_region_addr;
-  memif_del_external_region_t *del_external_region;
-  memif_get_external_buffer_offset_t *get_external_buffer_offset;
+    /* External region callbacks */
+    memif_add_external_region_t *add_external_region;
+    memif_get_external_region_addr_t *get_external_region_addr;
+    memif_del_external_region_t *del_external_region;
+    memif_get_external_buffer_offset_t *get_external_buffer_offset;
 } memif_socket_t;
 
-typedef int (memif_fd_event_handler_t) (memif_fd_event_type_t type,
-					void *private_ctx);
+typedef int(memif_fd_event_handler_t)(memif_fd_event_type_t type, void *private_ctx);
 
-typedef struct memif_fd_event_data
-{
-  memif_fd_event_handler_t *event_handler;
-  void *private_ctx;
+typedef struct memif_fd_event_data {
+    memif_fd_event_handler_t *event_handler;
+    void *private_ctx;
 } memif_fd_event_data_t;
 
-typedef struct memif_interrupt
-{
-  memif_connection_t *c;
-  uint16_t qid;
+typedef struct memif_interrupt {
+    memif_connection_t *c;
+    uint16_t qid;
 } memif_interrupt_t;
 
 /* main.c */
 
 /* if region doesn't contain shared memory, mmap region, check ring cookie */
-int memif_connect1 (memif_connection_t * c);
+int memif_connect1(memif_connection_t *c);
 
 /* memory map region, initialize rings and queues */
-int memif_init_regions_and_queues (memif_connection_t * c);
+int memif_init_regions_and_queues(memif_connection_t *c);
 
-int memif_disconnect_internal (memif_connection_t * c);
+int memif_disconnect_internal(memif_connection_t *c);
 
-int memif_interrupt_handler (memif_fd_event_type_t type, void *private_ctx);
+int memif_interrupt_handler(memif_fd_event_type_t type, void *private_ctx);
 
 /* map errno to memif error code */
-int memif_syscall_error_handler (int err_code);
+int memif_syscall_error_handler(int err_code);
 
 #ifndef __NR_memfd_create
 #if defined __x86_64__
@@ -274,19 +260,15 @@ int memif_syscall_error_handler (int err_code);
 #endif
 
 #ifndef HAVE_MEMFD_CREATE
-static inline int
-memfd_create (const char *name, unsigned int flags)
+static inline int memfd_create(const char *name, unsigned int flags)
 {
-  return syscall (__NR_memfd_create, name, flags);
+    return syscall(__NR_memfd_create, name, flags);
 }
 #endif
 
-static inline void *
-memif_get_buffer (memif_connection_t * conn, memif_ring_t * ring,
-		  uint16_t index)
+static inline void *memif_get_buffer(memif_connection_t *conn, memif_ring_t *ring, uint16_t index)
 {
-  return (conn->regions[ring->desc[index].region].addr +
-	  ring->desc[index].offset);
+    return (conn->regions[ring->desc[index].region].addr + ring->desc[index].offset);
 }
 
 #ifndef F_LINUX_SPECIFIC_BASE
@@ -294,17 +276,17 @@ memif_get_buffer (memif_connection_t * conn, memif_ring_t * ring,
 #endif
 
 #ifndef MFD_ALLOW_SEALING
-#define MFD_ALLOW_SEALING       0x0002U
+#define MFD_ALLOW_SEALING 0x0002U
 #endif
 
 #ifndef F_ADD_SEALS
 #define F_ADD_SEALS (F_LINUX_SPECIFIC_BASE + 9)
 #define F_GET_SEALS (F_LINUX_SPECIFIC_BASE + 10)
 
-#define F_SEAL_SEAL     0x0001	/* prevent further seals from being set */
-#define F_SEAL_SHRINK   0x0002	/* prevent file from shrinking */
-#define F_SEAL_GROW     0x0004	/* prevent file from growing */
-#define F_SEAL_WRITE    0x0008	/* prevent writes */
+#define F_SEAL_SEAL 0x0001   /* prevent further seals from being set */
+#define F_SEAL_SHRINK 0x0002 /* prevent file from shrinking */
+#define F_SEAL_GROW 0x0004   /* prevent file from growing */
+#define F_SEAL_WRITE 0x0008  /* prevent writes */
 #endif
 
 #endif /* _MEMIF_PRIVATE_H_ */

--- a/sdk/3rdparty/libmemif/src/socket.c
+++ b/sdk/3rdparty/libmemif/src/socket.c
@@ -35,818 +35,739 @@
 #include <memif_private.h>
 
 /* sends msg to socket */
-static int
-memif_msg_send_from_queue (memif_control_channel_t *cc)
+static int memif_msg_send_from_queue(memif_control_channel_t *cc)
 {
-  struct msghdr mh = { 0 };
-  struct iovec iov[1];
-  char ctl[CMSG_SPACE (sizeof (int))];
-  int rv, err = MEMIF_ERR_SUCCESS;	/* 0 */
-  memif_msg_queue_elt_t *e;
+    struct msghdr mh = {0};
+    struct iovec iov[1];
+    char ctl[CMSG_SPACE(sizeof(int))];
+    int rv, err = MEMIF_ERR_SUCCESS; /* 0 */
+    memif_msg_queue_elt_t *e;
 
-  /* Pick the first message */
-  e = TAILQ_FIRST (&cc->msg_queue);
-  if (e == NULL)
+    /* Pick the first message */
+    e = TAILQ_FIRST(&cc->msg_queue);
+    if (e == NULL)
+        return MEMIF_ERR_SUCCESS;
+
+    /* Construct the message */
+    iov[0].iov_base = (void *)&e->msg;
+    iov[0].iov_len = sizeof(memif_msg_t);
+    mh.msg_iov = iov;
+    mh.msg_iovlen = 1;
+
+    if (e->fd > 0) {
+        struct cmsghdr *cmsg;
+        memset(&ctl, 0, sizeof(ctl));
+        mh.msg_control = ctl;
+        mh.msg_controllen = sizeof(ctl);
+        cmsg = CMSG_FIRSTHDR(&mh);
+        cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+        cmsg->cmsg_level = SOL_SOCKET;
+        cmsg->cmsg_type = SCM_RIGHTS;
+        memcpy(CMSG_DATA(cmsg), &e->fd, sizeof(int));
+    }
+    rv = sendmsg(cc->fd, &mh, 0);
+    if (rv < 0)
+        err = memif_syscall_error_handler(errno);
+    DBG("Message type %u sent", e->msg.type);
+
+    /* If sent successfully, remove the msg from queue */
+    if (err == MEMIF_ERR_SUCCESS) {
+        TAILQ_REMOVE(&cc->msg_queue, e, next);
+        cc->sock->args.free(e);
+    }
+
+    return err;
+}
+
+static memif_msg_queue_elt_t *memif_msg_enq(memif_control_channel_t *cc)
+{
+    memif_msg_queue_elt_t *e;
+
+    e = cc->sock->args.alloc(sizeof(*e));
+    if (e == NULL)
+        return NULL;
+
+    e->fd = -1;
+    TAILQ_INSERT_TAIL(&cc->msg_queue, e, next);
+
+    return e;
+}
+
+static int memif_msg_enq_hello(memif_control_channel_t *cc)
+{
+    memif_msg_hello_t *h;
+    memif_msg_queue_elt_t *e = memif_msg_enq(cc);
+
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
+
+    e->msg.type = MEMIF_MSG_TYPE_HELLO;
+
+    h = &e->msg.hello;
+    h->min_version = MEMIF_VERSION;
+    h->max_version = MEMIF_VERSION;
+    h->max_s2m_ring = MEMIF_MAX_S2M_RING;
+    h->max_m2s_ring = MEMIF_MAX_M2S_RING;
+    h->max_region = MEMIF_MAX_REGION;
+    h->max_log2_ring_size = MEMIF_MAX_LOG2_RING_SIZE;
+
+    strlcpy((char *)h->name, (char *)cc->sock->args.app_name, sizeof(h->name));
+
     return MEMIF_ERR_SUCCESS;
-
-  /* Construct the message */
-  iov[0].iov_base = (void *) &e->msg;
-  iov[0].iov_len = sizeof (memif_msg_t);
-  mh.msg_iov = iov;
-  mh.msg_iovlen = 1;
-
-  if (e->fd > 0)
-    {
-      struct cmsghdr *cmsg;
-      memset (&ctl, 0, sizeof (ctl));
-      mh.msg_control = ctl;
-      mh.msg_controllen = sizeof (ctl);
-      cmsg = CMSG_FIRSTHDR (&mh);
-      cmsg->cmsg_len = CMSG_LEN (sizeof (int));
-      cmsg->cmsg_level = SOL_SOCKET;
-      cmsg->cmsg_type = SCM_RIGHTS;
-      memcpy (CMSG_DATA (cmsg), &e->fd, sizeof (int));
-    }
-  rv = sendmsg (cc->fd, &mh, 0);
-  if (rv < 0)
-    err = memif_syscall_error_handler (errno);
-  DBG ("Message type %u sent", e->msg.type);
-
-  /* If sent successfully, remove the msg from queue */
-  if (err == MEMIF_ERR_SUCCESS)
-    {
-      TAILQ_REMOVE (&cc->msg_queue, e, next);
-      cc->sock->args.free (e);
-    }
-
-  return err;
-}
-
-static memif_msg_queue_elt_t *
-memif_msg_enq (memif_control_channel_t *cc)
-{
-  memif_msg_queue_elt_t *e;
-
-  e = cc->sock->args.alloc (sizeof (*e));
-  if (e == NULL)
-    return NULL;
-
-  e->fd = -1;
-  TAILQ_INSERT_TAIL (&cc->msg_queue, e, next);
-
-  return e;
-}
-
-static int
-memif_msg_enq_hello (memif_control_channel_t *cc)
-{
-  memif_msg_hello_t *h;
-  memif_msg_queue_elt_t *e = memif_msg_enq (cc);
-
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
-
-  e->msg.type = MEMIF_MSG_TYPE_HELLO;
-
-  h = &e->msg.hello;
-  h->min_version = MEMIF_VERSION;
-  h->max_version = MEMIF_VERSION;
-  h->max_s2m_ring = MEMIF_MAX_S2M_RING;
-  h->max_m2s_ring = MEMIF_MAX_M2S_RING;
-  h->max_region = MEMIF_MAX_REGION;
-  h->max_log2_ring_size = MEMIF_MAX_LOG2_RING_SIZE;
-
-  strlcpy ((char *) h->name, (char *) cc->sock->args.app_name,
-	   sizeof (h->name));
-
-  return MEMIF_ERR_SUCCESS;
 }
 
 /* response from memif master - master is ready to handle next message */
-static int
-memif_msg_enq_ack (memif_control_channel_t *cc)
+static int memif_msg_enq_ack(memif_control_channel_t *cc)
 {
-  memif_msg_queue_elt_t *e = memif_msg_enq (cc);
+    memif_msg_queue_elt_t *e = memif_msg_enq(cc);
 
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  e->msg.type = MEMIF_MSG_TYPE_ACK;
-  e->fd = -1;
+    e->msg.type = MEMIF_MSG_TYPE_ACK;
+    e->fd = -1;
 
-  return MEMIF_ERR_SUCCESS; /* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
 /* send id and secret (optional) for interface identification */
-static int
-memif_msg_enq_init (memif_control_channel_t *cc)
+static int memif_msg_enq_init(memif_control_channel_t *cc)
 {
-  memif_msg_queue_elt_t *e = memif_msg_enq (cc);
+    memif_msg_queue_elt_t *e = memif_msg_enq(cc);
 
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  memif_msg_init_t *i = &e->msg.init;
+    memif_msg_init_t *i = &e->msg.init;
 
-  e->msg.type = MEMIF_MSG_TYPE_INIT;
-  e->fd = -1;
-  i->version = MEMIF_VERSION;
-  i->id = cc->conn->args.interface_id;
-  i->mode = cc->conn->args.mode;
+    e->msg.type = MEMIF_MSG_TYPE_INIT;
+    e->fd = -1;
+    i->version = MEMIF_VERSION;
+    i->id = cc->conn->args.interface_id;
+    i->mode = cc->conn->args.mode;
 
-  strlcpy ((char *) i->name, (char *) cc->sock->args.app_name,
-	   sizeof (i->name));
-  if (strlen ((char *) cc->conn->args.secret) > 0)
-    strlcpy ((char *) i->secret, (char *) cc->conn->args.secret,
-	     sizeof (i->secret));
+    strlcpy((char *)i->name, (char *)cc->sock->args.app_name, sizeof(i->name));
+    if (strlen((char *)cc->conn->args.secret) > 0)
+        strlcpy((char *)i->secret, (char *)cc->conn->args.secret, sizeof(i->secret));
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
 /* send information about region specified by region_index */
-static int
-memif_msg_enq_add_region (memif_control_channel_t *cc, uint8_t region_index)
+static int memif_msg_enq_add_region(memif_control_channel_t *cc, uint8_t region_index)
 {
-  memif_region_t *mr = &cc->conn->regions[region_index];
-  memif_msg_queue_elt_t *e = memif_msg_enq (cc);
+    memif_region_t *mr = &cc->conn->regions[region_index];
+    memif_msg_queue_elt_t *e = memif_msg_enq(cc);
 
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  memif_msg_add_region_t *ar = &e->msg.add_region;
+    memif_msg_add_region_t *ar = &e->msg.add_region;
 
-  e->msg.type = MEMIF_MSG_TYPE_ADD_REGION;
-  e->fd = mr->fd;
-  ar->index = region_index;
-  ar->size = mr->region_size;
+    e->msg.type = MEMIF_MSG_TYPE_ADD_REGION;
+    e->fd = mr->fd;
+    ar->index = region_index;
+    ar->size = mr->region_size;
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
 /* send information about ring specified by direction (S2M | M2S) and index */
-static int
-memif_msg_enq_add_ring (memif_control_channel_t *cc, uint8_t index,
-			uint8_t dir)
+static int memif_msg_enq_add_ring(memif_control_channel_t *cc, uint8_t index, uint8_t dir)
 {
-  memif_msg_queue_elt_t *e = memif_msg_enq (cc);
+    memif_msg_queue_elt_t *e = memif_msg_enq(cc);
 
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  memif_msg_add_ring_t *ar = &e->msg.add_ring;
+    memif_msg_add_ring_t *ar = &e->msg.add_ring;
 
-  e->msg.type = MEMIF_MSG_TYPE_ADD_RING;
+    e->msg.type = MEMIF_MSG_TYPE_ADD_RING;
 
-  /* TODO: support multiple rings */
-  memif_queue_t *mq;
-  if (dir == MEMIF_RING_M2S)
-    mq = &cc->conn->rx_queues[index];
-  else
-    mq = &cc->conn->tx_queues[index];
+    /* TODO: support multiple rings */
+    memif_queue_t *mq;
+    if (dir == MEMIF_RING_M2S)
+        mq = &cc->conn->rx_queues[index];
+    else
+        mq = &cc->conn->tx_queues[index];
 
-  e->fd = mq->int_fd;
-  ar->index = index;
-  ar->offset = mq->offset;
-  ar->region = mq->region;
-  ar->log2_ring_size = mq->log2_ring_size;
-  ar->flags = (dir == MEMIF_RING_S2M) ? MEMIF_MSG_ADD_RING_FLAG_S2M : 0;
-  ar->private_hdr_size = 0;
+    e->fd = mq->int_fd;
+    ar->index = index;
+    ar->offset = mq->offset;
+    ar->region = mq->region;
+    ar->log2_ring_size = mq->log2_ring_size;
+    ar->flags = (dir == MEMIF_RING_S2M) ? MEMIF_MSG_ADD_RING_FLAG_S2M : 0;
+    ar->private_hdr_size = 0;
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
 /* used as connection request from slave */
-static int
-memif_msg_enq_connect (memif_control_channel_t *cc)
+static int memif_msg_enq_connect(memif_control_channel_t *cc)
 {
-  memif_msg_queue_elt_t *e = memif_msg_enq (cc);
+    memif_msg_queue_elt_t *e = memif_msg_enq(cc);
 
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  memif_msg_connect_t *cm = &e->msg.connect;
+    memif_msg_connect_t *cm = &e->msg.connect;
 
-  e->msg.type = MEMIF_MSG_TYPE_CONNECT;
-  e->fd = -1;
-  strlcpy ((char *) cm->if_name, (char *) cc->conn->args.interface_name,
-	   sizeof (cm->if_name));
+    e->msg.type = MEMIF_MSG_TYPE_CONNECT;
+    e->fd = -1;
+    strlcpy((char *)cm->if_name, (char *)cc->conn->args.interface_name, sizeof(cm->if_name));
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
 /* used as confirmation of connection by master */
-static int
-memif_msg_enq_connected (memif_control_channel_t *cc)
+static int memif_msg_enq_connected(memif_control_channel_t *cc)
 {
-  memif_msg_queue_elt_t *e = memif_msg_enq (cc);
+    memif_msg_queue_elt_t *e = memif_msg_enq(cc);
 
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  memif_msg_connected_t *cm = &e->msg.connected;
+    memif_msg_connected_t *cm = &e->msg.connected;
 
-  e->msg.type = MEMIF_MSG_TYPE_CONNECTED;
-  e->fd = -1;
-  strlcpy ((char *) cm->if_name, (char *) cc->conn->args.interface_name,
-	   sizeof (cm->if_name));
+    e->msg.type = MEMIF_MSG_TYPE_CONNECTED;
+    e->fd = -1;
+    strlcpy((char *)cm->if_name, (char *)cc->conn->args.interface_name, sizeof(cm->if_name));
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
-int
-memif_msg_enq_disconnect (memif_control_channel_t *cc, uint8_t *err_string,
-			  uint32_t err_code)
+int memif_msg_enq_disconnect(memif_control_channel_t *cc, uint8_t *err_string, uint32_t err_code)
 {
-  memif_msg_queue_elt_t *e;
+    memif_msg_queue_elt_t *e;
 
-  e = cc->sock->args.alloc (sizeof (*e));
-  if (e == NULL)
-    return MEMIF_ERR_NOMEM;
+    e = cc->sock->args.alloc(sizeof(*e));
+    if (e == NULL)
+        return MEMIF_ERR_NOMEM;
 
-  e->fd = -1;
-  /* Insert disconenct message at the top of the msg queue */
-  TAILQ_INSERT_HEAD (&cc->msg_queue, e, next);
+    e->fd = -1;
+    /* Insert disconenct message at the top of the msg queue */
+    TAILQ_INSERT_HEAD(&cc->msg_queue, e, next);
 
-  memif_msg_disconnect_t *d = &e->msg.disconnect;
+    memif_msg_disconnect_t *d = &e->msg.disconnect;
 
-  e->msg.type = MEMIF_MSG_TYPE_DISCONNECT;
-  d->code = err_code;
-  uint16_t l = sizeof (d->string);
-  if (l > 96)
-    {
-      DBG ("Disconnect string too long. Sending the first %ld characters.",
-	   sizeof (d->string) - 1);
+    e->msg.type = MEMIF_MSG_TYPE_DISCONNECT;
+    d->code = err_code;
+    uint16_t l = sizeof(d->string);
+    if (l > 96) {
+        DBG("Disconnect string too long. Sending the first %ld characters.", sizeof(d->string) - 1);
     }
-  strlcpy ((char *) d->string, (char *) err_string, sizeof (d->string));
+    strlcpy((char *)d->string, (char *)err_string, sizeof(d->string));
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 }
 
-static int
-memif_msg_parse_hello (memif_control_channel_t *cc, memif_msg_t *msg)
+static int memif_msg_parse_hello(memif_control_channel_t *cc, memif_msg_t *msg)
 {
-  memif_msg_hello_t *h = &msg->hello;
-  memif_connection_t *c = cc->conn;
+    memif_msg_hello_t *h = &msg->hello;
+    memif_connection_t *c = cc->conn;
 
-  if (msg->hello.min_version > MEMIF_VERSION ||
-      msg->hello.max_version < MEMIF_VERSION)
-    {
-      DBG ("incompatible protocol version");
-      return MEMIF_ERR_PROTO;
+    if (msg->hello.min_version > MEMIF_VERSION || msg->hello.max_version < MEMIF_VERSION) {
+        DBG("incompatible protocol version");
+        return MEMIF_ERR_PROTO;
     }
 
-  c->run_args.num_s2m_rings = memif_min (h->max_s2m_ring + 1,
-					 c->args.num_s2m_rings);
-  c->run_args.num_m2s_rings = memif_min (h->max_m2s_ring + 1,
-					 c->args.num_m2s_rings);
-  c->run_args.log2_ring_size = memif_min (h->max_log2_ring_size,
-					  c->args.log2_ring_size);
-  c->run_args.buffer_size = c->args.buffer_size;
-  strlcpy ((char *) c->remote_name, (char *) h->name, sizeof (c->remote_name));
+    c->run_args.num_s2m_rings = memif_min(h->max_s2m_ring + 1, c->args.num_s2m_rings);
+    c->run_args.num_m2s_rings = memif_min(h->max_m2s_ring + 1, c->args.num_m2s_rings);
+    c->run_args.log2_ring_size = memif_min(h->max_log2_ring_size, c->args.log2_ring_size);
+    c->run_args.buffer_size = c->args.buffer_size;
+    strlcpy((char *)c->remote_name, (char *)h->name, sizeof(c->remote_name));
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
 /* handle interface identification (id, secret (optional)) */
-static int
-memif_msg_parse_init (memif_control_channel_t *cc, memif_msg_t *msg)
+static int memif_msg_parse_init(memif_control_channel_t *cc, memif_msg_t *msg)
 {
-  memif_msg_init_t *i = &msg->init;
-  memif_connection_t *c = NULL;
-  uint8_t err_string[96];
-  memset (err_string, 0, sizeof (char) * 96);
-  int err = MEMIF_ERR_SUCCESS;	/* 0 */
+    memif_msg_init_t *i = &msg->init;
+    memif_connection_t *c = NULL;
+    uint8_t err_string[96];
+    memset(err_string, 0, sizeof(char) * 96);
+    int err = MEMIF_ERR_SUCCESS; /* 0 */
 
-  /* Check compatible meimf version */
-  if (i->version != MEMIF_VERSION)
-    {
-      DBG ("MEMIF_VER_ERR");
-      memif_msg_enq_disconnect (cc, MEMIF_VER_ERR, 0);
-      return MEMIF_ERR_PROTO;
+    /* Check compatible meimf version */
+    if (i->version != MEMIF_VERSION) {
+        DBG("MEMIF_VER_ERR");
+        memif_msg_enq_disconnect(cc, MEMIF_VER_ERR, 0);
+        return MEMIF_ERR_PROTO;
     }
 
-  /* Find endpoint on the socket */
-  TAILQ_FOREACH (c, &cc->sock->master_interfaces, next)
-  {
-    /* Match interface id */
-    if (c->args.interface_id != i->id)
-      continue;
-    /* If control channel is present, interface is connected (or connecting) */
-    if (c->control_channel != NULL)
-      {
-	memif_msg_enq_disconnect (cc, "Already connected", 0);
-	return MEMIF_ERR_ALRCONN;
-      }
-    /* Verify secret */
-    if (c->args.secret[0] != '\0')
-      {
-	if (strncmp ((char *) c->args.secret, (char *) i->secret, 24) != 0)
-	  {
-	    memif_msg_enq_disconnect (cc, "Incorrect secret", 0);
-	    return MEMIF_ERR_SECRET;
-	  }
-      }
+    /* Find endpoint on the socket */
+    TAILQ_FOREACH(c, &cc->sock->master_interfaces, next)
+    {
+        /* Match interface id */
+        if (c->args.interface_id != i->id)
+            continue;
+        /* If control channel is present, interface is connected (or connecting) */
+        if (c->control_channel != NULL) {
+            memif_msg_enq_disconnect(cc, "Already connected", 0);
+            return MEMIF_ERR_ALRCONN;
+        }
+        /* Verify secret */
+        if (c->args.secret[0] != '\0') {
+            if (strncmp((char *)c->args.secret, (char *)i->secret, 24) != 0) {
+                memif_msg_enq_disconnect(cc, "Incorrect secret", 0);
+                return MEMIF_ERR_SECRET;
+            }
+        }
 
-    /* Assign the control channel to this interface */
-    c->control_channel = cc;
-    cc->conn = c;
+        /* Assign the control channel to this interface */
+        c->control_channel = cc;
+        cc->conn = c;
 
-    strlcpy ((char *) c->remote_name, (char *) i->name,
-	     sizeof (c->remote_name));
-  }
+        strlcpy((char *)c->remote_name, (char *)i->name, sizeof(c->remote_name));
+    }
 
-  return err;
+    return err;
 }
 
 /* receive region information and add new region to connection (if possible) */
-static int
-memif_msg_parse_add_region (memif_control_channel_t *cc, memif_msg_t *msg,
-			    int fd)
+static int memif_msg_parse_add_region(memif_control_channel_t *cc, memif_msg_t *msg, int fd)
 {
-  memif_msg_add_region_t *ar = &msg->add_region;
-  memif_region_t *mr;
-  memif_connection_t *c = cc->conn;
+    memif_msg_add_region_t *ar = &msg->add_region;
+    memif_region_t *mr;
+    memif_connection_t *c = cc->conn;
 
-  if (fd < 0)
-    return MEMIF_ERR_NO_SHMFD;
+    if (fd < 0)
+        return MEMIF_ERR_NO_SHMFD;
 
-  if (ar->index > MEMIF_MAX_REGION)
-    return MEMIF_ERR_MAXREG;
+    if (ar->index > MEMIF_MAX_REGION)
+        return MEMIF_ERR_MAXREG;
 
-  mr = (memif_region_t *) cc->sock->args.realloc (
-    c->regions, sizeof (memif_region_t) * (++c->regions_num));
-  if (mr == NULL)
-    return memif_syscall_error_handler (errno);
-  memset (mr + ar->index, 0, sizeof (memif_region_t));
-  c->regions = mr;
-  c->regions[ar->index].fd = fd;
-  c->regions[ar->index].region_size = ar->size;
-  c->regions[ar->index].addr = NULL;
-  /* region 0 is never external */
-  if (cc->sock->get_external_region_addr && (ar->index != 0))
-    c->regions[ar->index].is_external = 1;
+    mr = (memif_region_t *)cc->sock->args.realloc(c->regions,
+                                                  sizeof(memif_region_t) * (++c->regions_num));
+    if (mr == NULL)
+        return memif_syscall_error_handler(errno);
+    memset(mr + ar->index, 0, sizeof(memif_region_t));
+    c->regions = mr;
+    c->regions[ar->index].fd = fd;
+    c->regions[ar->index].region_size = ar->size;
+    c->regions[ar->index].addr = NULL;
+    /* region 0 is never external */
+    if (cc->sock->get_external_region_addr && (ar->index != 0))
+        c->regions[ar->index].is_external = 1;
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
 /* receive ring information and add new ring to connection queue
    (based on direction S2M | M2S) */
-static int
-memif_msg_parse_add_ring (memif_control_channel_t *cc, memif_msg_t *msg,
-			  int fd)
+static int memif_msg_parse_add_ring(memif_control_channel_t *cc, memif_msg_t *msg, int fd)
 {
-  memif_msg_add_ring_t *ar = &msg->add_ring;
-  memif_connection_t *c = cc->conn;
+    memif_msg_add_ring_t *ar = &msg->add_ring;
+    memif_connection_t *c = cc->conn;
 
-  memif_queue_t *mq;
+    memif_queue_t *mq;
 
-  if (fd < 0)
-    return MEMIF_ERR_NO_INTFD;
+    if (fd < 0)
+        return MEMIF_ERR_NO_INTFD;
 
-  if (ar->private_hdr_size != 0)
-    return MEMIF_ERR_PRIVHDR;
+    if (ar->private_hdr_size != 0)
+        return MEMIF_ERR_PRIVHDR;
 
-  if (ar->flags & MEMIF_MSG_ADD_RING_FLAG_S2M)
-    {
-      if (ar->index > MEMIF_MAX_S2M_RING)
-	return MEMIF_ERR_MAXRING;
-      if (ar->index >= c->args.num_s2m_rings)
-	return MEMIF_ERR_MAXRING;
+    if (ar->flags & MEMIF_MSG_ADD_RING_FLAG_S2M) {
+        if (ar->index > MEMIF_MAX_S2M_RING)
+            return MEMIF_ERR_MAXRING;
+        if (ar->index >= c->args.num_s2m_rings)
+            return MEMIF_ERR_MAXRING;
 
-      mq = (memif_queue_t *) cc->sock->args.realloc (
-	c->rx_queues, sizeof (memif_queue_t) * (++c->rx_queues_num));
-      memset (mq + ar->index, 0, sizeof (memif_queue_t));
-      if (mq == NULL)
-	return memif_syscall_error_handler (errno);
-      c->rx_queues = mq;
-      c->rx_queues[ar->index].int_fd = fd;
-      c->rx_queues[ar->index].log2_ring_size = ar->log2_ring_size;
-      c->rx_queues[ar->index].region = ar->region;
-      c->rx_queues[ar->index].offset = ar->offset;
-      c->run_args.num_s2m_rings++;
-    }
-  else
-    {
-      if (ar->index > MEMIF_MAX_M2S_RING)
-	return MEMIF_ERR_MAXRING;
-      if (ar->index >= c->args.num_m2s_rings)
-	return MEMIF_ERR_MAXRING;
+        mq = (memif_queue_t *)cc->sock->args.realloc(c->rx_queues,
+                                                     sizeof(memif_queue_t) * (++c->rx_queues_num));
+        memset(mq + ar->index, 0, sizeof(memif_queue_t));
+        if (mq == NULL)
+            return memif_syscall_error_handler(errno);
+        c->rx_queues = mq;
+        c->rx_queues[ar->index].int_fd = fd;
+        c->rx_queues[ar->index].log2_ring_size = ar->log2_ring_size;
+        c->rx_queues[ar->index].region = ar->region;
+        c->rx_queues[ar->index].offset = ar->offset;
+        c->run_args.num_s2m_rings++;
+    } else {
+        if (ar->index > MEMIF_MAX_M2S_RING)
+            return MEMIF_ERR_MAXRING;
+        if (ar->index >= c->args.num_m2s_rings)
+            return MEMIF_ERR_MAXRING;
 
-      mq = (memif_queue_t *) cc->sock->args.realloc (
-	c->tx_queues, sizeof (memif_queue_t) * (++c->tx_queues_num));
-      memset (mq + ar->index, 0, sizeof (memif_queue_t));
-      if (mq == NULL)
-	return memif_syscall_error_handler (errno);
-      c->tx_queues = mq;
-      c->tx_queues[ar->index].int_fd = fd;
-      c->tx_queues[ar->index].log2_ring_size = ar->log2_ring_size;
-      c->tx_queues[ar->index].region = ar->region;
-      c->tx_queues[ar->index].offset = ar->offset;
-      c->run_args.num_m2s_rings++;
+        mq = (memif_queue_t *)cc->sock->args.realloc(c->tx_queues,
+                                                     sizeof(memif_queue_t) * (++c->tx_queues_num));
+        memset(mq + ar->index, 0, sizeof(memif_queue_t));
+        if (mq == NULL)
+            return memif_syscall_error_handler(errno);
+        c->tx_queues = mq;
+        c->tx_queues[ar->index].int_fd = fd;
+        c->tx_queues[ar->index].log2_ring_size = ar->log2_ring_size;
+        c->tx_queues[ar->index].region = ar->region;
+        c->tx_queues[ar->index].offset = ar->offset;
+        c->run_args.num_m2s_rings++;
     }
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
-static int
-memif_configure_rx_interrupt (memif_connection_t *c)
+static int memif_configure_rx_interrupt(memif_connection_t *c)
 {
-  memif_socket_t *ms = (memif_socket_t *) c->args.socket;
-  memif_interrupt_t *idata;
-  memif_fd_event_t fde;
-  memif_fd_event_data_t *fdata;
-  void *ctx;
-  int i;
+    memif_socket_t *ms = (memif_socket_t *)c->args.socket;
+    memif_interrupt_t *idata;
+    memif_fd_event_t fde;
+    memif_fd_event_data_t *fdata;
+    void *ctx;
+    int i;
 
-  if (c->on_interrupt != NULL)
-    {
-      for (i = 0; i < c->run_args.num_m2s_rings; i++)
-	{
-	  /* Allocate fd event data */
-	  fdata = ms->args.alloc (sizeof (*fdata));
-	  if (fdata == NULL)
-	    {
-	      memif_msg_enq_disconnect (c->control_channel, "Internal error",
-					0);
-	      return MEMIF_ERR_NOMEM;
-	    }
-	  /* Allocate interrupt data */
-	  idata = ms->args.alloc (sizeof (*fdata));
-	  if (idata == NULL)
-	    {
-	      ms->args.free (fdata);
-	      memif_msg_enq_disconnect (c->control_channel, "Internal error",
-					0);
-	      return MEMIF_ERR_NOMEM;
-	    }
+    if (c->on_interrupt != NULL) {
+        for (i = 0; i < c->run_args.num_m2s_rings; i++) {
+            /* Allocate fd event data */
+            fdata = ms->args.alloc(sizeof(*fdata));
+            if (fdata == NULL) {
+                memif_msg_enq_disconnect(c->control_channel, "Internal error", 0);
+                return MEMIF_ERR_NOMEM;
+            }
+            /* Allocate interrupt data */
+            idata = ms->args.alloc(sizeof(*fdata));
+            if (idata == NULL) {
+                ms->args.free(fdata);
+                memif_msg_enq_disconnect(c->control_channel, "Internal error", 0);
+                return MEMIF_ERR_NOMEM;
+            }
 
-	  /* configure interrupt data */
-	  idata->c = c;
-	  idata->qid = i;
-	  /* configure fd event data */
-	  fdata->event_handler = memif_interrupt_handler;
-	  fdata->private_ctx = idata;
-	  fde.fd = c->rx_queues[i].int_fd;
-	  fde.type = MEMIF_FD_EVENT_READ;
-	  fde.private_ctx = fdata;
+            /* configure interrupt data */
+            idata->c = c;
+            idata->qid = i;
+            /* configure fd event data */
+            fdata->event_handler = memif_interrupt_handler;
+            fdata->private_ctx = idata;
+            fde.fd = c->rx_queues[i].int_fd;
+            fde.type = MEMIF_FD_EVENT_READ;
+            fde.private_ctx = fdata;
 
-	  /* Start listening for events */
-	  ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-	  ms->args.on_control_fd_update (fde, ctx);
-	}
+            /* Start listening for events */
+            ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+            ms->args.on_control_fd_update(fde, ctx);
+        }
     }
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 }
 
 /* slave -> master */
-static int
-memif_msg_parse_connect (memif_control_channel_t *cc, memif_msg_t *msg)
+static int memif_msg_parse_connect(memif_control_channel_t *cc, memif_msg_t *msg)
 {
-  memif_msg_connect_t *cm = &msg->connect;
-  memif_connection_t *c = cc->conn;
-  int err;
+    memif_msg_connect_t *cm = &msg->connect;
+    memif_connection_t *c = cc->conn;
+    int err;
 
-  err = memif_connect1 (c);
-  if (err != MEMIF_ERR_SUCCESS)
+    err = memif_connect1(c);
+    if (err != MEMIF_ERR_SUCCESS)
+        return err;
+
+    strlcpy((char *)c->remote_if_name, (char *)cm->if_name, sizeof(c->remote_if_name));
+
+    err = memif_configure_rx_interrupt(c);
+    if (err != MEMIF_ERR_SUCCESS)
+        return err;
+
+    c->on_connect((void *)c, c->private_ctx);
+
     return err;
-
-  strlcpy ((char *) c->remote_if_name, (char *) cm->if_name,
-	   sizeof (c->remote_if_name));
-
-  err = memif_configure_rx_interrupt (c);
-  if (err != MEMIF_ERR_SUCCESS)
-    return err;
-
-  c->on_connect ((void *) c, c->private_ctx);
-
-  return err;
 }
 
 /* master -> slave */
-static int
-memif_msg_parse_connected (memif_control_channel_t *cc, memif_msg_t *msg)
+static int memif_msg_parse_connected(memif_control_channel_t *cc, memif_msg_t *msg)
 {
-  memif_msg_connect_t *cm = &msg->connect;
-  memif_connection_t *c = cc->conn;
+    memif_msg_connect_t *cm = &msg->connect;
+    memif_connection_t *c = cc->conn;
 
-  int err;
-  err = memif_connect1 (c);
-  if (err != MEMIF_ERR_SUCCESS)
+    int err;
+    err = memif_connect1(c);
+    if (err != MEMIF_ERR_SUCCESS)
+        return err;
+
+    strlcpy((char *)c->remote_if_name, (char *)cm->if_name, sizeof(c->remote_if_name));
+
+    err = memif_configure_rx_interrupt(c);
+    if (err != MEMIF_ERR_SUCCESS)
+        return err;
+
+    c->on_connect((void *)c, c->private_ctx);
+
     return err;
-
-  strlcpy ((char *) c->remote_if_name, (char *) cm->if_name,
-	   sizeof (c->remote_if_name));
-
-  err = memif_configure_rx_interrupt (c);
-  if (err != MEMIF_ERR_SUCCESS)
-    return err;
-
-  c->on_connect ((void *) c, c->private_ctx);
-
-  return err;
 }
 
-static int
-memif_msg_parse_disconnect (memif_control_channel_t *cc, memif_msg_t *msg)
+static int memif_msg_parse_disconnect(memif_control_channel_t *cc, memif_msg_t *msg)
 {
-  memif_msg_disconnect_t *d = &msg->disconnect;
-  memif_connection_t *c = cc->conn;
+    memif_msg_disconnect_t *d = &msg->disconnect;
+    memif_connection_t *c = cc->conn;
 
-  memset (c->remote_disconnect_string, 0,
-	  sizeof (c->remote_disconnect_string));
-  strlcpy ((char *) c->remote_disconnect_string, (char *) d->string,
-	   sizeof (c->remote_disconnect_string));
+    memset(c->remote_disconnect_string, 0, sizeof(c->remote_disconnect_string));
+    strlcpy((char *)c->remote_disconnect_string, (char *)d->string,
+            sizeof(c->remote_disconnect_string));
 
-  /* on returning error, handle function will call memif_disconnect () */
-  DBG ("disconnect received: %s, mode: %d",
-       c->remote_disconnect_string, c->args.mode);
-  return MEMIF_ERR_DISCONNECT;
+    /* on returning error, handle function will call memif_disconnect () */
+    DBG("disconnect received: %s, mode: %d", c->remote_disconnect_string, c->args.mode);
+    return MEMIF_ERR_DISCONNECT;
 }
 
-static int
-memif_msg_receive_and_parse (memif_control_channel_t *cc)
+static int memif_msg_receive_and_parse(memif_control_channel_t *cc)
 {
-  char ctl[CMSG_SPACE (sizeof (int)) +
-	   CMSG_SPACE (sizeof (struct ucred))] = { 0 };
-  struct msghdr mh = { 0 };
-  struct iovec iov[1];
-  memif_msg_t msg = { 0 };
-  ssize_t size;
-  int err = MEMIF_ERR_SUCCESS;	/* 0 */
-  int fd = -1;
-  int i;
-  memif_socket_t *ms = NULL;
+    char ctl[CMSG_SPACE(sizeof(int)) + CMSG_SPACE(sizeof(struct ucred))] = {0};
+    struct msghdr mh = {0};
+    struct iovec iov[1];
+    memif_msg_t msg = {0};
+    ssize_t size;
+    int err = MEMIF_ERR_SUCCESS; /* 0 */
+    int fd = -1;
+    int i;
+    memif_socket_t *ms = NULL;
 
-  iov[0].iov_base = (void *) &msg;
-  iov[0].iov_len = sizeof (memif_msg_t);
-  mh.msg_iov = iov;
-  mh.msg_iovlen = 1;
-  mh.msg_control = ctl;
-  mh.msg_controllen = sizeof (ctl);
+    iov[0].iov_base = (void *)&msg;
+    iov[0].iov_len = sizeof(memif_msg_t);
+    mh.msg_iov = iov;
+    mh.msg_iovlen = 1;
+    mh.msg_control = ctl;
+    mh.msg_controllen = sizeof(ctl);
 
-  DBG ("recvmsg fd %d", cc->fd);
-  size = recvmsg (cc->fd, &mh, 0);
-  if (size != sizeof (memif_msg_t))
-    {
-      if (size == 0)
-	return MEMIF_ERR_DISCONNECTED;
-      else
-	return MEMIF_ERR_MFMSG;
+    DBG("recvmsg fd %d", cc->fd);
+    size = recvmsg(cc->fd, &mh, 0);
+    if (size != sizeof(memif_msg_t)) {
+        if (size == 0)
+            return MEMIF_ERR_DISCONNECTED;
+        else
+            return MEMIF_ERR_MFMSG;
     }
 
-  struct cmsghdr *cmsg;
+    struct cmsghdr *cmsg;
 
-  cmsg = CMSG_FIRSTHDR (&mh);
-  while (cmsg)
-    {
-      if (cmsg->cmsg_level == SOL_SOCKET)
-	{
-	  if (cmsg->cmsg_type == SCM_CREDENTIALS)
-	    {
-	      /* Do nothing */ ;
-	    }
-	  else if (cmsg->cmsg_type == SCM_RIGHTS)
-	    {
-	      int *fdp = (int *) CMSG_DATA (cmsg);
-	      fd = *fdp;
-	    }
-	}
-      cmsg = CMSG_NXTHDR (&mh, cmsg);
+    cmsg = CMSG_FIRSTHDR(&mh);
+    while (cmsg) {
+        if (cmsg->cmsg_level == SOL_SOCKET) {
+            if (cmsg->cmsg_type == SCM_CREDENTIALS) {
+                /* Do nothing */;
+            } else if (cmsg->cmsg_type == SCM_RIGHTS) {
+                int *fdp = (int *)CMSG_DATA(cmsg);
+                fd = *fdp;
+            }
+        }
+        cmsg = CMSG_NXTHDR(&mh, cmsg);
     }
 
-  DBG ("Message type %u received", msg.type);
+    DBG("Message type %u received", msg.type);
 
-  switch (msg.type)
-    {
+    switch (msg.type) {
     case MEMIF_MSG_TYPE_ACK:
-      break;
+        break;
 
     case MEMIF_MSG_TYPE_HELLO:
-      if ((err = memif_msg_parse_hello (cc, &msg)) != MEMIF_ERR_SUCCESS)
-	return err;
-      if ((err = memif_init_regions_and_queues (cc->conn)) !=
-	  MEMIF_ERR_SUCCESS)
-	return err;
-      if ((err = memif_msg_enq_init (cc)) != MEMIF_ERR_SUCCESS)
-	return err;
-      for (i = 0; i < cc->conn->regions_num; i++)
-	{
-	  if ((err = memif_msg_enq_add_region (cc, i)) != MEMIF_ERR_SUCCESS)
-	    return err;
-	}
-      for (i = 0; i < cc->conn->run_args.num_s2m_rings; i++)
-	{
-	  if ((err = memif_msg_enq_add_ring (cc, i, MEMIF_RING_S2M)) !=
-	      MEMIF_ERR_SUCCESS)
-	    return err;
-	}
-      for (i = 0; i < cc->conn->run_args.num_m2s_rings; i++)
-	{
-	  if ((err = memif_msg_enq_add_ring (cc, i, MEMIF_RING_M2S)) !=
-	      MEMIF_ERR_SUCCESS)
-	    return err;
-	}
-      if ((err = memif_msg_enq_connect (cc)) != MEMIF_ERR_SUCCESS)
-	return err;
-      break;
+        if ((err = memif_msg_parse_hello(cc, &msg)) != MEMIF_ERR_SUCCESS)
+            return err;
+        if ((err = memif_init_regions_and_queues(cc->conn)) != MEMIF_ERR_SUCCESS)
+            return err;
+        if ((err = memif_msg_enq_init(cc)) != MEMIF_ERR_SUCCESS)
+            return err;
+        for (i = 0; i < cc->conn->regions_num; i++) {
+            if ((err = memif_msg_enq_add_region(cc, i)) != MEMIF_ERR_SUCCESS)
+                return err;
+        }
+        for (i = 0; i < cc->conn->run_args.num_s2m_rings; i++) {
+            if ((err = memif_msg_enq_add_ring(cc, i, MEMIF_RING_S2M)) != MEMIF_ERR_SUCCESS)
+                return err;
+        }
+        for (i = 0; i < cc->conn->run_args.num_m2s_rings; i++) {
+            if ((err = memif_msg_enq_add_ring(cc, i, MEMIF_RING_M2S)) != MEMIF_ERR_SUCCESS)
+                return err;
+        }
+        if ((err = memif_msg_enq_connect(cc)) != MEMIF_ERR_SUCCESS)
+            return err;
+        break;
 
     case MEMIF_MSG_TYPE_INIT:
-      if ((err = memif_msg_parse_init (cc, &msg)) != MEMIF_ERR_SUCCESS)
-	return err;
-      /* c->remote_pid = cr->pid */
-      /* c->remote_uid = cr->uid */
-      /* c->remote_gid = cr->gid */
-      if ((err = memif_msg_enq_ack (cc)) != MEMIF_ERR_SUCCESS)
-	return err;
-      break;
+        if ((err = memif_msg_parse_init(cc, &msg)) != MEMIF_ERR_SUCCESS)
+            return err;
+        /* c->remote_pid = cr->pid */
+        /* c->remote_uid = cr->uid */
+        /* c->remote_gid = cr->gid */
+        if ((err = memif_msg_enq_ack(cc)) != MEMIF_ERR_SUCCESS)
+            return err;
+        break;
 
     case MEMIF_MSG_TYPE_ADD_REGION:
-      if ((err = memif_msg_parse_add_region (cc, &msg, fd)) !=
-	  MEMIF_ERR_SUCCESS)
-	return err;
-      if ((err = memif_msg_enq_ack (cc)) != MEMIF_ERR_SUCCESS)
-	return err;
-      break;
+        if ((err = memif_msg_parse_add_region(cc, &msg, fd)) != MEMIF_ERR_SUCCESS)
+            return err;
+        if ((err = memif_msg_enq_ack(cc)) != MEMIF_ERR_SUCCESS)
+            return err;
+        break;
 
     case MEMIF_MSG_TYPE_ADD_RING:
-      if ((err = memif_msg_parse_add_ring (cc, &msg, fd)) != MEMIF_ERR_SUCCESS)
-	return err;
-      if ((err = memif_msg_enq_ack (cc)) != MEMIF_ERR_SUCCESS)
-	return err;
-      break;
+        if ((err = memif_msg_parse_add_ring(cc, &msg, fd)) != MEMIF_ERR_SUCCESS)
+            return err;
+        if ((err = memif_msg_enq_ack(cc)) != MEMIF_ERR_SUCCESS)
+            return err;
+        break;
 
     case MEMIF_MSG_TYPE_CONNECT:
-      if ((err = memif_msg_parse_connect (cc, &msg)) != MEMIF_ERR_SUCCESS)
-	return err;
-      if ((err = memif_msg_enq_connected (cc)) != MEMIF_ERR_SUCCESS)
-	return err;
-      break;
+        if ((err = memif_msg_parse_connect(cc, &msg)) != MEMIF_ERR_SUCCESS)
+            return err;
+        if ((err = memif_msg_enq_connected(cc)) != MEMIF_ERR_SUCCESS)
+            return err;
+        break;
 
     case MEMIF_MSG_TYPE_CONNECTED:
-      if ((err = memif_msg_parse_connected (cc, &msg)) != MEMIF_ERR_SUCCESS)
-	return err;
-      break;
+        if ((err = memif_msg_parse_connected(cc, &msg)) != MEMIF_ERR_SUCCESS)
+            return err;
+        break;
 
     case MEMIF_MSG_TYPE_DISCONNECT:
-      if ((err = memif_msg_parse_disconnect (cc, &msg)) != MEMIF_ERR_SUCCESS)
-	return err;
-      break;
+        if ((err = memif_msg_parse_disconnect(cc, &msg)) != MEMIF_ERR_SUCCESS)
+            return err;
+        break;
 
     default:
-      return MEMIF_ERR_UNKNOWN_MSG;;
-      break;
+        return MEMIF_ERR_UNKNOWN_MSG;
+        ;
+        break;
     }
 
-  return MEMIF_ERR_SUCCESS;	/* 0 */
+    return MEMIF_ERR_SUCCESS; /* 0 */
 }
 
-void
-memif_delete_control_channel (memif_control_channel_t *cc)
+void memif_delete_control_channel(memif_control_channel_t *cc)
 {
-  memif_msg_queue_elt_t *e, *next;
-  memif_socket_t *ms = cc->sock;
-  memif_fd_event_t fde = {};
-  void *ctx;
+    memif_msg_queue_elt_t *e, *next;
+    memif_socket_t *ms = cc->sock;
+    memif_fd_event_t fde = {};
+    void *ctx;
 
-  fde.fd = cc->fd;
-  fde.type = MEMIF_FD_EVENT_DEL;
-  ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-  cc->sock->args.on_control_fd_update (fde, ctx);
+    fde.fd = cc->fd;
+    fde.type = MEMIF_FD_EVENT_DEL;
+    ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+    cc->sock->args.on_control_fd_update(fde, ctx);
 
-  if (cc->fd > 0)
-    close (cc->fd);
+    if (cc->fd > 0)
+        close(cc->fd);
 
-  /* Clear control message queue */
-  for (e = TAILQ_FIRST (&cc->msg_queue); e != NULL; e = next)
-    {
-      next = TAILQ_NEXT (e, next);
-      TAILQ_REMOVE (&cc->msg_queue, e, next);
-      cc->sock->args.free (e);
+    /* Clear control message queue */
+    for (e = TAILQ_FIRST(&cc->msg_queue); e != NULL; e = next) {
+        next = TAILQ_NEXT(e, next);
+        TAILQ_REMOVE(&cc->msg_queue, e, next);
+        cc->sock->args.free(e);
     }
 
-  /* remove reference */
-  if (cc->conn != NULL)
-    cc->conn->control_channel = NULL;
-  cc->conn = NULL;
-  cc->sock->args.free (cc);
+    /* remove reference */
+    if (cc->conn != NULL)
+        cc->conn->control_channel = NULL;
+    cc->conn = NULL;
+    cc->sock->args.free(cc);
 
-  return;
+    return;
 }
 
-int
-memif_control_channel_handler (memif_fd_event_type_t type, void *private_ctx)
+int memif_control_channel_handler(memif_fd_event_type_t type, void *private_ctx)
 {
-  memif_control_channel_t *cc = (memif_control_channel_t *) private_ctx;
-  int err;
+    memif_control_channel_t *cc = (memif_control_channel_t *)private_ctx;
+    int err;
 
-  /* Receive the message, parse the message and
-   * enqueue next message(s).
-   */
-  err = memif_msg_receive_and_parse (cc);
-  /* Can't assign to endpoint */
-  if (cc->conn == NULL)
-    {
-      /* A disconnect message is already in the queue */
-      memif_msg_send_from_queue (cc);
-      memif_delete_control_channel (cc);
+    /* Receive the message, parse the message and
+     * enqueue next message(s).
+     */
+    err = memif_msg_receive_and_parse(cc);
+    /* Can't assign to endpoint */
+    if (cc->conn == NULL) {
+        /* A disconnect message is already in the queue */
+        memif_msg_send_from_queue(cc);
+        memif_delete_control_channel(cc);
 
-      return MEMIF_ERR_SUCCESS;
+        return MEMIF_ERR_SUCCESS;
     }
-  /* error in memif_msg_receive */
-  if (err != MEMIF_ERR_SUCCESS)
-    goto disconnect;
+    /* error in memif_msg_receive */
+    if (err != MEMIF_ERR_SUCCESS)
+        goto disconnect;
 
-  /* Continue connecting, send next message from the queue */
-  err = memif_msg_send_from_queue (cc);
-  if (err != MEMIF_ERR_SUCCESS)
-    goto disconnect;
+    /* Continue connecting, send next message from the queue */
+    err = memif_msg_send_from_queue(cc);
+    if (err != MEMIF_ERR_SUCCESS)
+        goto disconnect;
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 
 disconnect:
-  memif_disconnect_internal (cc->conn);
-  return MEMIF_ERR_SUCCESS;
+    memif_disconnect_internal(cc->conn);
+    return MEMIF_ERR_SUCCESS;
 }
 
-int
-memif_listener_handler (memif_fd_event_type_t type, void *private_ctx)
+int memif_listener_handler(memif_fd_event_type_t type, void *private_ctx)
 {
-  memif_socket_t *ms = (memif_socket_t *) private_ctx;
-  memif_control_channel_t *cc;
-  memif_fd_event_t fde;
-  memif_fd_event_data_t *fdata = NULL;
-  struct sockaddr_un un;
-  int err, sockfd, addr_len = sizeof (un);
-  void *ctx;
+    memif_socket_t *ms = (memif_socket_t *)private_ctx;
+    memif_control_channel_t *cc;
+    memif_fd_event_t fde;
+    memif_fd_event_data_t *fdata = NULL;
+    struct sockaddr_un un;
+    int err, sockfd, addr_len = sizeof(un);
+    void *ctx;
 
-  if (ms == NULL)
-    return MEMIF_ERR_INVAL_ARG;
+    if (ms == NULL)
+        return MEMIF_ERR_INVAL_ARG;
 
-  if (type & MEMIF_FD_EVENT_READ)
-    {
-      /* Accept connection to the listener socket */
-      sockfd = accept (ms->listener_fd, (struct sockaddr *) &un,
-		       (socklen_t *) &addr_len);
-      if (sockfd < 0)
-	{
-	  return memif_syscall_error_handler (errno);
-	}
+    if (type & MEMIF_FD_EVENT_READ) {
+        /* Accept connection to the listener socket */
+        sockfd = accept(ms->listener_fd, (struct sockaddr *)&un, (socklen_t *)&addr_len);
+        if (sockfd < 0) {
+            return memif_syscall_error_handler(errno);
+        }
 
-      /* Create new control channel */
-      cc = ms->args.alloc (sizeof (*cc));
-      if (cc == NULL)
-	{
-	  err = MEMIF_ERR_NOMEM;
-	  goto error;
-	}
+        /* Create new control channel */
+        cc = ms->args.alloc(sizeof(*cc));
+        if (cc == NULL) {
+            err = MEMIF_ERR_NOMEM;
+            goto error;
+        }
 
-      cc->fd = sockfd;
-      /* The connection will be assigned after parsing MEMIF_MSG_TYPE_INIT msg
-       */
-      cc->conn = NULL;
-      cc->sock = ms;
-      TAILQ_INIT (&cc->msg_queue);
+        cc->fd = sockfd;
+        /* The connection will be assigned after parsing MEMIF_MSG_TYPE_INIT msg
+         */
+        cc->conn = NULL;
+        cc->sock = ms;
+        TAILQ_INIT(&cc->msg_queue);
 
-      /* Create memif fd event */
-      fdata = ms->args.alloc (sizeof (*fdata));
-      if (fdata == NULL)
-	{
-	  err = MEMIF_ERR_NOMEM;
-	  goto error;
-	}
+        /* Create memif fd event */
+        fdata = ms->args.alloc(sizeof(*fdata));
+        if (fdata == NULL) {
+            err = MEMIF_ERR_NOMEM;
+            goto error;
+        }
 
-      fdata->event_handler = memif_control_channel_handler;
-      fdata->private_ctx = cc;
+        fdata->event_handler = memif_control_channel_handler;
+        fdata->private_ctx = cc;
 
-      fde.fd = sockfd;
-      fde.type = MEMIF_FD_EVENT_READ;
-      fde.private_ctx = fdata;
+        fde.fd = sockfd;
+        fde.type = MEMIF_FD_EVENT_READ;
+        fde.private_ctx = fdata;
 
-      /* Start listenning for events on the new control channel */
-      ctx = ms->epfd != -1 ? ms : ms->private_ctx;
-      ms->args.on_control_fd_update (fde, ctx);
+        /* Start listenning for events on the new control channel */
+        ctx = ms->epfd != -1 ? ms : ms->private_ctx;
+        ms->args.on_control_fd_update(fde, ctx);
 
-      /* enqueue HELLO msg */
-      err = memif_msg_enq_hello (cc);
-      if (err != MEMIF_ERR_SUCCESS)
-	goto error;
+        /* enqueue HELLO msg */
+        err = memif_msg_enq_hello(cc);
+        if (err != MEMIF_ERR_SUCCESS)
+            goto error;
 
-      /* send HELLO msg */
-      err = memif_msg_send_from_queue (cc);
-      if (err != MEMIF_ERR_SUCCESS)
-	goto error;
+        /* send HELLO msg */
+        err = memif_msg_send_from_queue(cc);
+        if (err != MEMIF_ERR_SUCCESS)
+            goto error;
     }
 
-  return MEMIF_ERR_SUCCESS;
+    return MEMIF_ERR_SUCCESS;
 
 error:
-  if (sockfd >= 0)
-    close (sockfd);
-  if (cc != NULL)
-    ms->args.free (cc);
-  if (fdata != NULL)
-    ms->args.free (fdata);
+    if (sockfd >= 0)
+        close(sockfd);
+    if (cc != NULL)
+        ms->args.free(cc);
+    if (fdata != NULL)
+        ms->args.free(fdata);
 
-  return err;
+    return err;
 }

--- a/sdk/3rdparty/libmemif/src/socket.h
+++ b/sdk/3rdparty/libmemif/src/socket.h
@@ -21,21 +21,20 @@
 #include <memif_private.h>
 
 /* interface identification errors (disconnect messages)*/
-#define MEMIF_VER_ERR       "incompatible version"
-#define MEMIF_ID_ERR        "unmatched interface id"
-#define MEMIF_SLAVE_ERR     "cannot connect to salve"
-#define MEMIF_CONN_ERR      "already connected"
-#define MEMIF_MODE_ERR      "mode mismatch"
-#define MEMIF_SECRET_ERR    "incorrect secret"
-#define MEMIF_NOSECRET_ERR  "secret required"
+#define MEMIF_VER_ERR "incompatible version"
+#define MEMIF_ID_ERR "unmatched interface id"
+#define MEMIF_SLAVE_ERR "cannot connect to salve"
+#define MEMIF_CONN_ERR "already connected"
+#define MEMIF_MODE_ERR "mode mismatch"
+#define MEMIF_SECRET_ERR "incorrect secret"
+#define MEMIF_NOSECRET_ERR "secret required"
 
 /* socket.c */
 
-int memif_listener_handler (memif_fd_event_type_t type, void *private_ctx);
+int memif_listener_handler(memif_fd_event_type_t type, void *private_ctx);
 
-int memif_control_channel_handler (memif_fd_event_type_t type,
-				   void *private_ctx);
+int memif_control_channel_handler(memif_fd_event_type_t type, void *private_ctx);
 
-void memif_delete_control_channel (memif_control_channel_t *cc);
+void memif_delete_control_channel(memif_control_channel_t *cc);
 
 #endif /* _SOCKET_H_ */

--- a/sdk/include/logger.h
+++ b/sdk/include/logger.h
@@ -10,34 +10,34 @@
 #include <stdio.h>
 #include <time.h>
 
-#define logmsg(tag, fmt, ...)                         \
-    do {                                              \
-        printf("%s - " fmt "\n", tag, ##__VA_ARGS__); \
+#define logmsg(tag, fmt, ...)                                                                      \
+    do {                                                                                           \
+        printf("%s - " fmt "\n", tag, ##__VA_ARGS__);                                              \
     } while (0)
 
-#define log_info(fmt, ...)                  \
-    do {                                    \
-        logmsg("INFO", fmt, ##__VA_ARGS__); \
+#define log_info(fmt, ...)                                                                         \
+    do {                                                                                           \
+        logmsg("INFO", fmt, ##__VA_ARGS__);                                                        \
     } while (0)
 
 #ifdef DEBUG
-  #define log_debug(fmt, ...)                  \
-      do {                                     \
-          logmsg("DEBUG", fmt, ##__VA_ARGS__); \
-      } while (0)
+#define log_debug(fmt, ...)                                                                        \
+    do {                                                                                           \
+        logmsg("DEBUG", fmt, ##__VA_ARGS__);                                                       \
+    } while (0)
 #else
-  // Define log_debug as empty in release build
-  #define log_debug(fmt, ...)
+// Define log_debug as empty in release build
+#define log_debug(fmt, ...)
 #endif
 
-#define log_warn(fmt, ...)                  \
-    do {                                    \
-        logmsg("WARN", fmt, ##__VA_ARGS__); \
+#define log_warn(fmt, ...)                                                                         \
+    do {                                                                                           \
+        logmsg("WARN", fmt, ##__VA_ARGS__);                                                        \
     } while (0)
 
-#define log_error(fmt, ...)                  \
-    do {                                     \
-        logmsg("ERROR", fmt, ##__VA_ARGS__); \
+#define log_error(fmt, ...)                                                                        \
+    do {                                                                                           \
+        logmsg("ERROR", fmt, ##__VA_ARGS__);                                                       \
     } while (0)
 
 #endif /* LOG_H */

--- a/sdk/include/mcm_dp.h
+++ b/sdk/include/mcm_dp.h
@@ -27,8 +27,8 @@ extern "C" {
 // Media proxy magic_word and version
 // 4 letters can be casted to numerical value in code:
 #ifndef HEADER_MAGIC_WORD
-    #define HEADER_MAGIC_WORD "mcm"
-    #define HEADER_VERSION 0x10
+#define HEADER_MAGIC_WORD "mcm"
+#define HEADER_VERSION 0x10
 #endif
 
 typedef struct _msg_header {
@@ -44,7 +44,7 @@ typedef struct _ctl_cmd {
 typedef struct _mcm_proxy_ctrl_msg {
     msg_header header;
     ctl_cmd command;
-    void* data;
+    void *data;
 } mcm_proxy_ctl_msg;
 
 typedef enum {
@@ -89,11 +89,11 @@ typedef struct {
 
 typedef struct {
     struct {
-        uint16_t seq_num; /* Sequence number */
+        uint16_t seq_num;   /* Sequence number */
         uint32_t timestamp; /* Timestamp */
-    } metadata; /**< filled by sender side */
-    size_t len; /**< size of data filled in "data" */
-    void* data;
+    } metadata;             /**< filled by sender side */
+    size_t len;             /**< size of data filled in "data" */
+    void *data;
 } mcm_buffer;
 
 typedef enum {
@@ -111,30 +111,30 @@ typedef enum {
 
 typedef enum {
     AUDIO_FMT_PCM8 = 0, /**< 8 bits per channel */
-    AUDIO_FMT_PCM16, /**< 16 bits per channel */
-    AUDIO_FMT_PCM24, /**< 24 bits per channel */
-    AUDIO_FMT_AM824, /**< 32 bits per channel */
-    AUDIO_FMT_MAX, /**< max value of this enum */
+    AUDIO_FMT_PCM16,    /**< 16 bits per channel */
+    AUDIO_FMT_PCM24,    /**< 24 bits per channel */
+    AUDIO_FMT_AM824,    /**< 32 bits per channel */
+    AUDIO_FMT_MAX,      /**< max value of this enum */
 } mcm_audio_format;
 
 typedef enum {
     AUDIO_SAMPLING_48K = 0, /**< sampling rate of 48kHz */
-    AUDIO_SAMPLING_96K, /**< sampling rate of 96kHz */
-    AUDIO_SAMPLING_44K, /**< sampling rate of 44.1kHz */
-    AUDIO_SAMPLING_MAX, /**< max value of this enum */
+    AUDIO_SAMPLING_96K,     /**< sampling rate of 96kHz */
+    AUDIO_SAMPLING_44K,     /**< sampling rate of 44.1kHz */
+    AUDIO_SAMPLING_MAX,     /**< max value of this enum */
 } mcm_audio_sampling;
 
 typedef enum {
     AUDIO_PTIME_1MS = 0, /**< packet time of 1ms */
-    AUDIO_PTIME_125US, /**< packet time of 125us */
-    AUDIO_PTIME_250US, /**< packet time of 250us */
-    AUDIO_PTIME_333US, /**< packet time of 333us */
-    AUDIO_PTIME_4MS, /**< packet time of 4ms */
-    AUDIO_PTIME_80US, /**< packet time of 80us */
-    AUDIO_PTIME_1_09MS, /**< packet time of 1.09ms, only for 44.1kHz sample */
-    AUDIO_PTIME_0_14MS, /**< packet time of 0.14ms, only for 44.1kHz sample */
-    AUDIO_PTIME_0_09MS, /**< packet time of 0.09ms, only for 44.1kHz sample */
-    AUDIO_PTIME_MAX, /**< max value of this enum */
+    AUDIO_PTIME_125US,   /**< packet time of 125us */
+    AUDIO_PTIME_250US,   /**< packet time of 250us */
+    AUDIO_PTIME_333US,   /**< packet time of 333us */
+    AUDIO_PTIME_4MS,     /**< packet time of 4ms */
+    AUDIO_PTIME_80US,    /**< packet time of 80us */
+    AUDIO_PTIME_1_09MS,  /**< packet time of 1.09ms, only for 44.1kHz sample */
+    AUDIO_PTIME_0_14MS,  /**< packet time of 0.14ms, only for 44.1kHz sample */
+    AUDIO_PTIME_0_09MS,  /**< packet time of 0.09ms, only for 44.1kHz sample */
+    AUDIO_PTIME_MAX,     /**< max value of this enum */
 } mcm_audio_ptime;
 
 typedef enum {
@@ -148,8 +148,8 @@ typedef enum {
 
 typedef enum {
     AUDIO_TYPE_FRAME_LEVEL = 0, /**< app interface lib based on frame level */
-    AUDIO_TYPE_RTP_LEVEL, /**< app interface lib based on RTP level */
-    AUDIO_TYPE_MAX, /**< max value of this enum */
+    AUDIO_TYPE_RTP_LEVEL,       /**< app interface lib based on RTP level */
+    AUDIO_TYPE_MAX,             /**< max value of this enum */
 } mcm_audio_type;
 
 /**
@@ -157,8 +157,8 @@ typedef enum {
  */
 typedef enum {
     ANC_TYPE_FRAME_LEVEL = 0, /**< app interface lib based on frame level */
-    ANC_TYPE_RTP_LEVEL, /**< app interface lib based on RTP level */
-    ANC_TYPE_MAX, /**< max value of this enum */
+    ANC_TYPE_RTP_LEVEL,       /**< app interface lib based on RTP level */
+    ANC_TYPE_MAX,             /**< max value of this enum */
 } mcm_anc_type;
 
 typedef enum {
@@ -240,7 +240,7 @@ typedef struct _mcm_conn_context {
     int proxy_sockfd;
     uint32_t session_id;
     proto_type proto;
-    void* priv;
+    void *priv;
 
     /* video resolution */
     uint32_t width;
@@ -255,8 +255,8 @@ typedef struct _mcm_conn_context {
     int pkt_len;
 
     /* function */
-    mcm_buffer* (*dequeue_buffer)(mcm_conn_context* self, int timeout, int* error_code);
-    int (*enqueue_buffer)(mcm_conn_context* self, mcm_buffer* buf);
+    mcm_buffer *(*dequeue_buffer)(mcm_conn_context *self, int timeout, int *error_code);
+    int (*enqueue_buffer)(mcm_conn_context *self, mcm_buffer *buf);
 } mcm_conn_context;
 
 /**
@@ -264,13 +264,13 @@ typedef struct _mcm_conn_context {
  * @param param Parameters for the connect session.
  * \return The context handler of created connect session.
  */
-mcm_conn_context* mcm_create_connection(mcm_conn_param* param);
+mcm_conn_context *mcm_create_connection(mcm_conn_param *param);
 
 /**
  * \brief Destroy MCM DP connection.
  * @param pctx The context handler of connection.
  */
-void mcm_destroy_connection(mcm_conn_context* pctx);
+void mcm_destroy_connection(mcm_conn_context *pctx);
 
 /**
  * Get buffer from buffer queue.
@@ -287,7 +287,7 @@ void mcm_destroy_connection(mcm_conn_context* pctx);
  * @param error_code Error code if failed, can be set to NULL if doesn't care.
  * \return Pointer to the mcm_buffer, return NULL if failed.
  */
-mcm_buffer* mcm_dequeue_buffer(mcm_conn_context* pctx, int timeout, int* error_code);
+mcm_buffer *mcm_dequeue_buffer(mcm_conn_context *pctx, int timeout, int *error_code);
 
 /**
  * Put buffer to buffer queue.
@@ -300,7 +300,7 @@ mcm_buffer* mcm_dequeue_buffer(mcm_conn_context* pctx, int timeout, int* error_c
  * @param buf Pinter to the mcm_buffer.
  * \return Error code if failed, return "0" if success.
  */
-int mcm_enqueue_buffer(mcm_conn_context* pctx, mcm_buffer* buf);
+int mcm_enqueue_buffer(mcm_conn_context *pctx, mcm_buffer *buf);
 
 #ifdef __cplusplus
 }

--- a/sdk/include/media_proxy_ctrl.h
+++ b/sdk/include/media_proxy_ctrl.h
@@ -15,17 +15,18 @@ extern "C" {
 #include "libmemif.h"
 #include "mcm_dp.h"
 
-int get_media_proxy_addr(mcm_dp_addr* proxy_addr);
+int get_media_proxy_addr(mcm_dp_addr *proxy_addr);
 
-int open_socket(mcm_dp_addr* proxy_addr);
+int open_socket(mcm_dp_addr *proxy_addr);
 
 void close_socket(int sockfd);
 
-int media_proxy_create_session(int sockfd, mcm_conn_param* param, uint32_t* session_id);
+int media_proxy_create_session(int sockfd, mcm_conn_param *param, uint32_t *session_id);
 
-void media_proxy_destroy_session(mcm_conn_context* pctx);
+void media_proxy_destroy_session(mcm_conn_context *pctx);
 
-int media_proxy_query_interface(int sockfd, uint32_t session_id, mcm_conn_param* param, memif_conn_param* memif_conn_args);
+int media_proxy_query_interface(int sockfd, uint32_t session_id, mcm_conn_param *param,
+                                memif_conn_param *memif_conn_args);
 
 #ifdef __cplusplus
 }

--- a/sdk/include/memif_impl.h
+++ b/sdk/include/memif_impl.h
@@ -29,7 +29,7 @@ typedef struct {
 
     size_t buffer_size;
     /* buffer queue */
-    memif_buffer_t* shm_bufs;
+    memif_buffer_t *shm_bufs;
     /* number of buffers pointing to shared memory */
     uint16_t buf_num;
 
@@ -47,10 +47,11 @@ typedef struct {
 } memif_ops_t;
 
 /* Create memif connection . */
-mcm_conn_context* mcm_create_connection_memif(mcm_conn_param* svc_args, memif_conn_param* memif_args);
+mcm_conn_context *mcm_create_connection_memif(mcm_conn_param *svc_args,
+                                              memif_conn_param *memif_args);
 
 /* Destroy memif connection. */
-void mcm_destroy_connection_memif(memif_conn_context* pctx);
+void mcm_destroy_connection_memif(memif_conn_context *pctx);
 
 /* Alloc buffer from queue. */
 // void* memif_alloc_buffer(void* conn_ctx, size_t size);
@@ -65,10 +66,10 @@ void mcm_destroy_connection_memif(memif_conn_context* pctx);
 // void memif_free_buffer(void* conn_ctx, mcm_buffer* buf);
 
 /* Alloc video frame buffer from buffer queue. */
-mcm_buffer* memif_dequeue_buffer(mcm_conn_context* conn_ctx, int timeout, int* error_code);
+mcm_buffer *memif_dequeue_buffer(mcm_conn_context *conn_ctx, int timeout, int *error_code);
 
 /* Return video frame buffer to buffer queue. */
-int memif_enqueue_buffer(mcm_conn_context* conn_ctx, mcm_buffer* buf);
+int memif_enqueue_buffer(mcm_conn_context *conn_ctx, mcm_buffer *buf);
 
 #ifdef __cplusplus
 }

--- a/sdk/include/udp_impl.h
+++ b/sdk/include/udp_impl.h
@@ -21,22 +21,22 @@ typedef struct _udp_context {
 } udp_context;
 
 /* Create MCM DP connect session for application. */
-udp_context* mcm_create_connection_udp(mcm_conn_param* param);
+udp_context *mcm_create_connection_udp(mcm_conn_param *param);
 
 /* Destroy MCM DP connection. */
-void mcm_destroy_connection_udp(udp_context* conn_ctx);
+void mcm_destroy_connection_udp(udp_context *conn_ctx);
 
 /* Alloc buffer from queue. */
-mcm_buffer* mcm_alloc_buffer_udp(void* conn_ctx, size_t size);
+mcm_buffer *mcm_alloc_buffer_udp(void *conn_ctx, size_t size);
 
 /* Send out video frame on TX side. */
-int mcm_send_buffer_udp(void* conn_ctx, mcm_buffer* buf);
+int mcm_send_buffer_udp(void *conn_ctx, mcm_buffer *buf);
 
 /* Receive video frame on RX side. */
-int mcm_recv_buffer_udp(void* conn_ctx, mcm_buffer* buf);
+int mcm_recv_buffer_udp(void *conn_ctx, mcm_buffer *buf);
 
 /* Return video frame buffer to queue. */
-void mcm_free_buffer_udp(void* conn_ctx, mcm_buffer** buf);
+void mcm_free_buffer_udp(void *conn_ctx, mcm_buffer **buf);
 
 #ifdef __cplusplus
 }

--- a/sdk/samples/rtsp_recver_app.c
+++ b/sdk/samples/rtsp_recver_app.c
@@ -20,44 +20,43 @@
 
 static volatile bool keepRunning = true;
 
-void intHandler(int dummy)
-{
-    keepRunning = 0;
-}
+void intHandler(int dummy) { keepRunning = 0; }
 
 /* print a description of all supported options */
-void usage(FILE* fp, const char* path)
+void usage(FILE *fp, const char *path)
 {
     /* take only the last portion of the path */
-    const char* basename = strrchr(path, '/');
+    const char *basename = strrchr(path, '/');
     basename = basename ? basename + 1 : path;
 
     fprintf(fp, "usage: %s [OPTION]\n", basename);
     fprintf(fp, "-h, --help\t\t\t"
                 "Print this help and exit.\n");
-    fprintf(fp, "-r, --ip=ip_address\t\t"
-                "Receive data from IP address (defaults: %s).\n", DEFAULT_RECV_IP);
-    fprintf(fp, "-p, --port=port_number\t"
-                "Receive data from Port (defaults: %s).\n", DEFAULT_RECV_PORT);
+    fprintf(fp,
+            "-r, --ip=ip_address\t\t"
+            "Receive data from IP address (defaults: %s).\n",
+            DEFAULT_RECV_IP);
+    fprintf(fp,
+            "-p, --port=port_number\t"
+            "Receive data from Port (defaults: %s).\n",
+            DEFAULT_RECV_PORT);
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     char recv_addr[46] = DEFAULT_RECV_IP;
     char recv_port[6] = DEFAULT_RECV_PORT;
 
-    mcm_conn_context* dp_ctx = NULL;
-    mcm_conn_param param = { 0 };
-    mcm_buffer* buf = NULL;
+    mcm_conn_context *dp_ctx = NULL;
+    mcm_conn_param param = {0};
+    mcm_buffer *buf = NULL;
 
     int help_flag = 0;
     int opt;
-    struct option longopts[] = {
-        { "help", no_argument, &help_flag, 1 },
-        { "ip", required_argument, NULL, 'r' },
-        { "port", required_argument, NULL, 'p' },
-        { 0 }
-    };
+    struct option longopts[] = {{"help", no_argument, &help_flag, 1},
+                                {"ip", required_argument, NULL, 'r'},
+                                {"port", required_argument, NULL, 'p'},
+                                {0}};
 
     /* infinite loop, to be broken when we are done parsing options */
     while (1) {
@@ -85,7 +84,7 @@ int main(int argc, char** argv)
     }
 
     if (help_flag) {
-        usage (stdout, argv[0]);
+        usage(stdout, argv[0]);
         return 0;
     }
 
@@ -107,7 +106,7 @@ int main(int argc, char** argv)
     uint32_t frame_count = 0;
     const uint32_t fps_interval = 30;
     double fps = 0.0;
-    void* ptr = NULL;
+    void *ptr = NULL;
     int timeout = -1;
     bool first_frame = true;
     long latency = 0;
@@ -137,13 +136,13 @@ int main(int argc, char** argv)
 
         /* operate on the buffer */
         ptr = buf->data;
-        if (*(uint32_t*)ptr != frame_count) {
-            printf("Wrong data content: expected %d, got %u\n", frame_count, *(uint32_t*)ptr);
+        if (*(uint32_t *)ptr != frame_count) {
+            printf("Wrong data content: expected %d, got %u\n", frame_count, *(uint32_t *)ptr);
             /* catch up the sender frame count */
-            frame_count = *(uint32_t*)ptr;
+            frame_count = *(uint32_t *)ptr;
         }
         ptr += sizeof(frame_count);
-        ts_send = *(struct timespec*)ptr;
+        ts_send = *(struct timespec *)ptr;
 
         /* free buffer */
         if (mcm_enqueue_buffer(dp_ctx, buf) != 0) {
@@ -167,8 +166,7 @@ int main(int argc, char** argv)
         latency = 1000 * (ts_recv.tv_sec - ts_send.tv_sec);
         latency += (ts_recv.tv_nsec - ts_send.tv_nsec) / 1000000;
 
-        printf("RX frames: [%u], latency: %ld ms, FPS: %0.3f\n",
-            frame_count, latency, fps);
+        printf("RX frames: [%u], latency: %ld ms, FPS: %0.3f\n", frame_count, latency, fps);
     }
 
     /* Clean up */

--- a/sdk/samples/sender_app.c
+++ b/sdk/samples/sender_app.c
@@ -35,87 +35,100 @@
 static volatile bool keepRunning = true;
 static char input_file[128] = "";
 
-void intHandler(int dummy)
-{
-    keepRunning = 0;
-}
+void intHandler(int dummy) { keepRunning = 0; }
 
 /* print a description of all supported options */
-void usage(FILE* fp, const char* path)
+void usage(FILE *fp, const char *path)
 {
     /* take only the last portion of the path */
-    const char* basename = strrchr(path, '/');
+    const char *basename = strrchr(path, '/');
     basename = basename ? basename + 1 : path;
 
     fprintf(fp, "usage: %s [OPTION]\n", basename);
     fprintf(fp, "-H, --help\t\t\t"
                 "Print this help and exit\n");
-    fprintf(fp, "-w, --width=<frame_width>\t"
-                "Width of test video frame (default: %d)\n",
-        DEFAULT_FRAME_WIDTH);
-    fprintf(fp, "-h, --height=<frame_height>\t"
-                "Height of test video frame (default: %d)\n",
-        DEFAULT_FRAME_HEIGHT);
-    fprintf(fp, "-f, --fps=<video_fps>\t\t"
-                "Test video FPS (frame per second) (default: %0.2f)\n",
-        DEFAULT_FPS);
-    fprintf(fp, "-s, --ip=ip_address\t\t"
-                "Send data to IP address (default: %s)\n",
-        DEFAULT_SEND_IP);
-    fprintf(fp, "-p, --port=port_number\t\t"
-                "Send data to Port (default: %s)\n",
-        DEFAULT_SEND_PORT);
-    fprintf(fp, "-o, --protocol=protocol_type\t"
-                "Set protocol type (default: %s)\n",
-        DEFAULT_PROTOCOL);
-    fprintf(fp, "-n, --number=frame_number\t"
-                "Total frame number to send (default: %d)\n",
-        DEFAULT_TOTAL_NUM);
+    fprintf(fp,
+            "-w, --width=<frame_width>\t"
+            "Width of test video frame (default: %d)\n",
+            DEFAULT_FRAME_WIDTH);
+    fprintf(fp,
+            "-h, --height=<frame_height>\t"
+            "Height of test video frame (default: %d)\n",
+            DEFAULT_FRAME_HEIGHT);
+    fprintf(fp,
+            "-f, --fps=<video_fps>\t\t"
+            "Test video FPS (frame per second) (default: %0.2f)\n",
+            DEFAULT_FPS);
+    fprintf(fp,
+            "-s, --ip=ip_address\t\t"
+            "Send data to IP address (default: %s)\n",
+            DEFAULT_SEND_IP);
+    fprintf(fp,
+            "-p, --port=port_number\t\t"
+            "Send data to Port (default: %s)\n",
+            DEFAULT_SEND_PORT);
+    fprintf(fp,
+            "-o, --protocol=protocol_type\t"
+            "Set protocol type (default: %s)\n",
+            DEFAULT_PROTOCOL);
+    fprintf(fp,
+            "-n, --number=frame_number\t"
+            "Total frame number to send (default: %d)\n",
+            DEFAULT_TOTAL_NUM);
     fprintf(fp, "-i, --file=input_file\t\t"
                 "Input file name (optional)\n");
-    fprintf(fp, "-s, --socketpath=socket_path\t"
-                "Set memif socket path (default: %s)\n",
-        DEFAULT_MEMIF_SOCKET_PATH);
-    fprintf(fp, "-m, --master=is_master\t\t"
-                "Set memif conn is master (default: %d)\n",
-        DEFAULT_MEMIF_IS_MASTER);
-    fprintf(fp, "-d, --interfaceid=interface_id\t"
-                "Set memif conn interface id (default: %d)\n",
-        DEFAULT_MEMIF_INTERFACE_ID);
-    fprintf(fp, "-l, --loop=is_loop\t"
-                "Set infinity loop sending (default: %d)\n",
-        DEFAULT_INFINITY_LOOP);
+    fprintf(fp,
+            "-s, --socketpath=socket_path\t"
+            "Set memif socket path (default: %s)\n",
+            DEFAULT_MEMIF_SOCKET_PATH);
+    fprintf(fp,
+            "-m, --master=is_master\t\t"
+            "Set memif conn is master (default: %d)\n",
+            DEFAULT_MEMIF_IS_MASTER);
+    fprintf(fp,
+            "-d, --interfaceid=interface_id\t"
+            "Set memif conn interface id (default: %d)\n",
+            DEFAULT_MEMIF_INTERFACE_ID);
+    fprintf(fp,
+            "-l, --loop=is_loop\t"
+            "Set infinity loop sending (default: %d)\n",
+            DEFAULT_INFINITY_LOOP);
     fprintf(fp, "\n");
 }
 
 static int getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, bool interlaced)
 {
-    size_t size = (size_t)(width*height);
+    size_t size = (size_t)(width * height);
     switch (fmt) {
-        case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY) */
-            size = size * 2;
-            break;
-        case PIX_FMT_RGB8:
-            size = size * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
-            break;
-/* Customized YUV 420 8bit, set transport format as ST20_FMT_YUV_420_8BIT. For direct transport of
-none-RFC4175 formats like I420/NV12. When this input/output format is set, the frame is identical to
-transport frame without conversion. The frame should not have lines padding) */
-        case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
-            size = size * 3 / 2;
-            break;
-        case PIX_FMT_YUV444P_10BIT_LE:
-            size = size * 2 * 3;
-            break;
-        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
-        default:
-            size = size * 2 * 2;
+    case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY)
+                           */
+        size = size * 2;
+        break;
+    case PIX_FMT_RGB8:
+        size = size * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
+        break;
+        /* Customized YUV 420 8bit, set transport format as ST20_FMT_YUV_420_8BIT. For direct
+        transport of none-RFC4175 formats like I420/NV12. When this input/output format is set, the
+        frame is identical to transport frame without conversion. The frame should not have lines
+        padding) */
+    case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka
+                          ST_FRAME_FMT_YUV420PLANAR8) */
+        size = size * 3 / 2;
+        break;
+    case PIX_FMT_YUV444P_10BIT_LE:
+        size = size * 2 * 3;
+        break;
+    case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka
+                                      ST_FRAME_FMT_YUV422PLANAR10LE) */
+    default:
+        size = size * 2 * 2;
     }
-    if (interlaced) size /= 2; /* if all fmt support interlace? */
+    if (interlaced)
+        size /= 2; /* if all fmt support interlace? */
     return (int)size;
 }
 
-int read_test_data(FILE* fp, mcm_buffer* buf, uint32_t frame_size)
+int read_test_data(FILE *fp, mcm_buffer *buf, uint32_t frame_size)
 {
     int ret = 0;
 
@@ -125,28 +138,28 @@ int read_test_data(FILE* fp, mcm_buffer* buf, uint32_t frame_size)
     if (fread(buf->data, frame_size, 1, fp) < 1) {
         ret = -1;
     }
-    if(ret >= 0 ) {
+    if (ret >= 0) {
         buf->len = frame_size;
     }
     return ret;
 }
 
-int gen_test_data(mcm_buffer* buf, uint32_t frame_count)
+int gen_test_data(mcm_buffer *buf, uint32_t frame_count)
 {
     /* operate on the buffer */
-    void* ptr = buf->data;
+    void *ptr = buf->data;
 
     /* frame counter */
-    *(uint32_t*)ptr = frame_count;
+    *(uint32_t *)ptr = frame_count;
     ptr += sizeof(frame_count);
 
     /* timestamp */
-    clock_gettime( CLOCK_REALTIME , (struct timespec*)ptr);
+    clock_gettime(CLOCK_REALTIME, (struct timespec *)ptr);
 
     return 0;
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     char recv_addr[46] = DEFAULT_RECV_IP;
     char recv_port[6] = DEFAULT_RECV_PORT;
@@ -168,33 +181,23 @@ int main(int argc, char** argv)
     video_pixel_format pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
     uint32_t frame_size = 0;
 
-    mcm_conn_context* dp_ctx = NULL;
-    mcm_conn_param param = { 0 };
-    mcm_buffer* buf = NULL;
+    mcm_conn_context *dp_ctx = NULL;
+    mcm_conn_param param = {0};
+    mcm_buffer *buf = NULL;
     uint32_t total_num = 300;
 
     int help_flag = 0;
     int opt;
     struct option longopts[] = {
-        { "help", no_argument, &help_flag, 'H' },
-        { "width", required_argument, NULL, 'w' },
-        { "height", required_argument, NULL, 'h' },
-        { "fps", required_argument, NULL, 'f' },
-        { "rcv_ip", required_argument, NULL, 'r' },
-        { "rcv_port", required_argument, NULL, 'i' },
-        { "send_ip", required_argument, NULL, 's' },
-        { "send_port", required_argument, NULL, 'p' },
-        { "protocol", required_argument, NULL, 'o' },
-        { "number", required_argument, NULL, 'n' },
-        { "file", required_argument, NULL, 'b' },
-        { "type", required_argument, NULL, 't' },
-        { "socketpath", required_argument, NULL, 'k' },
-        { "master", required_argument, NULL, 'm' },
-        { "interfaceid", required_argument, NULL, 'd' },
-        { "loop", required_argument, NULL, 'l' },
-        { "pix_fmt", required_argument, NULL, 'x' },
-        { 0 }
-    };
+        {"help", no_argument, &help_flag, 'H'},        {"width", required_argument, NULL, 'w'},
+        {"height", required_argument, NULL, 'h'},      {"fps", required_argument, NULL, 'f'},
+        {"rcv_ip", required_argument, NULL, 'r'},      {"rcv_port", required_argument, NULL, 'i'},
+        {"send_ip", required_argument, NULL, 's'},     {"send_port", required_argument, NULL, 'p'},
+        {"protocol", required_argument, NULL, 'o'},    {"number", required_argument, NULL, 'n'},
+        {"file", required_argument, NULL, 'b'},        {"type", required_argument, NULL, 't'},
+        {"socketpath", required_argument, NULL, 'k'},  {"master", required_argument, NULL, 'm'},
+        {"interfaceid", required_argument, NULL, 'd'}, {"loop", required_argument, NULL, 'l'},
+        {"pix_fmt", required_argument, NULL, 'x'},     {0}};
 
     /* infinite loop, to be broken when we are done parsing options */
     while (1) {
@@ -250,17 +253,17 @@ int main(int argc, char** argv)
             interface_id = atoi(optarg);
             break;
         case 'l':
-            loop = (atoi(optarg)>0);
+            loop = (atoi(optarg) > 0);
             break;
         case 'x':
             strlcpy(pix_fmt_string, optarg, sizeof(pix_fmt_string));
-            if (strncmp(pix_fmt_string, "yuv422p", sizeof(pix_fmt_string)) == 0){
+            if (strncmp(pix_fmt_string, "yuv422p", sizeof(pix_fmt_string)) == 0) {
                 pix_fmt = PIX_FMT_YUV422P;
             } else if (strncmp(pix_fmt_string, "yuv422p10le", sizeof(pix_fmt_string)) == 0) {
                 pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
-            } else if (strncmp(pix_fmt_string, "yuv444p10le", sizeof(pix_fmt_string)) == 0){
+            } else if (strncmp(pix_fmt_string, "yuv444p10le", sizeof(pix_fmt_string)) == 0) {
                 pix_fmt = PIX_FMT_YUV444P_10BIT_LE;
-            } else if (strncmp(pix_fmt_string, "rgb8", sizeof(pix_fmt_string)) == 0){
+            } else if (strncmp(pix_fmt_string, "rgb8", sizeof(pix_fmt_string)) == 0) {
                 pix_fmt = PIX_FMT_RGB8;
             } else {
                 pix_fmt = PIX_FMT_NV12;
@@ -285,7 +288,8 @@ int main(int argc, char** argv)
 
     if (strncmp(protocol_type, "memif", sizeof(protocol_type)) == 0) {
         param.protocol = PROTO_MEMIF;
-        strlcpy(param.memif_interface.socket_path, socket_path, sizeof(param.memif_interface.socket_path));
+        strlcpy(param.memif_interface.socket_path, socket_path,
+                sizeof(param.memif_interface.socket_path));
         param.memif_interface.is_master = is_master;
         param.memif_interface.interface_id = interface_id;
     } else if (strncmp(protocol_type, "udp", sizeof(protocol_type)) == 0) {
@@ -335,9 +339,9 @@ int main(int argc, char** argv)
     case PAYLOAD_TYPE_ST22_VIDEO:
     default:
         /* video format */
-        param.payload_args.video_args.width   = param.width = width;
-        param.payload_args.video_args.height  = param.height = height;
-        param.payload_args.video_args.fps     = param.fps = vid_fps;
+        param.payload_args.video_args.width = param.width = width;
+        param.payload_args.video_args.height = param.height = height;
+        param.payload_args.video_args.fps = param.fps = vid_fps;
         param.payload_args.video_args.pix_fmt = param.pix_fmt = pix_fmt;
         break;
     }
@@ -356,7 +360,7 @@ int main(int argc, char** argv)
 
     signal(SIGINT, intHandler);
 
-    FILE* input_fp = NULL;
+    FILE *input_fp = NULL;
     uint32_t frame_count = 0;
     const uint32_t fps_interval = 30;
     double fps = 0.0;
@@ -364,7 +368,7 @@ int main(int argc, char** argv)
     struct timespec ts_frame_begin = {}, ts_frame_end = {};
 
     if (strlen(input_file) > 0) {
-        struct stat statbuf = { 0 };
+        struct stat statbuf = {0};
         if (stat(input_file, &statbuf) == -1) {
             perror(NULL);
             exit(-1);
@@ -440,7 +444,8 @@ int main(int argc, char** argv)
         clock_gettime(CLOCK_REALTIME, &ts_frame_end);
 
         /* sleep for 1/fps */
-        __useconds_t spend = 1000000 * (ts_frame_end.tv_sec - ts_frame_begin.tv_sec) + (ts_frame_end.tv_nsec - ts_frame_begin.tv_nsec)/1000;
+        __useconds_t spend = 1000000 * (ts_frame_end.tv_sec - ts_frame_begin.tv_sec) +
+                             (ts_frame_end.tv_nsec - ts_frame_begin.tv_nsec) / 1000;
         printf("pacing: %d\n", pacing);
         printf("spend: %d\n", spend);
     }

--- a/sdk/src/mcm_dp.c
+++ b/sdk/src/mcm_dp.c
@@ -115,7 +115,8 @@ static int mcm_calc_audio_buffer_size(mcm_audio_args *params, uint32_t *size)
     return 0;
 }
 
-static void parse_memif_param(mcm_conn_param* request, memif_socket_args_t* memif_socket_args, memif_conn_args_t* memif_conn_args)
+static void parse_memif_param(mcm_conn_param *request, memif_socket_args_t *memif_socket_args,
+                              memif_conn_args_t *memif_conn_args)
 {
     char type_str[8] = "";
     char interface_name[32];
@@ -130,18 +131,24 @@ static void parse_memif_param(mcm_conn_param* request, memif_socket_args_t* memi
     memif_conn_args->is_master = request->memif_interface.is_master;
     memif_conn_args->interface_id = request->memif_interface.interface_id;
 
-    snprintf(memif_socket_args->app_name, sizeof(memif_socket_args->app_name), "memif_%s_%d", type_str, atoi(request->local_addr.port));
-    snprintf(interface_name, sizeof(interface_name), "memif_%s_%d", type_str, atoi(request->local_addr.port));
-    strlcpy((char*)memif_conn_args->interface_name, interface_name, sizeof(memif_conn_args->interface_name));
+    snprintf(memif_socket_args->app_name, sizeof(memif_socket_args->app_name), "memif_%s_%d",
+             type_str, atoi(request->local_addr.port));
+    snprintf(interface_name, sizeof(interface_name), "memif_%s_%d", type_str,
+             atoi(request->local_addr.port));
+    strlcpy((char *)memif_conn_args->interface_name, interface_name,
+            sizeof(memif_conn_args->interface_name));
     if (!strlen(request->memif_interface.socket_path)) {
-        strlcpy(memif_socket_args->path, "/run/mcm/mcm_rx_memif.sock", sizeof(memif_socket_args->path));
+        strlcpy(memif_socket_args->path, "/run/mcm/mcm_rx_memif.sock",
+                sizeof(memif_socket_args->path));
     } else {
-        strlcpy(memif_socket_args->path, request->memif_interface.socket_path, sizeof(memif_socket_args->path));
+        strlcpy(memif_socket_args->path, request->memif_interface.socket_path,
+                sizeof(memif_socket_args->path));
     }
 
     switch (request->payload_type) {
     case PAYLOAD_TYPE_ST30_AUDIO:
-        err = mcm_calc_audio_buffer_size(&request->payload_args.audio_args, &memif_conn_args->buffer_size);
+        err = mcm_calc_audio_buffer_size(&request->payload_args.audio_args,
+                                         &memif_conn_args->buffer_size);
         if (err)
             log_error("Invalid audio parameters.");
         break;
@@ -150,17 +157,18 @@ static void parse_memif_param(mcm_conn_param* request, memif_socket_args_t* memi
     case PAYLOAD_TYPE_ST22_VIDEO:
     case PAYLOAD_TYPE_RTSP_VIDEO:
     default:
-        memif_conn_args->buffer_size = request->payload_args.video_args.width * request->payload_args.video_args.height * 4;
+        memif_conn_args->buffer_size =
+            request->payload_args.video_args.width * request->payload_args.video_args.height * 4;
     }
 
     memif_conn_args->log2_ring_size = 4;
 }
 
 /* Connect to MCM media proxy daemon through memif. */
-mcm_conn_context* mcm_create_connection_proxy(mcm_conn_param* param)
+mcm_conn_context *mcm_create_connection_proxy(mcm_conn_param *param)
 {
     int ret = 0;
-    mcm_conn_context* conn_ctx = NULL;
+    mcm_conn_context *conn_ctx = NULL;
     mcm_dp_addr media_proxy_addr = {};
     int sockfd = 0;
     uint32_t session_id = 0;
@@ -219,10 +227,10 @@ mcm_conn_context* mcm_create_connection_proxy(mcm_conn_param* param)
  *              media-proxy.
  * @return Connection context if success, NULL if failed.
  ******************************************************/
-mcm_conn_context* mcm_create_connection(mcm_conn_param* param)
+mcm_conn_context *mcm_create_connection(mcm_conn_param *param)
 {
-    void* p_ctx = NULL;
-    mcm_conn_context* conn_ctx = NULL;
+    void *p_ctx = NULL;
+    mcm_conn_context *conn_ctx = NULL;
 
     if (param == NULL) {
         log_error("Illegal Parameters.");
@@ -254,7 +262,7 @@ mcm_conn_context* mcm_create_connection(mcm_conn_param* param)
             return NULL;
         }
         conn_ctx->proto = PROTO_UDP;
-        conn_ctx->priv = (void*)p_ctx;
+        conn_ctx->priv = (void *)p_ctx;
         break;
     case PROTO_MEMIF:
         memif_conn_param memif_param = {};
@@ -281,7 +289,7 @@ mcm_conn_context* mcm_create_connection(mcm_conn_param* param)
 }
 
 /* Destroy MCM DP connection. */
-void mcm_destroy_connection(mcm_conn_context* pctx)
+void mcm_destroy_connection(mcm_conn_context *pctx)
 {
     useconds_t wait_time = 0;
 
@@ -309,10 +317,10 @@ void mcm_destroy_connection(mcm_conn_context* pctx)
 
     switch (pctx->proto) {
     case PROTO_MEMIF:
-        mcm_destroy_connection_memif((memif_conn_context*)pctx->priv);
+        mcm_destroy_connection_memif((memif_conn_context *)pctx->priv);
         break;
     case PROTO_UDP:
-        mcm_destroy_connection_udp((udp_context*)pctx->priv);
+        mcm_destroy_connection_udp((udp_context *)pctx->priv);
         break;
     default:
         log_warn("Unsupported protocol: %d", pctx->proto);
@@ -322,12 +330,12 @@ void mcm_destroy_connection(mcm_conn_context* pctx)
     free(pctx);
 }
 
-mcm_buffer* mcm_dequeue_buffer(mcm_conn_context* pctx, int timeout, int* error_code)
+mcm_buffer *mcm_dequeue_buffer(mcm_conn_context *pctx, int timeout, int *error_code)
 {
     return pctx->dequeue_buffer(pctx, timeout, error_code);
 }
 
-int mcm_enqueue_buffer(mcm_conn_context* pctx, mcm_buffer* buf)
+int mcm_enqueue_buffer(mcm_conn_context *pctx, mcm_buffer *buf)
 {
     return pctx->enqueue_buffer(pctx, buf);
 }

--- a/sdk/src/media_proxy_ctrl.c
+++ b/sdk/src/media_proxy_ctrl.c
@@ -12,9 +12,9 @@
 #include "logger.h"
 #include "media_proxy_ctrl.h"
 
-int get_media_proxy_addr(mcm_dp_addr* proxy_addr)
+int get_media_proxy_addr(mcm_dp_addr *proxy_addr)
 {
-    char* penv_val = NULL;
+    char *penv_val = NULL;
     const char DEFAULT_PROXY_IP[] = "127.0.0.1";
     const char DEFAULT_PROXY_PORT[] = "8002";
 
@@ -40,7 +40,7 @@ int get_media_proxy_addr(mcm_dp_addr* proxy_addr)
     return 0;
 }
 
-int open_socket(mcm_dp_addr* proxy_addr)
+int open_socket(mcm_dp_addr *proxy_addr)
 {
     int sockfd = -1;
     struct sockaddr_in srvaddr = {};
@@ -58,7 +58,7 @@ int open_socket(mcm_dp_addr* proxy_addr)
     srvaddr.sin_port = htons(atoi(proxy_addr->port));
 
     /* connect to media-proxy socket. */
-    if (connect(sockfd, (struct sockaddr*)&srvaddr, sizeof(srvaddr)) != 0) {
+    if (connect(sockfd, (struct sockaddr *)&srvaddr, sizeof(srvaddr)) != 0) {
         log_error("Failed to connect to media-proxy socket.");
         close(sockfd);
         return -1;
@@ -76,7 +76,7 @@ void close_socket(int sockfd)
     return;
 }
 
-int media_proxy_create_session(int sockfd, mcm_conn_param* param, uint32_t* session_id)
+int media_proxy_create_session(int sockfd, mcm_conn_param *param, uint32_t *session_id)
 {
     ssize_t ret = 0;
     mcm_proxy_ctl_msg msg = {};
@@ -87,7 +87,7 @@ int media_proxy_create_session(int sockfd, mcm_conn_param* param, uint32_t* sess
     }
 
     /* intialize message header. */
-    msg.header.magic_word = *(uint32_t*)HEADER_MAGIC_WORD;
+    msg.header.magic_word = *(uint32_t *)HEADER_MAGIC_WORD;
     msg.header.version = HEADER_VERSION;
 
     msg.command.inst = MCM_CREATE_SESSION;
@@ -124,7 +124,8 @@ int media_proxy_create_session(int sockfd, mcm_conn_param* param, uint32_t* sess
     return 0;
 }
 
-int media_proxy_query_interface(int sockfd, uint32_t session_id, mcm_conn_param* param, memif_conn_param* memif_conn_args)
+int media_proxy_query_interface(int sockfd, uint32_t session_id, mcm_conn_param *param,
+                                memif_conn_param *memif_conn_args)
 {
     ssize_t ret = 0;
     mcm_proxy_ctl_msg msg = {};
@@ -135,7 +136,7 @@ int media_proxy_query_interface(int sockfd, uint32_t session_id, mcm_conn_param*
     }
 
     /* intialize message header. */
-    msg.header.magic_word = *(uint32_t*)HEADER_MAGIC_WORD;
+    msg.header.magic_word = *(uint32_t *)HEADER_MAGIC_WORD;
     msg.header.version = HEADER_VERSION;
 
     /* memif parameters */
@@ -171,7 +172,7 @@ int media_proxy_query_interface(int sockfd, uint32_t session_id, mcm_conn_param*
     return 0;
 }
 
-void media_proxy_destroy_session(mcm_conn_context* pctx)
+void media_proxy_destroy_session(mcm_conn_context *pctx)
 {
     int sockfd = 0;
     uint32_t session_id = 0;
@@ -186,7 +187,7 @@ void media_proxy_destroy_session(mcm_conn_context* pctx)
     session_id = pctx->session_id;
 
     /* intialize message header. */
-    msg.header.magic_word = *(uint32_t*)HEADER_MAGIC_WORD;
+    msg.header.magic_word = *(uint32_t *)HEADER_MAGIC_WORD;
     msg.header.version = HEADER_VERSION;
 
     msg.command.inst = MCM_DESTROY_SESSION;

--- a/sdk/src/memif_impl.c
+++ b/sdk/src/memif_impl.c
@@ -20,7 +20,7 @@ void print_memif_details(memif_conn_handle_t conn)
     memif_details_t md;
     memset(&md, 0, sizeof(md));
     ssize_t buflen = 2048;
-    char* buf = (char*)malloc(buflen);
+    char *buf = (char *)malloc(buflen);
     memset(buf, 0, buflen);
     int err, e;
 
@@ -33,12 +33,12 @@ void print_memif_details(memif_conn_handle_t conn)
         }
     }
 
-    printf("\tinterface name: %s\n", (char*)md.if_name);
-    printf("\tapp name: %s\n", (char*)md.inst_name);
-    printf("\tremote interface name: %s\n", (char*)md.remote_if_name);
-    printf("\tremote app name: %s\n", (char*)md.remote_inst_name);
+    printf("\tinterface name: %s\n", (char *)md.if_name);
+    printf("\tapp name: %s\n", (char *)md.inst_name);
+    printf("\tremote interface name: %s\n", (char *)md.remote_if_name);
+    printf("\tremote app name: %s\n", (char *)md.remote_inst_name);
     printf("\tid: %u\n", md.id);
-    printf("\tsecret: %s\n", (char*)md.secret);
+    printf("\tsecret: %s\n", (char *)md.secret);
     printf("\trole: ");
     if (md.role)
         printf("slave\n");
@@ -59,7 +59,7 @@ void print_memif_details(memif_conn_handle_t conn)
         printf("unknown\n");
         break;
     }
-    printf("\tsocket path: %s\n", (char*)md.socket_path);
+    printf("\tsocket path: %s\n", (char *)md.socket_path);
     printf("\tregions num: %d\n", md.regions_num);
     for (int i = 0; i < md.regions_num; i++) {
         printf("\t\tregions idx: %d\n", md.regions[i].index);
@@ -90,10 +90,10 @@ void print_memif_details(memif_conn_handle_t conn)
 
 /* informs user about connected status. private_ctx is used by user to identify
  * connection */
-int on_connect(memif_conn_handle_t conn, void* priv_data)
+int on_connect(memif_conn_handle_t conn, void *priv_data)
 {
     int err = 0;
-    memif_conn_context* pmemif = (memif_conn_context*)priv_data;
+    memif_conn_context *pmemif = (memif_conn_context *)priv_data;
 
     err = memif_refill_queue(conn, 0, -1, 0);
     if (err != MEMIF_ERR_SUCCESS) {
@@ -111,10 +111,10 @@ int on_connect(memif_conn_handle_t conn, void* priv_data)
 
 /* informs user about disconnected status. private_ctx is used by user to
  * identify connection */
-int on_disconnect(memif_conn_handle_t conn, void* priv_data)
+int on_disconnect(memif_conn_handle_t conn, void *priv_data)
 {
     int err = 0;
-    memif_conn_context* pmemif = (memif_conn_context*)priv_data;
+    memif_conn_context *pmemif = (memif_conn_context *)priv_data;
 
     // if (pmemif->is_connected == 0)
     //     return 0;
@@ -134,7 +134,7 @@ int on_disconnect(memif_conn_handle_t conn, void* priv_data)
     return 0;
 }
 
-int tx_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int tx_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int err = 0;
     uint16_t rx_buf_num = 0;
@@ -159,21 +159,23 @@ int tx_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
     return 0;
 }
 
-int rx_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
+int rx_on_receive(memif_conn_handle_t conn, void *priv_data, uint16_t qid)
 {
     int err = 0;
     // uint16_t rx_buf_num = 0;
-    memif_conn_context* pmemif = (memif_conn_context*)priv_data;
+    memif_conn_context *pmemif = (memif_conn_context *)priv_data;
     // static int counter = 0;
     // static memif_buffer_t rx_buf = {};
 
     /* receive packets from the shared memory */
-    err = memif_rx_burst(conn, qid, pmemif->working_bufs, MEMIF_BUFFER_NUM, (uint16_t*)&pmemif->buf_num);
+    err = memif_rx_burst(conn, qid, pmemif->working_bufs, MEMIF_BUFFER_NUM,
+                         (uint16_t *)&pmemif->buf_num);
     if (err != MEMIF_ERR_SUCCESS) {
         log_error("memif_rx_burst: %s", memif_strerror(err));
         log_error("received buffer number: %d", pmemif->buf_num);
         // log_error("buffer flag: %d, len: %d, index: %d\n",
-        //     pmemif->working_bufs.flags, pmemif->working_bufs.len, pmemif->working_bufs.desc_index);
+        //     pmemif->working_bufs.flags, pmemif->working_bufs.len,
+        //     pmemif->working_bufs.desc_index);
         // pmemif->buf_num = 0;
         return err;
     }
@@ -197,11 +199,12 @@ int rx_on_receive(memif_conn_handle_t conn, void* priv_data, uint16_t qid)
     return 0;
 }
 
-mcm_conn_context* mcm_create_connection_memif(mcm_conn_param* svc_args, memif_conn_param* memif_args)
+mcm_conn_context *mcm_create_connection_memif(mcm_conn_param *svc_args,
+                                              memif_conn_param *memif_args)
 {
     int ret = 0;
-    mcm_conn_context* conn_ctx = NULL;
-    memif_conn_context* shm_conn = NULL;
+    mcm_conn_context *conn_ctx = NULL;
+    memif_conn_context *shm_conn = NULL;
     memif_socket_handle_t memif_socket;
 
     if (svc_args == NULL || memif_args == NULL) {
@@ -211,7 +214,7 @@ mcm_conn_context* mcm_create_connection_memif(mcm_conn_param* svc_args, memif_co
 
     /* unlink socket file */
     if (memif_args->conn_args.is_master && memif_args->socket_args.path[0] != '@') {
-        struct stat st = { 0 };
+        struct stat st = {0};
         if (stat("/run/mcm", &st) == -1) {
             if (mkdir("/run/mcm", 0666) == -1) {
                 perror("Fail to create directory for memif.");
@@ -239,11 +242,11 @@ mcm_conn_context* mcm_create_connection_memif(mcm_conn_param* svc_args, memif_co
 
     log_info("Create memif interface.");
     if (svc_args->type == is_tx) {
-        ret = memif_create(&shm_conn->conn, &memif_args->conn_args,
-            on_connect, on_disconnect, tx_on_receive, shm_conn);
+        ret = memif_create(&shm_conn->conn, &memif_args->conn_args, on_connect, on_disconnect,
+                           tx_on_receive, shm_conn);
     } else {
-        ret = memif_create(&shm_conn->conn, &memif_args->conn_args,
-            on_connect, on_disconnect, rx_on_receive, shm_conn);
+        ret = memif_create(&shm_conn->conn, &memif_args->conn_args, on_connect, on_disconnect,
+                           rx_on_receive, shm_conn);
     }
     if (ret != MEMIF_ERR_SUCCESS) {
         log_info("memif_create: %s", memif_strerror(ret));
@@ -283,7 +286,7 @@ mcm_conn_context* mcm_create_connection_memif(mcm_conn_param* svc_args, memif_co
 
     /* connection protocol */
     conn_ctx->proto = PROTO_MEMIF;
-    conn_ctx->priv = (void*)shm_conn;
+    conn_ctx->priv = (void *)shm_conn;
     /* video frame format */
     conn_ctx->width = svc_args->width;
     conn_ctx->height = svc_args->height;
@@ -299,26 +302,26 @@ mcm_conn_context* mcm_create_connection_memif(mcm_conn_param* svc_args, memif_co
     return conn_ctx;
 }
 
-mcm_buffer* memif_dequeue_buffer(mcm_conn_context* conn_ctx, int timeout, int* error_code)
+mcm_buffer *memif_dequeue_buffer(mcm_conn_context *conn_ctx, int timeout, int *error_code)
 {
     int err = 0;
-    memif_conn_context* memif_conn = NULL;
+    memif_conn_context *memif_conn = NULL;
     memif_buffer_t memif_buf = {};
     uint16_t buf_num = 0;
-    mcm_buffer* buf = NULL;
+    mcm_buffer *buf = NULL;
 
     if (!conn_ctx || !conn_ctx->priv) {
         log_error("Illegal Parameter.");
         return NULL;
     }
-    memif_conn = (memif_conn_context*)conn_ctx->priv;
+    memif_conn = (memif_conn_context *)conn_ctx->priv;
 
     while (memif_conn->is_connected == 0) {
         log_error("Data connection stopped.");
         return NULL;
     }
 
-    if (conn_ctx->type == is_tx) {  /* TX */
+    if (conn_ctx->type == is_tx) { /* TX */
         /* trigger the callbacks. */
         err = memif_poll_event(memif_conn->sockfd, 0);
         if (err != MEMIF_ERR_SUCCESS) {
@@ -328,8 +331,8 @@ mcm_buffer* memif_dequeue_buffer(mcm_conn_context* conn_ctx, int timeout, int* e
 
         do {
             const size_t sleep_interval = 10; /* 0.01 s */
-            err = memif_buffer_alloc(memif_conn->conn, memif_conn->qid, &memif_buf, 1,
-                &buf_num, conn_ctx->frame_size);
+            err = memif_buffer_alloc(memif_conn->conn, memif_conn->qid, &memif_buf, 1, &buf_num,
+                                     conn_ctx->frame_size);
             if (err == MEMIF_ERR_SUCCESS) {
                 break;
             } else {
@@ -370,7 +373,7 @@ mcm_buffer* memif_dequeue_buffer(mcm_conn_context* conn_ctx, int timeout, int* e
                 *error_code = err;
             }
         }
-    } else {    /* RX */
+    } else { /* RX */
         /* waiting for the buffer ready from rx_on_receive callback. */
         if (memif_conn->buf_num <= 0) {
             err = memif_poll_event(memif_conn->sockfd, timeout);
@@ -398,10 +401,10 @@ mcm_buffer* memif_dequeue_buffer(mcm_conn_context* conn_ctx, int timeout, int* e
     return buf;
 }
 
-int memif_enqueue_buffer(mcm_conn_context* conn_ctx, mcm_buffer* buf)
+int memif_enqueue_buffer(mcm_conn_context *conn_ctx, mcm_buffer *buf)
 {
     int err = 0;
-    memif_conn_context* memif_conn = NULL;
+    memif_conn_context *memif_conn = NULL;
     uint16_t buf_num = 0;
     // static size_t frame_count = 0;
 
@@ -410,7 +413,7 @@ int memif_enqueue_buffer(mcm_conn_context* conn_ctx, mcm_buffer* buf)
         return -1;
     }
 
-    memif_conn = (memif_conn_context*)conn_ctx->priv;
+    memif_conn = (memif_conn_context *)conn_ctx->priv;
 
     if (memif_conn->is_connected == 0) {
         log_error("Data connection stopped.");
@@ -427,7 +430,8 @@ int memif_enqueue_buffer(mcm_conn_context* conn_ctx, mcm_buffer* buf)
         if (buf->len < memif_conn->working_bufs[0].len)
             memif_conn->working_bufs[0].len = buf->len;
 
-        err = memif_tx_burst(memif_conn->conn, memif_conn->qid, &memif_conn->working_bufs[0], 1, &buf_num);
+        err = memif_tx_burst(memif_conn->conn, memif_conn->qid, &memif_conn->working_bufs[0], 1,
+                             &buf_num);
         if (err != MEMIF_ERR_SUCCESS) {
             log_error("memif_tx_burst: %s", memif_strerror(err));
         }
@@ -447,7 +451,7 @@ int memif_enqueue_buffer(mcm_conn_context* conn_ctx, mcm_buffer* buf)
     return err;
 }
 
-void mcm_destroy_connection_memif(memif_conn_context* pctx)
+void mcm_destroy_connection_memif(memif_conn_context *pctx)
 {
     if (!pctx) {
         log_error("Illegal Parameter.");

--- a/sdk/src/udp_impl.c
+++ b/sdk/src/udp_impl.c
@@ -13,9 +13,9 @@
 #include "udp_impl.h"
 #include "logger.h"
 
-udp_context* mcm_create_connection_udp(mcm_conn_param* param)
+udp_context *mcm_create_connection_udp(mcm_conn_param *param)
 {
-    udp_context* udp_ctx = NULL;
+    udp_context *udp_ctx = NULL;
     struct sockaddr_in tx_addr = {}, rx_addr = {};
     int sockfd = 0;
 
@@ -32,7 +32,7 @@ udp_context* mcm_create_connection_udp(mcm_conn_param* param)
         rx_addr.sin_port = htons(atoi(param->local_addr.port));
 
         /* Bind socket with RX address. */
-        if (bind(sockfd, (const struct sockaddr*)&rx_addr, sizeof(rx_addr)) < 0) {
+        if (bind(sockfd, (const struct sockaddr *)&rx_addr, sizeof(rx_addr)) < 0) {
             log_error("Fail to bind socket for RX.");
             close(sockfd);
             return NULL;
@@ -64,7 +64,7 @@ udp_context* mcm_create_connection_udp(mcm_conn_param* param)
     return udp_ctx;
 }
 
-void mcm_destroy_connection_udp(udp_context* pctx)
+void mcm_destroy_connection_udp(udp_context *pctx)
 {
     if (pctx == NULL) {
         return;
@@ -76,9 +76,9 @@ void mcm_destroy_connection_udp(udp_context* pctx)
     return;
 }
 
-mcm_buffer* mcm_alloc_buffer_udp(void* conn_ctx, size_t len)
+mcm_buffer *mcm_alloc_buffer_udp(void *conn_ctx, size_t len)
 {
-    mcm_buffer* pbuf = NULL;
+    mcm_buffer *pbuf = NULL;
 
     pbuf = calloc(1, sizeof(mcm_buffer));
     if (pbuf == NULL) {
@@ -95,9 +95,9 @@ mcm_buffer* mcm_alloc_buffer_udp(void* conn_ctx, size_t len)
     return pbuf;
 }
 
-void mcm_free_buffer_udp(void* conn_ctx, mcm_buffer** buf)
+void mcm_free_buffer_udp(void *conn_ctx, mcm_buffer **buf)
 {
-    mcm_buffer* pbuf = NULL;
+    mcm_buffer *pbuf = NULL;
 
     if (buf == NULL || *buf == NULL) {
         return;
@@ -112,11 +112,11 @@ void mcm_free_buffer_udp(void* conn_ctx, mcm_buffer** buf)
     return;
 }
 
-int mcm_send_buffer_udp(void* conn_ctx, mcm_buffer* buf)
+int mcm_send_buffer_udp(void *conn_ctx, mcm_buffer *buf)
 {
     int ret = 0;
-    udp_context* ctx = NULL;
-    char* data = NULL; // Changed to char* for pointer arithmetic
+    udp_context *ctx = NULL;
+    char *data = NULL; // Changed to char* for pointer arithmetic
     ssize_t n = 0;
     size_t len = 0;
 
@@ -125,7 +125,7 @@ int mcm_send_buffer_udp(void* conn_ctx, mcm_buffer* buf)
         return -1;
     }
 
-    ctx = (udp_context*)conn_ctx;
+    ctx = (udp_context *)conn_ctx;
 
     data = buf->data;
     len = (size_t)buf->len;
@@ -136,7 +136,7 @@ int mcm_send_buffer_udp(void* conn_ctx, mcm_buffer* buf)
     while (len > 0) {
         size_t send_length = len > SIZE_MAX ? SIZE_MAX : len;
         n = sendto(ctx->sockfd, data, send_length, MSG_CONFIRM,
-            (const struct sockaddr*)&ctx->rx_addr, sizeof(ctx->rx_addr));
+                   (const struct sockaddr *)&ctx->rx_addr, sizeof(ctx->rx_addr));
         if (n < 0 || len < (size_t)n) {
             log_error("Fail to send out data.");
             ret = -1;
@@ -148,10 +148,10 @@ int mcm_send_buffer_udp(void* conn_ctx, mcm_buffer* buf)
     return ret;
 }
 
-int mcm_recv_buffer_udp(void* conn_ctx, mcm_buffer* buf)
+int mcm_recv_buffer_udp(void *conn_ctx, mcm_buffer *buf)
 {
     int ret = 0;
-    udp_context* ctx = NULL;
+    udp_context *ctx = NULL;
     socklen_t addrlen = 0;
 
     if (conn_ctx == NULL || buf == NULL) {
@@ -159,12 +159,12 @@ int mcm_recv_buffer_udp(void* conn_ctx, mcm_buffer* buf)
         return -1;
     }
 
-    ctx = (udp_context*)conn_ctx;
+    ctx = (udp_context *)conn_ctx;
 
     addrlen = sizeof(ctx->tx_addr);
 
-    ret = recvfrom(ctx->sockfd, buf->data, buf->len, MSG_WAITALL,
-        (struct sockaddr*)&ctx->tx_addr, &addrlen);
+    ret = recvfrom(ctx->sockfd, buf->data, buf->len, MSG_WAITALL, (struct sockaddr *)&ctx->tx_addr,
+                   &addrlen);
     if (ret == -1) {
         log_error("Fail to send out data.");
     }

--- a/sdk/tests/test_log.c
+++ b/sdk/tests/test_log.c
@@ -9,7 +9,7 @@
 
 #include "logger.h"
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     log_info("Normal information.");
     log_warn("Warning.");

--- a/tests/unit/proxy_context_tests.cc
+++ b/tests/unit/proxy_context_tests.cc
@@ -2,7 +2,8 @@
 #include "proxy_context.h"
 
 // TODO: Create real tests
-TEST(ProxyContextTests, ProxyContextConstructor) {
+TEST(ProxyContextTests, ProxyContextConstructor)
+{
     ProxyContext ctx;
     EXPECT_EQ(ctx.getTCPListenPort(), 8002);
     EXPECT_EQ(ctx.getRPCListenAddress(), "0.0.0.0:8001");


### PR DESCRIPTION
Use clang-format to format whole project to a style similar to linux kernel code style.

For now I used: 
```
IncludeBlocks: Preserve
SortIncludes: false
```
because reordering includes brakes the build process.

