### PR TITLE
Test scripting improvements and af_xdp fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,7 @@ media-proxy/protos/controller.pb.cc
 media-proxy/protos/controller.pb.h
 
 # for VS Code settings
-.vscode/c_cpp_properties.json
-.vscode/settings.json
+.vscode/*
 
 # For FFmpeg plugin
 ffmpeg-plugin/FFmpeg/
@@ -30,3 +29,5 @@ docs/_build
 media-proxy/tests/test.yuv
 media-proxy/tests/memif_test_rx
 media-proxy/tests/memif_test_tx
+tests/single-node-sample-apps/error_*
+tests/single-node-sample-apps/out

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,8 +61,8 @@ Detailed information about MCM SDK can be found in [sdk](sdk) directory.
 
 1. **Install Dependencies**, choose between options `a)` or `b)`.
 
-    a) The `build_dep.sh` script can be used for all-in-one environment preparation. The script is designed for Debian and was tested under `Ubuntu 20.04`, `Ubuntu 22.04` and `Ubuntu 24.04` environments.
-   To use this option just run the script after cloning the repository by typing `build_dep.sh`
+    a) The `./scripts/setup_build_env.sh` script can be used for all-in-one environment preparation. The script is designed for Debian and was tested under `Ubuntu 20.04`, `Ubuntu 22.04` and `Ubuntu 24.04` environments.
+   To use this option just run the script after cloning the repository by typing `./scripts/setup_build_env.sh`
 
     b) The following method is universal and should work for most Linux OS distributions.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ Detailed information about MCM SDK can be found in [sdk](sdk) directory.
 
 1. **Install Dependencies**, choose between options `a)` or `b)`.
 
-    a) The `./scripts/setup_build_env.sh` script can be used for all-in-one environment preparation. The script is designed for Debian and was tested under `Ubuntu 20.04`, `Ubuntu 22.04` and `Ubuntu 24.04` environments.
+    a) The `setup_build_env.sh` script located in the `scripts` folder can be used for all-in-one environment preparation. The script is designed for Debian and was tested under `Ubuntu 20.04`, `Ubuntu 22.04` and `Ubuntu 24.04` environments.
    To use this option just run the script after cloning the repository by typing `./scripts/setup_build_env.sh`
 
     b) The following method is universal and should work for most Linux OS distributions.

--- a/scripts/setup_build_env.sh
+++ b/scripts/setup_build_env.sh
@@ -3,10 +3,11 @@
 set -eo pipefail
 
 SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
-REPO_DIR="${SCRIPT_DIR:-$(pwd)}"
+REPO_DIR="$(readlink -f "../${SCRIPT_DIR}")"
 
 . "${REPO_DIR}/common.sh"
 
+NPROC="$(nproc)"
 export MCM_DIR="${REPO_DIR}/build/mcm"
 export MTL_VER="d2515b90cc0ef651f6d0a6661d5a644490bfc3f3"
 export MTL_DIR="${REPO_DIR}/build/mtl"
@@ -120,7 +121,7 @@ popd
 pushd "${LIBFABRIC_DIR}"
 ./autogen.sh && \
 ./configure && \
-make -j$(nproc) && \
+make -j "${NPROC}" && \
 make install && \
 popd
 
@@ -143,10 +144,10 @@ popd
 mkdir -p "${GRPC_DIR}/cmake/build"
 pushd "${GRPC_DIR}/cmake/build"
 cmake -DgRPC_BUILD_TESTS=OFF -DgRPC_INSTALL=ON ../.. && \
-make -j $(nproc) && \
+make -j "${NPROC}" && \
 make install && \
 cmake -DgRPC_BUILD_TESTS=ON -DgRPC_INSTALL=ON ../.. && \
-make -j $(nproc) grpc_cli && \
+make -j "${NPROC}" grpc_cli && \
 cp grpc_cli "/usr/local/bin/"
 popd
 

--- a/tests/single-node-sample-apps/test-rdma.sh
+++ b/tests/single-node-sample-apps/test-rdma.sh
@@ -146,14 +146,14 @@ function run_test_rdma() {
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -t 8002"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
-    tx_media_proxy_pid=$!
+    tx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -t 8003"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
-    rx_media_proxy_pid=$!
+    rx_media_proxy_pid="$!"
 
     sleep 1
 
@@ -161,34 +161,34 @@ function run_test_rdma() {
     export MCM_MEDIA_PROXY_PORT=8003
     local recver_app_cmd="recver_app -r $rdma_iface_ip -t rdma -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
-    recver_app_pid=$!
+    recver_app_pid="$!"
 
 
     info "Starting sender_app"
     export MCM_MEDIA_PROXY_PORT=8002
     local sender_app_cmd="sender_app -s $rdma_iface_ip -t rdma -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
-    sender_app_pid=$!
+    sender_app_pid="$!"
 
     info "Waiting for recver_app to connect to Rx media_proxy"
     wait_text 10 $recver_app_out "Success connect to MCM media-proxy"
-    local recver_app_timeout=$?
+    local recver_app_timeout="$?"
     [ $recver_app_timeout -eq 0 ] && info "Connection established"
 
     info "Waiting for sender_app to connect to Tx media_proxy"
     wait_text 10 $sender_app_out "Success connect to MCM media-proxy"
-    local sender_app_timeout=$?
+    local sender_app_timeout="$?"
     [ $sender_app_timeout -eq 0 ] && info "Connection established"
 
     wait_completion "$wait_interval"
-    local timeout=$?
+    local timeout="$?"
 
     sleep 1
 
     shutdown_apps
 
     check_results
-    local error=$?
+    local error="$?"
 
     info "Tx media_proxy stats"
     local regex="throughput ([0-9]*\.[0-9]*) Mb/s: [0-9]*\.[0-9]* Mb/s, cpu busy ([0-9]*\.[0-9]*)"

--- a/tests/single-node-sample-apps/test.sh
+++ b/tests/single-node-sample-apps/test.sh
@@ -10,6 +10,12 @@ script_dir="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
 bin_dir="$(readlink -f "${script_dir}/../../out/bin")"
 out_dir="$(readlink -f "${script_dir}/out")"
 
+# Colors enablement
+highlight_msg_on="\e[38;05;33m"
+highlight_info_on='\e[38;05;45m'
+highlight_err_on='\e[38;05;9m'
+highlight_off="\e[m"
+
 # Test configuration
 test_option="$1"
 nic_pf="$2"
@@ -17,7 +23,7 @@ tx_vf_number=0
 rx_vf_number=1
 
 # Media file names
-input_file="$(realpath $3)"
+input_file="$(realpath "${3}")"
 output_file="${out_dir}/out_rx.bin"
 
 # Video parameters
@@ -42,27 +48,24 @@ recver_app_out="${out_dir}/out_recver_app.txt"
 repeat_number=3
 
 function message() {
+    local timestamp
     local type="$1"
     shift
-    local highlight_on="\e[38;05;33m"
-    local highlight_off="\e[m"
-    local timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
-    echo -e "${highlight_on}$timestamp $type${highlight_off} $*"
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+    echo -e "${highlight_msg_on}${timestamp} $type${highlight_off} $*"
 }
 
 function info() {
-    local highlight_on='\e[38;05;45m';
-    message "${highlight_on}[INFO]" "$*"
+    message "${highlight_info_on}[INFO]" "$*"
 }
 
 function error() {
-    local highlight_on='\e[38;05;9m';
-    message "${highlight_on}[ERRO]" "$*"
+    message "${highlight_err_on}[ERRO]" "$*"
 }
 
 function cleanup() {
-    local buckup_after_error="${1:-0}"
-    if [ "${buckup_after_error}" == "0" ]; then
+    local backup_after_error="${1:-0}"
+    if [ "${backup_after_error}" == "0" ]; then
         info "Cleanup"
         rm -rf "$out_dir" &>/dev/null
     else
@@ -76,9 +79,9 @@ function run_in_background() {
     # 1st argument is a command with arguments to be run in background
     # 2nd argument is a file for stdout/stderr to be redirected to
     # Returns PID of a spawned process
-    info "run: ${1}"
+    info "Run: ${1}"
     echo -e "${1}\n" > "${2}"
-    stdbuf -o0 -e0 $1 &>>"${2}" &
+    stdbuf -o0 -e0 "${1}" &>>"${2}" &
 }
 
 function wait_text() {
@@ -146,10 +149,12 @@ function check_results() {
 }
 
 function get_vf_bdf() {
+    local params
+    local regex
     local pf="$1"
     local vf="$2"
-    local params=$(cat "/sys/bus/pci/devices/$pf/virtfn$vf/uevent")
-    local regex="PCI_SLOT_NAME=([0-9a-f]{4}:[0-9a-f]{2,4}:[0-9a-f]{2}\.[0-9a-f])"
+    params="$(cat "/sys/bus/pci/devices/$pf/virtfn$vf/uevent")"
+    regex="PCI_SLOT_NAME=([0-9a-f]{4}:[0-9a-f]{2,4}:[0-9a-f]{2}\.[0-9a-f])"
     [[ ! $params =~ $regex ]] && error "Cannot get VF $vf bus device function" && return 1
     echo "${BASH_REMATCH[1]}"
     return 0
@@ -159,16 +164,17 @@ function initialize_nic() {
     local pf="$1"
     local tx_vf="$2"
     local rx_vf="$3"
+    local description
 
-    info "Checking PF $pf status"
+    info "Checking PF ${pf} status"
 
     # Check if PF exists
-    lspci -D | grep $pf &>/dev/null
+    lspci -D | grep "${pf}" &>/dev/null
     [ $? -ne 0 ] && error "PF not found" && return 1
 
     # Get network interface name of PF
-    local description="$(lshw -c network -businfo -quiet | grep "$pf")"
-    local regex="pci@$pf[[:space:]]+([a-zA-Z0-9\-]+)"
+    description="$(lshw -c network -businfo -quiet | grep "$pf")"
+    local regex="pci@${pf}[[:space:]]+([a-zA-Z0-9\-]+)"
     [[ ! $description =~ $regex ]] && error "Cannot get network interface name" && return 1
 
     # Check if network interface is up
@@ -233,14 +239,14 @@ function run_test_memif() {
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -d $tx_vf_bdf -i 192.168.96.1 -t 8002"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
-    tx_media_proxy_pid=$!
+    tx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d $rx_vf_bdf -i 192.168.96.2 -t 8003"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
-    rx_media_proxy_pid=$!
+    rx_media_proxy_pid="$!"
 
     sleep 1
 
@@ -248,7 +254,7 @@ function run_test_memif() {
     export MCM_MEDIA_PROXY_PORT=8002
     local sender_app_cmd="sender_app -s 192.168.96.2 -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o memif"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
-    sender_app_pid=$!
+    sender_app_pid="$!"
 
     sleep 1
 
@@ -256,10 +262,10 @@ function run_test_memif() {
     export MCM_MEDIA_PROXY_PORT=8003
     local recver_app_cmd="recver_app -r 192.168.96.1 -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o memif"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
-    recver_app_pid=$!
+    recver_app_pid="$!"
 
     wait_completion "$wait_interval"
-    local timeout=$?
+    local timeout="$?"
 
     sleep 1
 
@@ -268,7 +274,7 @@ function run_test_memif() {
     sleep 1
 
     check_results
-    local error=$?
+    local error="$?"
 
     info "Cleanup"
     cleanup "${error}"
@@ -289,14 +295,14 @@ function run_test_stXX() {
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -d $tx_vf_bdf -i 192.168.96.1 -t 8002"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
-    tx_media_proxy_pid=$!
+    tx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d $rx_vf_bdf -i 192.168.96.2 -t 8003"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
-    rx_media_proxy_pid=$!
+    rx_media_proxy_pid="$!"
 
     sleep 1
 
@@ -304,33 +310,33 @@ function run_test_stXX() {
     export MCM_MEDIA_PROXY_PORT=8003
     local recver_app_cmd="recver_app -r 192.168.96.1 -t $1 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
-    recver_app_pid=$!
+    recver_app_pid="$!"
 
     info "Waiting for recver_app to connect to Rx media_proxy"
     wait_text 50 $recver_app_out "Success connect to MCM media-proxy"
-    local recver_app_timeout=$?
+    local recver_app_timeout="$?"
     [ $recver_app_timeout -eq 0 ] && info "Connection established"
 
     info "Starting sender_app"
     export MCM_MEDIA_PROXY_PORT=8002
     local sender_app_cmd="sender_app -s 192.168.96.2 -t $1 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
-    sender_app_pid=$!
+    sender_app_pid="$!"
 
     info "Waiting for sender_app to connect to Tx media_proxy"
     wait_text 100 $sender_app_out "Success connect to MCM media-proxy"
-    local sender_app_timeout=$?
+    local sender_app_timeout="$?"
     [ $sender_app_timeout -eq 0 ] && info "Connection established"
 
     wait_completion "$wait_interval"
-    local timeout=$?
+    local timeout="$?"
 
     sleep 1
 
     shutdown_apps
 
     check_results
-    local error=$?
+    local error="$?"
 
     info "Tx media_proxy stats"
     local regex="throughput ([0-9]*\.[0-9]*) Mb/s: [0-9]*\.[0-9]* Mb/s, cpu busy ([0-9]*\.[0-9]*)"
@@ -349,16 +355,16 @@ function run_test_stXX() {
     done < "$rx_media_proxy_out"
 
     info "Cleanup"
-    cleanup $error
+    cleanup "${error}"
 
-    return $(($error || $timeout || $recver_app_timeout || $sender_app_timeout))
+    return $((error || timeout || recver_app_timeout || sender_app_timeout))
 }
 
 info "Test MCM Tx/Rx for Single Node"
-info "  Binary directory: $(realpath $bin_dir)"
-info "  Output directory: $(realpath $out_dir)"
+info "  Binary directory: $(realpath "${bin_dir}")"
+info "  Output directory: $(realpath "${out_dir}")"
 info "  Input file path: $input_file"
-info "  Input file size: $(stat -c%s $input_file) byte(s)"
+info "  Input file size: $(stat -c%s "${input_file}") byte(s)"
 info "  Frame size: $width x $height, FPS: $fps"
 info "  Pixel format: $pixel_format"
 info "  Duration: ${duration}s"

--- a/tests/single-node-sample-apps/test.sh
+++ b/tests/single-node-sample-apps/test.sh
@@ -7,8 +7,8 @@
 script_dir="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
 . "${script_dir}/test_memif.sh"
 . "${script_dir}/test_af_xdp.sh"
-bin_dir="$script_dir/../../out/bin"
-out_dir="$script_dir/out"
+bin_dir="$(readlink -f "${script_dir}/../../out/bin")"
+out_dir="$(readlink -f "${script_dir}/out")"
 
 # Test configuration
 test_option="$1"
@@ -18,7 +18,7 @@ rx_vf_number=1
 
 # Media file names
 input_file="$(realpath $3)"
-output_file="$out_dir/out_rx.bin"
+output_file="${out_dir}/out_rx.bin"
 
 # Video parameters
 duration="${4:-10}"
@@ -32,11 +32,11 @@ pixel_format="${9:-yuv422p10le}"
 wait_interval=$((duration + 5))
 
 # Stdout/stderr forwarded output file names
-mtl_manager_out="$out_dir/out_mtl_manager.txt"
-tx_media_proxy_out="$out_dir/out_tx_media_proxy.txt"
-rx_media_proxy_out="$out_dir/out_rx_media_proxy.txt"
-sender_app_out="$out_dir/out_sender_app.txt"
-recver_app_out="$out_dir/out_recver_app.txt"
+mtl_manager_out="${out_dir}/out_mtl_manager.txt"
+tx_media_proxy_out="${out_dir}/out_tx_media_proxy.txt"
+rx_media_proxy_out="${out_dir}/out_rx_media_proxy.txt"
+sender_app_out="${out_dir}/out_sender_app.txt"
+recver_app_out="${out_dir}/out_recver_app.txt"
 
 # Number of test repetitions
 repeat_number=3
@@ -61,14 +61,24 @@ function error() {
 }
 
 function cleanup() {
-    rm -rf "$out_dir" &>/dev/null
+    local buckup_after_error="${1:-0}"
+    if [ "${buckup_after_error}" == "0" ]; then
+        info "Cleanup"
+        rm -rf "$out_dir" &>/dev/null
+    else
+        error_our_dir="$script_dir/error_$(date +%F-%H_%M_%S)"
+        info "Cleanup. Output saved to $error_our_dir"
+        mv "$out_dir" "$error_our_dir" &>/dev/null
+    fi
 }
 
 function run_in_background() {
     # 1st argument is a command with arguments to be run in background
     # 2nd argument is a file for stdout/stderr to be redirected to
     # Returns PID of a spawned process
-    stdbuf -o0 -e0 $1 &>"$2" &
+    info "run: ${1}"
+    echo -e "${1}\n" > "${2}"
+    stdbuf -o0 -e0 $1 &>>"${2}" &
 }
 
 function wait_text() {
@@ -85,7 +95,7 @@ function wait_completion() {
     info "Waiting for transmission to complete (interval ${1}s)"
     timeout $1 tail --pid=$sender_app_pid --pid=$recver_app_pid -f /dev/null
     [ $? -eq 124 ] && error "timeout occurred" && return 1
-    info "Transmission completed" 
+    info "Transmission completed"
     return 0
 }
 
@@ -261,7 +271,7 @@ function run_test_memif() {
     local error=$?
 
     info "Cleanup"
-    cleanup
+    cleanup "${error}"
 
     return $(($error || $timeout))
 }
@@ -339,7 +349,7 @@ function run_test_stXX() {
     done < "$rx_media_proxy_out"
 
     info "Cleanup"
-    cleanup
+    cleanup $error
 
     return $(($error || $timeout || $recver_app_timeout || $sender_app_timeout))
 }
@@ -375,26 +385,28 @@ do
 
     case $test_option in
         af_xdp)
-            run_test_af_xdp_rx
-            run_test_af_xdp_tx
+            run_test_af_xdp
+            error="$?"
             ;;
         memif)
-            run_test_memif
-            run_test_memif_tx
+            run_test_memif && \
+            run_test_memif_tx && \
             run_test_memif_rx
+            error="$?"
             ;;
         st20)
             run_test_stXX st20
+            error="$?"
             ;;
         st22)
             run_test_stXX st22
+            error="$?"
             ;;
         *)
             error "Unknown test option"
             exit 1
     esac
-
-    [ $? -ne 0 ] && error "Test failed" && exit 1
+    [ "${error}" -ne 0 ] && error "Test failed" && exit 1
 done
 
 deinitialize_nic "$nic_pf"

--- a/tests/single-node-sample-apps/test_af_xdp.sh
+++ b/tests/single-node-sample-apps/test_af_xdp.sh
@@ -3,19 +3,52 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2024 Intel Corporation
 
-function run_test_af_xdp_rx()
+function get_next_free_ip()
+{
+    ip_last_octet="$(echo $1 | cut -d'.' -f4)"
+    iface_old_ip="$1"
+    while [ ! -z "$iface_old_ip" ]; do
+        ip_last_octet="$((ip_last_octet+1))"
+        iface_new_ip="$(echo $1 | cut -d'.' -f1-3).$ip_last_octet"
+        iface_old_ip=$(ip -json a | jq ".[].addr_info[] | select(.family==\"inet\") | select(.local==\"$iface_new_ip\").local")
+    done
+    echo "${iface_new_ip}"
+}
+
+function run_test_af_xdp()
 {
     iface_name="$($nicctl list all | grep $nic_pf | cut -f6)"
-    iface_ip="$(ip -json a show $iface_name | jq '.[0].addr_info[0].local' -r)"
-    ip_last_octet="$(echo $iface_ip | cut -d'.' -f4)"
-    iface_new_ip="$(echo $iface_ip | cut -d'.' -f1-3).$((ip_last_octet+1))"
+    iface_ip="$(ip -json a show $iface_name | jq '.[0].addr_info[] | select(.family=="inet").local' -r)"
+    if [ -z $iface_ip ]; then
+        iface_ip="$(get_next_free_ip "192.168.96.0")"
+        iface_new_ip="$(get_next_free_ip "${iface_ip}")"
+        ip address add "${iface_ip}/22" dev "${iface_name}" &>/dev/null
+        ip_created="${iface_ip}"
+    else
+        ip_last_octet="$(echo $iface_ip | cut -d'.' -f4)"
+        iface_new_ip="$(echo $iface_ip | cut -d'.' -f1-3).$((ip_last_octet+1))"
+        ip_created=""
+    fi
 
+    run_test_af_xdp_rx &&
+    run_test_af_xdp_tx
+    local error=$?
+
+    if [ ! -z "${ip_created}" ]; then
+        ip address del "${ip_created}/22" dev "${iface_name}" &>/dev/null
+    fi
+    return $error
+}
+
+function run_test_af_xdp_rx()
+{
     mkdir -p "$out_dir"
 
     info "Connection type: af_xdp af_xdp_rx"
     info "iface_name: $iface_name"
     info "iface_ip: $iface_ip"
     info "iface_new_ip: $iface_new_ip"
+    info "ip_created: $ip_created"
 
     info "Starting MtlManager"
     local mtl_manager_cmd="MtlManager"
@@ -26,7 +59,6 @@ function run_test_af_xdp_rx()
 
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -d $tx_vf_bdf -i $iface_new_ip -t 8002"
-    info "tx_media_proxy_cmd=$tx_media_proxy_cmd"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
     tx_media_proxy_pid=$!
 
@@ -34,25 +66,22 @@ function run_test_af_xdp_rx()
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d native_af_xdp:$iface_name -i $iface_ip -t 8003"
-    info "rx_media_proxy_cmd=$rx_media_proxy_cmd"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
     rx_media_proxy_pid=$!
 
     sleep 1
 
     info "Starting recver_app"
-    export MCM_MEDIA_PROXY_PORT=8003
-    local recver_app_cmd="recver_app -r $iface_new_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
-    info "recver_app_cmd=$recver_app_cmd"
+    export MCM_MEDIA_PROXY_PORT=8002
+    local recver_app_cmd="recver_app -r $iface_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
     recver_app_pid=$!
 
     sleep 1
 
     info "Starting sender_app"
-    export MCM_MEDIA_PROXY_PORT=8002
-    local sender_app_cmd="sender_app -s $iface_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
-    info "sender_app_cmd=$sender_app_cmd"
+    export MCM_MEDIA_PROXY_PORT=8003
+    local sender_app_cmd="sender_app -s $iface_new_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
     sender_app_pid=$!
 
@@ -70,18 +99,13 @@ function run_test_af_xdp_rx()
     local error=$?
 
     info "Cleanup"
-    cleanup
+    cleanup $error
 
     return $(($error || $timeout))
 }
 
 function run_test_af_xdp_tx()
 {
-    iface_name="$($nicctl list all | grep $nic_pf | cut -f6)"
-    iface_ip="$(ip -json a show $iface_name | jq '.[0].addr_info[0].local' -r)"
-    ip_last_octet="$(echo $iface_ip | cut -d'.' -f4)"
-    iface_new_ip="$(echo $iface_ip | cut -d'.' -f1-3).$((ip_last_octet+1))"
-
     mkdir -p "$out_dir"
 
     info "Connection type: af_xdp af_xdp_tx"
@@ -98,7 +122,6 @@ function run_test_af_xdp_tx()
 
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -d native_af_xdp:$iface_name -i $iface_ip -t 8002"
-    info "tx_media_proxy_cmd=$tx_media_proxy_cmd"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
     tx_media_proxy_pid=$!
 
@@ -106,7 +129,6 @@ function run_test_af_xdp_tx()
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d $rx_vf_bdf -i $iface_new_ip -t 8003"
-    info "rx_media_proxy_cmd=$rx_media_proxy_cmd"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
     rx_media_proxy_pid=$!
 
@@ -115,7 +137,6 @@ function run_test_af_xdp_tx()
     info "Starting recver_app"
     export MCM_MEDIA_PROXY_PORT=8003
     local recver_app_cmd="recver_app -r $iface_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
-    info "recver_app_cmd=$recver_app_cmd"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
     recver_app_pid=$!
 
@@ -124,7 +145,6 @@ function run_test_af_xdp_tx()
     info "Starting sender_app"
     export MCM_MEDIA_PROXY_PORT=8002
     local sender_app_cmd="sender_app -s $iface_new_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
-    info "sender_app_cmd=$sender_app_cmd"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
     sender_app_pid=$!
 
@@ -142,7 +162,7 @@ function run_test_af_xdp_tx()
     local error=$?
 
     info "Cleanup"
-    cleanup
+    cleanup $error
 
     return $(($error || $timeout))
 }

--- a/tests/single-node-sample-apps/test_af_xdp.sh
+++ b/tests/single-node-sample-apps/test_af_xdp.sh
@@ -32,7 +32,7 @@ function run_test_af_xdp()
 
     run_test_af_xdp_rx &&
     run_test_af_xdp_tx
-    local error=$?
+    local error="$?"
 
     if [ ! -z "${ip_created}" ]; then
         ip address del "${ip_created}/22" dev "${iface_name}" &>/dev/null
@@ -53,21 +53,21 @@ function run_test_af_xdp_rx()
     info "Starting MtlManager"
     local mtl_manager_cmd="MtlManager"
     run_in_background "$mtl_manager_cmd" "$mtl_manager_out"
-    mtl_manager_pid=$!
+    mtl_manager_pid="$!"
 
     sleep 1
 
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -d $tx_vf_bdf -i $iface_new_ip -t 8002"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
-    tx_media_proxy_pid=$!
+    tx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d native_af_xdp:$iface_name -i $iface_ip -t 8003"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
-    rx_media_proxy_pid=$!
+    rx_media_proxy_pid="$!"
 
     sleep 1
 
@@ -75,7 +75,7 @@ function run_test_af_xdp_rx()
     export MCM_MEDIA_PROXY_PORT=8002
     local recver_app_cmd="recver_app -r $iface_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
-    recver_app_pid=$!
+    recver_app_pid="$!"
 
     sleep 1
 
@@ -83,10 +83,10 @@ function run_test_af_xdp_rx()
     export MCM_MEDIA_PROXY_PORT=8003
     local sender_app_cmd="sender_app -s $iface_new_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
-    sender_app_pid=$!
+    sender_app_pid="$!"
 
     wait_completion "$wait_interval"
-    local timeout=$?
+    local timeout="$?"
 
     sleep 1
 
@@ -96,12 +96,12 @@ function run_test_af_xdp_rx()
     sleep 1
 
     check_results
-    local error=$?
+    local error="$?"
 
     info "Cleanup"
-    cleanup $error
+    cleanup "${error}"
 
-    return $(($error || $timeout))
+    return $((error || timeout))
 }
 
 function run_test_af_xdp_tx()
@@ -116,21 +116,21 @@ function run_test_af_xdp_tx()
     info "Starting MtlManager"
     local mtl_manager_cmd="MtlManager"
     run_in_background "$mtl_manager_cmd" "$mtl_manager_out"
-    mtl_manager_pid=$!
+    mtl_manager_pid="$!"
 
     sleep 1
 
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -d native_af_xdp:$iface_name -i $iface_ip -t 8002"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
-    tx_media_proxy_pid=$!
+    tx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d $rx_vf_bdf -i $iface_new_ip -t 8003"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
-    rx_media_proxy_pid=$!
+    rx_media_proxy_pid="$!"
 
     sleep 1
 
@@ -138,7 +138,7 @@ function run_test_af_xdp_tx()
     export MCM_MEDIA_PROXY_PORT=8003
     local recver_app_cmd="recver_app -r $iface_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o auto"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
-    recver_app_pid=$!
+    recver_app_pid="$!"
 
     sleep 1
 
@@ -146,10 +146,10 @@ function run_test_af_xdp_tx()
     export MCM_MEDIA_PROXY_PORT=8002
     local sender_app_cmd="sender_app -s $iface_new_ip -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o auto"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
-    sender_app_pid=$!
+    sender_app_pid="$!"
 
     wait_completion "$wait_interval"
-    local timeout=$?
+    local timeout="$?"
 
     sleep 1
 
@@ -159,10 +159,10 @@ function run_test_af_xdp_tx()
     sleep 1
 
     check_results
-    local error=$?
+    local error="$?"
 
     info "Cleanup"
-    cleanup $error
+    cleanup "${error}"
 
-    return $(($error || $timeout))
+    return $((error || timeout))
 }

--- a/tests/single-node-sample-apps/test_memif.sh
+++ b/tests/single-node-sample-apps/test_memif.sh
@@ -10,40 +10,40 @@ function run_test_memif_rx() {
 
     # Notice: sender_app should be started before recver_app. Currently, this is
     # the only successful scenario.
-    mkdir -p "$out_dir"
+    mkdir -p "${out_dir}"
     export socket_path="/run/mcm/mcm_rx_memif.sock"
 
     info "Connection type: MEMIF libmemif_rx"
 
     info "Starting Tx side media_proxy"
-    local tx_media_proxy_cmd="media_proxy -d $tx_vf_bdf -i 192.168.96.1 -t 8002"
-    run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
-    tx_media_proxy_pid=$!
+    local tx_media_proxy_cmd="media_proxy -d ${tx_vf_bdf} -i 192.168.96.1 -t 8002"
+    run_in_background "${bin_dir}/${tx_media_proxy_cmd}" "${tx_media_proxy_out}"
+    tx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d $rx_vf_bdf -i 192.168.96.2 -t 8003"
-    run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
-    rx_media_proxy_pid=$!
+    run_in_background "${bin_dir}/${rx_media_proxy_cmd}" "${rx_media_proxy_out}"
+    rx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting sender_app"
     export MCM_MEDIA_PROXY_PORT=8002
-    local sender_app_cmd="sender_app -s 192.168.96.2 -t st20 -w $width -h $height -f $fps -x $pixel_format -b $input_file -n $frames_number -o memif --socketpath=${socket_path}"
-    run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
-    sender_app_pid=$!
+    local sender_app_cmd="sender_app -s 192.168.96.2 -t st20 -w ${width} -h ${height} -f ${fps} -x ${pixel_format} -b ${input_file} -n ${frames_number} -o memif --socketpath=${socket_path}"
+    run_in_background "${bin_dir}/${sender_app_cmd}" "${sender_app_out}"
+    sender_app_pid="$!"
 
     sleep 1
 
     info "Starting memif_test_rx"
-    local recver_app_cmd="memif_test_rx -w $width -h $height -f $output_file -s $socket_path"
-    run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
-    recver_app_pid=$!
+    local recver_app_cmd="memif_test_rx -w ${width} -h ${height} -f ${output_file} -s ${socket_path}"
+    run_in_background "${bin_dir}/${recver_app_cmd}" "${recver_app_out}"
+    recver_app_pid="$!"
 
-    wait_completion "$wait_interval"
-    local timeout=$?
+    wait_completion "${wait_interval}"
+    local timeout="$?"
 
     sleep 1
 
@@ -52,12 +52,12 @@ function run_test_memif_rx() {
     sleep 1
 
     check_results
-    local error=$?
+    local error="$?"
 
     info "Cleanup"
     cleanup
 
-    return $(($error || $timeout))
+    return $((error || timeout))
 }
 
 function run_test_memif_tx() {
@@ -75,21 +75,21 @@ function run_test_memif_tx() {
     info "Starting Tx side media_proxy"
     local tx_media_proxy_cmd="media_proxy -d $tx_vf_bdf -i 192.168.96.1 -t 8002"
     run_in_background "$bin_dir/$tx_media_proxy_cmd" "$tx_media_proxy_out"
-    tx_media_proxy_pid=$!
+    tx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting Rx side media_proxy"
     local rx_media_proxy_cmd="media_proxy -d $rx_vf_bdf -i 192.168.96.2 -t 8003"
     run_in_background "$bin_dir/$rx_media_proxy_cmd" "$rx_media_proxy_out"
-    rx_media_proxy_pid=$!
+    rx_media_proxy_pid="$!"
 
     sleep 1
 
     info "Starting memif_test_tx"
     local sender_app_cmd="memif_test_tx -m -w $width -h $height -f $input_file -s $socket_path"
     run_in_background "$bin_dir/$sender_app_cmd" "$sender_app_out"
-    sender_app_pid=$!
+    sender_app_pid="$!"
 
     sleep 1
 
@@ -97,10 +97,10 @@ function run_test_memif_tx() {
     export MCM_MEDIA_PROXY_PORT=8003
     local recver_app_cmd="recver_app -r 192.168.96.1 -t st20 -w $width -h $height -f $fps -x $pixel_format -b $output_file -o memif --socketpath=$socket_path"
     run_in_background "$bin_dir/$recver_app_cmd" "$recver_app_out"
-    recver_app_pid=$!
+    recver_app_pid="$!"
 
     wait_completion "$wait_interval"
-    local timeout=$?
+    local timeout="$?"
 
     sleep 1
 
@@ -109,10 +109,10 @@ function run_test_memif_tx() {
     sleep 1
 
     check_results
-    local error=$?
+    local error="$?"
 
     info "Cleanup"
     cleanup
 
-    return $(($error || $timeout))
+    return $((error || timeout))
 }


### PR DESCRIPTION
Test scripting improvements and af_xdp fixes
- added basic path resolution
- added copy logs on error functionality
- many fixes to the af_xdp workflow
- .gitignore updated

Shellcheck warnings and errors fixed:
- (SC1087): Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet).
- (SC2086): Double quote to prevent globing and word splitting.
- (SC2004): $/${} is unnecessary on arithmetic variables.

Added .shellcheckrc with `external-sources=true`

Moved and renamed `build_dep.sh` to `scripts/setup_build_env.sh`