### PR TITLE
Fix last packet contents in sender_app

### DIFF
--- a/sdk/samples/sender_app.c
+++ b/sdk/samples/sender_app.c
@@ -35,7 +35,9 @@ int read_test_data(FILE* fp, mcm_buffer* buf, uint32_t frame_size)
     assert(fp != NULL && buf != NULL);
     assert(buf->len >= frame_size);
 
-    if (fread(buf->data, frame_size, 1, fp) < 1) {
+    memset(buf->data, 0, buf->len);
+
+    if (fread(buf->data, 1, frame_size, fp) < 1) {
         ret = -1;
     }
     if(ret >= 0 ) {


### PR DESCRIPTION
Zero the whole buffer provided by MCM before reading data from a file. Fix the arguments order in fread().