### PR TITLE
Refactor MCM Data Plane SDK API + upgrade FFmpeg plugins and sample apps

### DIFF
--- a/docs/sdk/SDK_API_DEFINITION.md
+++ b/docs/sdk/SDK_API_DEFINITION.md
@@ -1,0 +1,205 @@
+# Mesh Data Plane SDK Definition
+
+## mesh_create_client()
+```c
+int mesh_create_client(MeshClient **mc,
+                       MeshClientConfig *cfg)
+```
+Creates a new mesh client from the given configuration structure.
+
+#### Parameters
+* `[OUT]` `mc` – Address of a pointer to a mesh client structure.
+* `[IN]` `cfg` – Pointer to a mesh client configuration structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_delete_client()
+```c
+int mesh_delete_client(MeshClient **mc)
+```
+Deletes the mesh client and its resources.
+
+#### Parameters
+* `[IN/OUT]` `mc` – Address of a pointer to a mesh client structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_create_connection()
+```c
+int mesh_create_connection(MeshClient *mc,
+                           MeshConnection **conn)
+```
+Creates a new media connection for the given mesh client.
+
+#### Parameters
+* `[IN]` `mc` – Pointer to a parent mesh client.
+* `[OUT]` `conn` – Address of a pointer to the connection structure.
+* `[IN]` `cfg` – Pointer to a connection configuration structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_apply_connection_config_memif()
+```c
+int mesh_apply_connection_config_memif(MeshConnection *conn,
+                                       MeshConfig_Memif *cfg)
+```
+Applies the configuration to setup a single node direct connection via memif
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[IN]` `cfg` – Pointer to a configuration structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_apply_connection_config_st2110()
+```c
+int mesh_apply_connection_config_st2110(MeshConnection *conn,
+                                        MeshConfig_ST2110 *cfg)
+```
+Applies the configuration to setup an SMPTE ST2110-xx connection via Media Proxy
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[IN]` `cfg` – Pointer to a configuration structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_apply_connection_config_rdma()
+```c
+int mesh_apply_connection_config_rdma(MeshConnection *conn,
+                                      MeshConfig_RDMA *cfg)
+```
+Applies the configuration to setup an RDMA connection via Media Proxy
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[IN]` `cfg` – Pointer to a configuration structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_apply_connection_config_video()
+```c
+int mesh_apply_connection_config_video(MeshConnection *conn,
+                                       MeshConfig_Video *cfg)
+```
+Applies the configuration to setup the connection payload for Video frames
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[IN]` `cfg` – Pointer to a configuration structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_apply_connection_config_audio()
+```c
+int mesh_apply_connection_config_audio(MeshConnection *conn,
+                                       MeshConfig_Audio *cfg)
+```
+Applies the configuration to setup the connection payload for Audio packets
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[IN]` `cfg` – Pointer to a configuration structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_delete_connection()
+```c
+int mesh_delete_connection(MeshConnection **conn)
+```
+Deletes the connection and its resources.
+
+#### Parameters
+* `[IN/OUT]` `conn` – Address of a pointer to the connection structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_get_buffer()
+```c
+int mesh_get_buffer(MeshConnection *conn,
+                    MeshBuffer **buf)
+```
+Gets a buffer from the media connection.
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[OUT]` `buf` – Address of a pointer to a mesh buffer structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_get_buffer_timeout()
+```c
+int mesh_get_buffer_timeout(MeshConnection *conn,
+                            MeshBuffer **buf,
+                            int timeout_ms)
+```
+Gets a buffer from the media connection with a timeout.
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[OUT]` `buf` – Address of a pointer to a mesh buffer structure.
+* `[IN]` `timeout_ms` – Timeout interval in milliseconds.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_put_buffer()
+```c
+int mesh_put_buffer(MeshBuffer **buf)
+```
+Puts the buffer to the media connection.
+
+#### Parameters
+* `[IN/OUT]` `buf` – Address of a pointer to a mesh buffer structure.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_put_buffer_timeout()
+```c
+int mesh_put_buffer_timeout(MeshBuffer **buf,
+                            int timeout_ms)
+```
+Puts the buffer to the media connection with a timeout.
+
+#### Parameters
+* `[IN/OUT]` `buf` – Address of a pointer to a mesh buffer structure.
+* `[IN]` `timeout_ms` – Timeout interval in milliseconds.
+
+#### Returns
+0 if successful. Otherwise, returns an error.
+
+
+## mesh_err2str()
+```c
+const char *mesh_err2str(int err)
+```
+Gets a text description of the error code.
+
+#### Parameters
+* `[IN]` `err` – Error code returned from any Mesh DP API call.
+
+#### Returns
+NULL-terminated string describing the error code.

--- a/docs/sdk/SDK_API_DEFINITION.md
+++ b/docs/sdk/SDK_API_DEFINITION.md
@@ -12,7 +12,7 @@ Creates a new mesh client from the given configuration structure.
 * `[IN]` `cfg` – Pointer to a mesh client configuration structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_delete_client()
@@ -25,7 +25,7 @@ Deletes the mesh client and its resources.
 * `[IN/OUT]` `mc` – Address of a pointer to a mesh client structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_create_connection()
@@ -38,10 +38,9 @@ Creates a new media connection for the given mesh client.
 #### Parameters
 * `[IN]` `mc` – Pointer to a parent mesh client.
 * `[OUT]` `conn` – Address of a pointer to the connection structure.
-* `[IN]` `cfg` – Pointer to a connection configuration structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_apply_connection_config_memif()
@@ -49,14 +48,14 @@ Creates a new media connection for the given mesh client.
 int mesh_apply_connection_config_memif(MeshConnection *conn,
                                        MeshConfig_Memif *cfg)
 ```
-Applies the configuration to setup a single node direct connection via memif
+Applies the configuration to setup a single node direct connection via memif.
 
 #### Parameters
 * `[IN]` `conn` – Pointer to a connection structure.
 * `[IN]` `cfg` – Pointer to a configuration structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_apply_connection_config_st2110()
@@ -64,14 +63,14 @@ Applies the configuration to setup a single node direct connection via memif
 int mesh_apply_connection_config_st2110(MeshConnection *conn,
                                         MeshConfig_ST2110 *cfg)
 ```
-Applies the configuration to setup an SMPTE ST2110-xx connection via Media Proxy
+Applies the configuration to setup an SMPTE ST2110-xx connection via Media Proxy.
 
 #### Parameters
 * `[IN]` `conn` – Pointer to a connection structure.
 * `[IN]` `cfg` – Pointer to a configuration structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_apply_connection_config_rdma()
@@ -79,14 +78,14 @@ Applies the configuration to setup an SMPTE ST2110-xx connection via Media Proxy
 int mesh_apply_connection_config_rdma(MeshConnection *conn,
                                       MeshConfig_RDMA *cfg)
 ```
-Applies the configuration to setup an RDMA connection via Media Proxy
+Applies the configuration to setup an RDMA connection via Media Proxy.
 
 #### Parameters
 * `[IN]` `conn` – Pointer to a connection structure.
 * `[IN]` `cfg` – Pointer to a configuration structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_apply_connection_config_video()
@@ -94,14 +93,14 @@ Applies the configuration to setup an RDMA connection via Media Proxy
 int mesh_apply_connection_config_video(MeshConnection *conn,
                                        MeshConfig_Video *cfg)
 ```
-Applies the configuration to setup the connection payload for Video frames
+Applies the configuration to setup the connection payload for Video frames.
 
 #### Parameters
 * `[IN]` `conn` – Pointer to a connection structure.
 * `[IN]` `cfg` – Pointer to a configuration structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_apply_connection_config_audio()
@@ -109,14 +108,42 @@ Applies the configuration to setup the connection payload for Video frames
 int mesh_apply_connection_config_audio(MeshConnection *conn,
                                        MeshConfig_Audio *cfg)
 ```
-Applies the configuration to setup the connection payload for Audio packets
+Applies the configuration to setup the connection payload for Audio packets.
 
 #### Parameters
 * `[IN]` `conn` – Pointer to a connection structure.
 * `[IN]` `cfg` – Pointer to a configuration structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
+
+
+## mesh_establish_connection()
+```c
+int mesh_establish_connection(MeshConnection *conn,
+                              int kind)
+```
+Applies the configuration to setup the connection payload for Audio packets.
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+* `[IN]` `kind` – Connection kind: Sender or Receiver.
+
+#### Returns
+0 on success; an error code otherwise.
+
+
+## mesh_shutdown_connection()
+```c
+int mesh_shutdown_connection(MeshConnection *conn)
+```
+Closes the active mesh connection.
+
+#### Parameters
+* `[IN]` `conn` – Pointer to a connection structure.
+
+#### Returns
+0 on success; an error code otherwise.
 
 
 ## mesh_delete_connection()
@@ -129,7 +156,7 @@ Deletes the connection and its resources.
 * `[IN/OUT]` `conn` – Address of a pointer to the connection structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_get_buffer()
@@ -144,7 +171,7 @@ Gets a buffer from the media connection.
 * `[OUT]` `buf` – Address of a pointer to a mesh buffer structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_get_buffer_timeout()
@@ -161,7 +188,7 @@ Gets a buffer from the media connection with a timeout.
 * `[IN]` `timeout_ms` – Timeout interval in milliseconds.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_put_buffer()
@@ -174,7 +201,7 @@ Puts the buffer to the media connection.
 * `[IN/OUT]` `buf` – Address of a pointer to a mesh buffer structure.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_put_buffer_timeout()
@@ -189,7 +216,7 @@ Puts the buffer to the media connection with a timeout.
 * `[IN]` `timeout_ms` – Timeout interval in milliseconds.
 
 #### Returns
-0 if successful. Otherwise, returns an error.
+0 on success; an error code otherwise.
 
 
 ## mesh_err2str()
@@ -199,7 +226,7 @@ const char *mesh_err2str(int err)
 Gets a text description of the error code.
 
 #### Parameters
-* `[IN]` `err` – Error code returned from any Mesh DP API call.
+* `[IN]` `err` – Error code returned from any Mesh Data Plane API call.
 
 #### Returns
 NULL-terminated string describing the error code.

--- a/docs/sdk/SDK_API_EXAMPLES.md
+++ b/docs/sdk/SDK_API_EXAMPLES.md
@@ -1,0 +1,216 @@
+# Mesh Data Plane SDK – Examples
+
+## SMPTE ST2110-22 compressed video sender example
+
+```c
+int main(void)
+{
+    /* Default client configuration */
+    MeshClientConfig client_config = { 0 };
+    
+    /* ST2110-XX configuration */
+    MeshConfig_ST2110 conn_config = {
+        .remote_ip_addr = "192.168.96.2",
+        .remote_port = 9001,
+        .transport = MESH_CONN_TRANSPORT_ST2110_22,
+    };
+
+    /* Video configuration */
+    MeshConfig_Video payload_config = {
+        .width = 1920,
+        .height = 1080,
+        .fps = 60,
+        .pixel_format = MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE,
+    };
+
+    MeshConnection *conn;
+    MeshClient *mc;
+    int err;
+    int i, n;
+
+    /* Create a mesh client */
+    err = mesh_create_client(&mc, &client_config);
+    if (err) {
+        printf("Failed to create mesh client: %s (%d)\n", mesh_err2str(err), err);
+        exit(1);
+    }
+
+    /* Create a mesh connection */
+    err = mesh_create_connection(mc, &conn);
+    if (err) {
+        printf("Failed to create connection: %s (%d)\n", mesh_err2str(err), err);
+        goto exit_delete_client;
+    }
+
+    /* Apply connection configuration */
+    err = mesh_apply_connection_config_st2110(conn, &conn_config);
+    if (err) {
+        printf("Failed to apply SMPTE ST2110 configuration: %s (%d)\n", mesh_err2str(err), err);
+        goto exit_delete_conn;
+    }
+
+    /* Apply video payload configuration */
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    if (err) {
+        printf("Failed to apply video configuration: %s (%d)\n", mesh_err2str(err), err);
+        goto exit_delete_conn;
+    }
+
+    /* Establish a connection for sending data */
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    if (err) {
+        printf("Failed to establish connection: %s (%d)\n", mesh_err2str(err), err);
+        goto exit_delete_conn;
+    }
+
+    /* 10 video frames to be sent */
+    n = 10;
+
+    /* Send data loop */
+    for (i = 0; i < n; i++) {
+        MeshBuffer *buf;
+
+        /* Ask the mesh to allocate a shared memory buffer for user data */
+        err = mesh_get_buffer(conn, &buf);
+        if (err) {
+            printf("Failed to get buffer: %s (%d)\n", mesh_err2str(err), err);
+            break;
+        }
+
+        /* Fill the buffer with user data */
+        put_user_video_frames(buf->data, buf->data_len);
+
+        /* Send the buffer */
+        err = mesh_put_buffer(&buf);
+        if (err) {
+            printf("Failed to put buffer: %s (%d)\n", mesh_err2str(err), err);
+            break;
+        }
+    }
+
+    /* Shutdown the connection */
+    err = mesh_shutdown_connection(&conn);
+    if (err)
+        printf("Failed to shutdown connection: %s (%d)\n", mesh_err2str(err), err);
+
+exit_delete_conn:
+    /* Delete the media connection */
+    mesh_delete_connection(&conn);
+
+exit_delete_client:
+    /* Delete the mesh client */
+    mesh_delete_client(&mc);
+
+    if (err)
+        exit(1);
+}
+```
+
+## SMPTE ST2110-22 compressed video receiver example
+```c
+int main(void)
+{
+    /* Default client configuration */
+    MeshClientConfig client_config = { 0 };
+    
+    /* ST2110-XX configuration */
+    MeshConfig_ST2110 conn_config = {
+        .remote_ip_addr = "192.168.96.1",
+        .local_port = 9001,
+        .transport = MESH_CONN_TRANSPORT_ST2110_22,
+    };
+
+    /* Video configuration */
+    MeshConfig_Video payload_config = {
+        .width = 1920,
+        .height = 1080,
+        .fps = 60,
+        .pixel_format = MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE,
+    };
+
+    MeshConnection *conn;
+    MeshClient *mc;
+    int err;
+    int i, n;
+
+    /* Create a mesh client */
+    err = mesh_create_client(&mc, &client_config);
+    if (err) {
+        printf("Failed to create mesh client: %s (%d)\n", mesh_err2str(err), err);
+        exit(1);
+    }
+
+    /* Create a mesh connection */
+    err = mesh_create_connection(mc, &conn);
+    if (err) {
+        printf("Failed to create connection: %s (%d)\n", mesh_err2str(err), err);
+        goto exit_delete_client;
+    }
+
+    /* Apply connection configuration */
+    err = mesh_apply_connection_config_st2110(conn, &conn_config);
+    if (err) {
+        printf("Failed to apply SMPTE ST2110 configuration: %s (%d)\n",
+               mesh_err2str(err), err);
+        goto exit_delete_conn;
+    }
+
+    /* Apply video payload configuration */
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    if (err) {
+        printf("Failed to apply video configuration: %s (%d)\n",
+               mesh_err2str(err), err);
+        goto exit_delete_conn;
+    }
+
+    /* Establish a connection for receiving data */
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_RECEIVER);
+    if (err) {
+        printf("Failed to establish connection: %s (%d)\n",
+               mesh_err2str(err), err);
+        goto exit_delete_conn;
+    }
+
+    /* Receive data loop */
+    do {
+        MeshBuffer *buf;
+
+        /* Receive a buffer from the mesh */
+        err = mesh_get_buffer(conn, &buf);
+        if (err == MESH_ERR_CONNECTION_CLOSED) {
+            printf("Connection closed\n");
+            break;
+        }
+        if (err) {
+            printf("Failed to get buffer: %s (%d)\n", mesh_err2str(err), err);
+            break;
+        }
+
+        /* Process the received user data */
+        get_user_video_frames(buf->data, buf->data_len);
+
+        /* Release and put the buffer back to the mesh */
+        err = mesh_put_buffer(&buf);
+        if (err) {
+            printf("Failed to put buffer: %s (%d)\n", mesh_err2str(err), err);
+            break;
+        }
+    } while (1);
+
+    /* Shutdown the connection */
+    err = mesh_shutdown_connection(&conn);
+    if (err)
+        printf("Failed to shutdown connection: %s (%d)\n", mesh_err2str(err), err);
+
+exit_delete_conn:
+    /* Delete the media connection */
+    mesh_delete_connection(&conn);
+
+exit_delete_client:
+    /* Delete the mesh client */
+    mesh_delete_client(&mc);
+
+    if (err)
+        exit(1);
+}
+```

--- a/docs/sdk/SDK_API_EXAMPLES.md
+++ b/docs/sdk/SDK_API_EXAMPLES.md
@@ -24,6 +24,7 @@ int main(void)
     };
 
     MeshConnection *conn;
+    MeshBuffer *buf;
     MeshClient *mc;
     int err;
     int i, n;
@@ -68,8 +69,6 @@ int main(void)
 
     /* Send data loop */
     for (i = 0; i < n; i++) {
-        MeshBuffer *buf;
-
         /* Ask the mesh to allocate a shared memory buffer for user data */
         err = mesh_get_buffer(conn, &buf);
         if (err) {

--- a/docs/sdk/SDK_API_WORKFLOW.md
+++ b/docs/sdk/SDK_API_WORKFLOW.md
@@ -1,0 +1,170 @@
+# Mesh Data Plane SDK – API Workflow
+## General workflow
+1. Create a Mesh client:
+   * `mesh_create_client()`
+1. Create a Mesh connection:
+   * `mesh_create_connection()`
+1. Apply the connection configuration:
+   * `struct MeshConfig_Memif {...}` -> `mesh_apply_config_memif()`
+   * `struct MeshConfig_ST2110 {...}` -> `mesh_apply_config_st2110()`
+   * `struct MeshConfig_RDMA {...}` -> `mesh_apply_config_rdma()`
+1. Apply the payload configuration:
+   * `struct MeshConfig_Video` -> `mesh_apply_config_video()`
+   * `struct MeshConfig_Audio` -> `mesh_apply_config_audio()`
+1. Establish the Mesh connection:
+   * `mesh_establish_connection()`
+1. Get a buffer from the Mesh connection:
+   * `mesh_get_buffer()`
+   * `mesh_get_buffer_timeout()`
+1. Put the buffer to the Mesh connection:
+   * `mesh_put_buffer()`
+   * `mesh_put_buffer_timeout()`
+1. Shutdown the Mesh connection:
+   * `mesh_shutdown_connection()`
+1. Delete the Mesh connection:
+   * `mesh_delete_connection()`
+1. Delete the Mesh client:
+   * `mesh_delete_client()`
+
+## Configure connection – Memif
+1. Define a memif configuration:
+   * `struct MeshConfig_Memif`
+      * `.socket_path`
+      * `.interface_id`
+1. Apply the configuration:
+   * `mesh_apply_config_memif()`
+
+## Configure connection – SMPTE ST2110-XX
+1. Define an SMPTE ST2110-XX configuration:
+   * `struct MeshConfig_ST2110`
+      * `.remote_ip_addr`
+      * `.remote_port`
+      * `.local_ip_addr`
+      * `.local_port`
+      * `.transport`
+         * `MESH_CONN_TRANSPORT_ST2110_20` – SMPTE ST2110-20 Uncompressed Video
+         * `MESH_CONN_TRANSPORT_ST2110_22` – SMPTE ST2110-22 Constant Bit-Rate Compressed Video
+         * `MESH_CONN_TRANSPORT_ST2110_30` – SMPTE ST2110-30 Audio
+1. Apply the configuration:
+   * `mesh_apply_config_st2110()`
+
+## Configure connection – RDMA
+1. Define an RDMA configuration:
+   * `struct MeshConfig_RDMA`
+      * `.remote_ip_addr`
+      * `.remote_port`
+      * `.local_ip_addr`
+      * `.local_port`
+1. Apply the configuration:
+   * `mesh_apply_config_rdma()`
+
+## Configure payload – Video
+1. Define a video configuration:
+   * `struct MeshConfig_Video`
+      * `.width`
+      * `.height`
+      * `.fps`
+      * `.pixel_format` – `MESH_VIDEO_PIXEL_FORMAT_*`
+1. Apply the configuration:
+   * `mesh_apply_config_video()`
+
+## Configure payload – Audio
+1. Define an audio configuration:
+   * `struct MeshConfig_Audio`
+      * `.channels`
+      * `.sample_rate` – `MESH_AUDIO_SAMPLE_RATE_*`
+      * `.format` – `MESH_AUDIO_FORMAT_*`
+      * `.packet_time` – `MESH_AUDIO_PACKET_TIME_*`
+1. Apply the configuration:
+   * `mesh_apply_config_audio()`
+
+## Mesh DP SDK API internals – Connection configuration flowchart
+
+```mermaid
+flowchart LR
+   kind(.kind) --> sender[_Sender_]
+   kind --> receiver[_Receiver_]
+
+   conn_type(.conn_type) --> memif_t[_memif_]
+   conn_type --> st_t[_SMPTE ST2110-XX_]
+   conn_type --> rdma_t[_RDMA_]
+
+   conn(.conn) --> memif(.memif)
+      memif --> socket_path(".socket_path
+                             .interface_id")
+
+   conn --> st(.st2110) --> st_param(".remote_ip_addr
+                                      .remote_port
+                                      .local_ip_addr
+                                      .local_port")
+            st ---> transport(.transport)
+               transport --> st20["_SMPTE ST2110-20_ 
+                  Uncompressed Video"]
+               transport --> st22["_SMPTE ST2110-22_
+                  Constant Bit-Rate Compressed Video"]
+               transport --> st30["_SMPTE ST2110-30_
+                  Audio"]
+
+   conn --> rdma(.rdma) --> rdma_param(".remote_ip_addr
+                                        .remote_port
+                                        .local_ip_addr
+                                        .local_port")
+
+   payload_type(.payload_type) --> video_t(_Video_)
+   payload_type --> audio_t(_Audio_)
+
+   payload(.payload) --> video(.video) --> videoparam(".width
+                                                       .height
+                                                       .fps
+                                                       .pixel_format")
+   payload --> audio(.audio) --> audioparam(".channels
+                                             .sample_rate
+                                             .format
+                                             .packet_time")
+```
+
+## Mesh DP SDK API internals – Connection configuration mindmap
+```mermaid
+mindmap
+)__MeshConnection__ configuration(
+   **.kind**
+      (_Sender_)
+      (_Receiver_)
+   **.conn_type**
+      (memif)
+      (SMPTE ST2110-XX)
+      (RDMA)
+   **.conn**
+      ((**.memif**))
+         (.socket_path)
+         (.interface_id)
+      ((**.st2110**))
+         (.remote_ip_addr)
+         (.remote_port)
+         (.local_ip_addr)
+         (.local_port)
+         (.transport)
+            [_ST2110-20_]
+            [_ST2110-22_]
+            [_ST2110-30_]
+      ((**.rdma**))
+         (.remote_ip_addr)
+         (.remote_port)
+         (.local_ip_addr)
+         (.local_port)
+   **.payload_type**
+      (_Video_)
+      (_Audio_)
+   **.payload**
+      ((**.video**))
+         (.width)
+         (.height)
+         (.fps)
+         (.pixel_format)
+      ((**.audio**))
+         (.channels)
+         (.sample_rate)
+         (.format)
+         (.packet_time)
+```
+

--- a/docs/sdk/SDK_SMPTE_ST2110_RX_FLOW.md
+++ b/docs/sdk/SDK_SMPTE_ST2110_RX_FLOW.md
@@ -6,7 +6,7 @@ The diagram in this document shows interaction between a user app and Mesh Data 
 1. Create client.
 1. Create connection.
 1. Configure connection.
-1. Establish Tx connection.
+1. Establish Rx connection.
 1. Receive video frames.
 1. Shutdown connection.
 1. Delete connection.

--- a/docs/sdk/SDK_SMPTE_ST2110_RX_FLOW.md
+++ b/docs/sdk/SDK_SMPTE_ST2110_RX_FLOW.md
@@ -1,0 +1,104 @@
+# Mesh Data Plane SDK – Example / SMPTE ST2110-22 Rx Flow
+
+The diagram in this document shows interaction between a user app and Mesh Data Plane in the video receive mode over SMPTE ST2110-22.
+
+### Rx flow stages
+1. Create client.
+1. Create connection.
+1. Configure connection.
+1. Establish Tx connection.
+1. Receive video frames.
+1. Shutdown connection.
+1. Delete connection.
+1. Delete client.
+
+```mermaid
+sequenceDiagram
+   participant app as User Rx App
+   participant sdk as Mesh DP SDK
+   participant memif as Memif
+   participant proxy as Media Proxy
+   participant mtl as MTL
+   participant network as Network
+
+   note over app, network: Create client
+   app ->>+ sdk: Create client
+   sdk ->>- app: Client created
+
+   note over app, network: Create connection
+   app ->>+ sdk: Create connection
+   sdk ->> sdk: Register connection in the client
+   sdk ->>- app: Connection created
+
+   note over app, network: Configure connection
+   app ->> sdk: Apply SMPTE ST2110-XX configuration
+   app ->> sdk: Apply video configuration
+
+   note over app, network: Establish Rx connection
+   app ->>+ sdk: Establish Rx connection
+   sdk ->>+ proxy: Open TCP connection to Proxy
+   proxy ->>+ mtl: Start Rx session
+   note right of mtl: SMPTE ST2110-22
+   mtl ->>+ network: Update ARP table
+   mtl ->>- proxy: Session started
+   proxy ->>+ memif: Create Memif Tx connection
+   memif ->>- proxy: Connection created
+   proxy ->>- sdk: Connection established
+
+   sdk ->>+ proxy: Query Memif info
+   proxy ->>- sdk: Memif info
+
+   sdk ->>+ memif: Create Memif Rx connection
+   memif ->>- sdk: Connection created
+   sdk ->>- app: Connection established
+
+   note over app, network: Receive video frames
+   loop
+
+   note right of mtl: SMPTE ST2110-22
+   network ->>+ mtl: Data received
+   mtl ->> mtl: Decode ST2110-22
+   mtl ->>- proxy: Frame received
+   proxy ->>+ memif: Dequeue buffer
+   memif ->>- proxy: Buffer dequeued
+   proxy ->> proxy: Write data to buffer
+   proxy ->> memif: Enqueue buffer
+
+   app ->>+ sdk: Get buffer
+   alt
+      sdk ->>+ memif: Dequeue buffer
+      memif ->>- sdk: Buffer dequeued
+      sdk ->> app: Buffer received
+   else
+      sdk -->>- app: Connection closed
+      note over app, sdk: No more frames, exit the loop
+   end
+
+   app ->> app: Read frame from buffer
+   app ->>+ sdk: Put buffer
+   sdk ->>+ memif: Enqueue buffer
+   memif ->>- sdk: Buffer enqueued
+   sdk ->>- app: Buffer released
+
+   end
+
+   note over app, network: Shutdown connection
+   app ->>+ sdk: Shutdown connection
+   sdk ->>+ proxy: Close TCP connection to Proxy
+   proxy ->> mtl: Stop Rx session
+   note right of mtl: SMPTE ST2110-22
+   mtl ->> network: Terminate connection
+   proxy ->>- memif: Close Memif Tx connection
+   sdk ->> memif: Close Memif Rx connection
+   sdk ->>- app: Connection closed
+
+   note over app, network: Delete connection
+   app ->>+ sdk: Delete connection
+   sdk ->> sdk: Unregister connection in the client
+   sdk ->>- app: Connection deleted
+
+   note over app, network: Delete client
+   app ->>+ sdk: Delete client
+   sdk ->>- app: Client deleted
+
+```

--- a/docs/sdk/SDK_SMPTE_ST2110_TX_FLOW.md
+++ b/docs/sdk/SDK_SMPTE_ST2110_TX_FLOW.md
@@ -1,0 +1,97 @@
+# Mesh Data Plane SDK – Example / SMPTE ST2110-22 Tx Flow
+
+The diagram in this document shows interaction between a user app and Mesh Data Plane in the video transmit mode over SMPTE ST2110-22.
+
+### Tx flow stages
+1. Create client.
+1. Create connection.
+1. Configure connection.
+1. Establish Tx connection.
+1. Send N video frames.
+1. Shutdown connection.
+1. Delete connection.
+1. Delete client.
+
+```mermaid
+sequenceDiagram
+   participant app as User Tx App
+   participant sdk as Mesh DP SDK
+   participant memif as Memif
+   participant proxy as Media Proxy
+   participant mtl as MTL
+   participant network as Network
+
+   note over app, network: Create client
+   app ->>+ sdk: Create client
+   sdk ->>- app: Client created
+
+   note over app, network: Create connection
+   app ->>+ sdk: Create connection
+   sdk ->> sdk: Register connection in the client
+   sdk ->>- app: Connection created
+
+   note over app, network: Configure connection
+   app ->> sdk: Apply SMPTE ST2110-XX configuration
+   app ->> sdk: Apply video configuration
+
+   note over app, network: Establish Tx connection
+   app ->>+ sdk: Establish Tx connection
+   sdk ->>+ proxy: Open TCP connection to Proxy
+   proxy ->>+ mtl: Start Tx session
+   note right of mtl: SMPTE ST2110-22
+   mtl ->>+ network: Connect to remote host
+   network ->>- mtl: Connection established
+   mtl ->>- proxy: Session started
+   proxy ->>+ memif: Create Memif Rx connection
+   memif ->>- proxy: Connection created
+   proxy ->>- sdk: Connection established
+
+   sdk ->>+ proxy: Query Memif info
+   proxy ->>- sdk: Memif info
+
+   sdk ->>+ memif: Create Memif Tx connection
+   memif ->>- sdk: Connection created
+   sdk ->>- app: Connection established
+
+   note over app, network: Send N video frames
+   loop
+
+   app ->>+ sdk: Get buffer
+   sdk ->>+ memif: Dequeue buffer
+   memif ->>- sdk: Buffer dequeued
+   sdk ->>- app: Buffer allocated
+   app ->> app: Write frame into buffer
+   app ->>+ sdk: Put buffer
+   sdk ->>+ memif: Enqueue buffer
+   memif ->>- sdk: Buffer enqueued
+   sdk ->>- app: Buffer sent
+
+   proxy ->>+ memif: Dequeue buffer
+   memif ->>- proxy: Buffer dequeued
+   proxy ->>+ mtl: Send frame
+   note right of mtl: SMPTE ST2110-22
+   mtl ->> mtl: Encode ST2110-22
+   mtl ->>- network: Transmit data
+
+   end
+
+   note over app, network: Shutdown connection
+   app ->>+ sdk: Shutdown connection
+   sdk ->>+ proxy: Close TCP connection to Proxy
+   proxy ->> mtl: Stop Tx session
+   note right of mtl: SMPTE ST2110-22
+   mtl ->> network: Terminate connection
+   proxy ->>- memif: Close Memif Rx connection
+   sdk ->> memif: Close Memif Tx connection
+   sdk ->>- app: Connection closed
+
+   note over app, network: Delete connection
+   app ->>+ sdk: Delete connection
+   sdk ->> sdk: Unregister connection in the client
+   sdk ->>- app: Connection deleted
+
+   note over app, network: Delete client
+   app ->>+ sdk: Delete client
+   sdk ->>- app: Client deleted
+
+```

--- a/ffmpeg-plugin/6.1/0001-mcm-add-in-out-dev-support.patch
+++ b/ffmpeg-plugin/6.1/0001-mcm-add-in-out-dev-support.patch
@@ -46,7 +46,7 @@ index ff11033a01..96c17b34c7 100755
  enabled libaribcaption    && require_pkg_config libaribcaption "libaribcaption >= 1.1.1" "aribcaption/aribcaption.h" aribcc_context_alloc
  enabled lv2               && require_pkg_config lv2 lilv-0 "lilv/lilv.h" lilv_world_new
  enabled libiec61883       && require libiec61883 libiec61883/iec61883.h iec61883_cmp_connect -lraw1394 -lavc1394 -lrom1394 -liec61883
-+enabled mcm               && { check_pkg_config libmcm_dp "libmcm_dp >= 24.00" mcm_dp.h mcm_dequeue_buffer ||
++enabled mcm               && { check_pkg_config libmcm_dp "libmcm_dp >= 24.00" mesh_dp.h mesh_get_buffer   ||
 +                               die "ERROR: libmcm_dp must be installed and version must be >= 24.00"; }
  enabled libass            && require_pkg_config libass "libass >= 0.11.0" ass/ass.h ass_library_init
  enabled libbluray         && require_pkg_config libbluray libbluray libbluray/bluray.h bd_open

--- a/ffmpeg-plugin/7.0/0001-mcm-add-in-out-dev-support.patch
+++ b/ffmpeg-plugin/7.0/0001-mcm-add-in-out-dev-support.patch
@@ -46,7 +46,7 @@ index 20d4e4b615..9fdac37877 100755
  enabled libaribcaption    && require_pkg_config libaribcaption "libaribcaption >= 1.1.1" "aribcaption/aribcaption.h" aribcc_context_alloc
  enabled lv2               && require_pkg_config lv2 lilv-0 "lilv/lilv.h" lilv_world_new
  enabled libiec61883       && require libiec61883 libiec61883/iec61883.h iec61883_cmp_connect -lraw1394 -lavc1394 -lrom1394 -liec61883
-+enabled mcm               && { check_pkg_config libmcm_dp "libmcm_dp >= 24.00" mcm_dp.h mcm_dequeue_buffer ||
++enabled mcm               && { check_pkg_config libmcm_dp "libmcm_dp >= 24.00" mesh_dp.h mesh_get_buffer   ||
 +                               die "ERROR: libmcm_dp must be installed and version must be >= 24.00"; }
  enabled libass            && require_pkg_config libass "libass >= 0.11.0" ass/ass.h ass_library_init
  enabled libbluray         && require_pkg_config libbluray libbluray libbluray/bluray.h bd_open

--- a/ffmpeg-plugin/mcm_audio_rx.c
+++ b/ffmpeg-plugin/mcm_audio_rx.c
@@ -34,7 +34,6 @@ typedef struct McmAudioDemuxerContext {
     MeshClient *mc;
     MeshConnection *conn;
     bool first_frame;
-
 } McmAudioDemuxerContext;
 
 static int mcm_audio_read_header(AVFormatContext* avctx, enum AVCodecID codec_id)

--- a/ffmpeg-plugin/mcm_audio_tx.c
+++ b/ffmpeg-plugin/mcm_audio_tx.c
@@ -32,7 +32,6 @@ typedef struct McmAudioMuxerContext {
     MeshConnection *conn;
     MeshBuffer *unsent_buf;
     int unsent_len;
-
 } McmAudioMuxerContext;
 
 static int mcm_audio_write_header(AVFormatContext* avctx)

--- a/ffmpeg-plugin/mcm_audio_tx.c
+++ b/ffmpeg-plugin/mcm_audio_tx.c
@@ -10,7 +10,7 @@
 #include "libavformat/avformat.h"
 #include "libavformat/mux.h"
 #include "libavdevice/mcm_common.h"
-#include <mcm_dp.h>
+#include <mesh_dp.h>
 #include <unistd.h>
 
 typedef struct McmAudioMuxerContext {
@@ -28,32 +28,20 @@ typedef struct McmAudioMuxerContext {
     int sample_rate;
     char* ptime;
 
-    mcm_conn_context *tx_handle;
-    mcm_buffer *unsent_mcm_buf;
+    MeshClient *mc;
+    MeshConnection *conn;
+    MeshBuffer *unsent_buf;
     int unsent_len;
+
 } McmAudioMuxerContext;
 
 static int mcm_audio_write_header(AVFormatContext* avctx)
 {
     AVCodecParameters* codecpar = avctx->streams[0]->codecpar;
     McmAudioMuxerContext *s = avctx->priv_data;
-    mcm_audio_sampling mcm_sample_rate;
-    mcm_conn_param param = { 0 };
-    mcm_audio_ptime mcm_ptime;
-    mcm_audio_format mcm_fmt;
+    int kind = MESH_CONN_KIND_SENDER;
+    MeshConfig_Audio cfg;
     int err;
-
-    err = mcm_parse_conn_param(avctx, &param, is_tx, s->ip_addr, s->port,
-                               s->protocol_type, s->payload_type, s->socket_name,
-                               s->interface_id);
-    if (err)
-        return err;
-
-    /* payload type */
-    if (param.payload_type != PAYLOAD_TYPE_ST30_AUDIO) {
-        av_log(avctx, AV_LOG_ERROR, "Unknown payload type\n");
-        return AVERROR(EINVAL);
-    }
 
     /* check channels argument */
     if (codecpar->ch_layout.nb_channels != s->channels) {
@@ -69,79 +57,113 @@ static int mcm_audio_write_header(AVFormatContext* avctx)
         return AVERROR(EINVAL);
     }
 
-    err = mcm_parse_audio_sample_rate(avctx, &mcm_sample_rate, s->sample_rate);
+    err = mcm_parse_audio_sample_rate(avctx, &cfg.sample_rate, s->sample_rate);
     if (err)
         return err;
 
-    err = mcm_parse_audio_packet_time(avctx, &mcm_ptime, s->ptime);
+    err = mcm_parse_audio_packet_time(avctx, &cfg.packet_time, s->ptime);
     if (err)
         return err;
-
-    err = mcm_check_audio_params_compat(mcm_sample_rate, mcm_ptime);
-    if (err) {
-        av_log(avctx, AV_LOG_ERROR, "Incompatible audio parameters\n");
-        return AVERROR(EINVAL);
-    }
 
     switch (codecpar->codec_id) {
     case AV_CODEC_ID_PCM_S24BE:
-        mcm_fmt = AUDIO_FMT_PCM24;
+        cfg.format = MESH_AUDIO_FORMAT_PCM_S24BE;
         break;
     case AV_CODEC_ID_PCM_S16BE:
-        mcm_fmt = AUDIO_FMT_PCM16;
+        cfg.format = MESH_AUDIO_FORMAT_PCM_S16BE;
         break;
     default:
         av_log(avctx, AV_LOG_ERROR, "Audio PCM format not supported\n");
         return AVERROR(EINVAL);
     }
 
-    /* audio format */
-    param.payload_args.audio_args.type = AUDIO_TYPE_FRAME_LEVEL;
-    param.payload_args.audio_args.channel = s->channels;
-    param.payload_args.audio_args.sampling = mcm_sample_rate;
-    param.payload_args.audio_args.ptime = mcm_ptime;
-    param.payload_args.audio_args.format = mcm_fmt;
+    cfg.channels = s->channels;
 
-    s->tx_handle = mcm_create_connection(&param);
-    if (!s->tx_handle) {
-        av_log(avctx, AV_LOG_ERROR, "Create connection failed\n");
-        return AVERROR(EIO);
+    err = mcm_get_client(&s->mc);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Get mesh client failed: %s (%d)\n",
+               mesh_err2str(err), err);
+        return AVERROR(EINVAL);
+    }
+
+    err = mesh_create_connection(s->mc, &s->conn);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Create connection failed: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EIO);
+        goto exit_put_client;
+    }
+
+    err = mcm_parse_conn_param(avctx, s->conn, kind, s->ip_addr, s->port,
+                                  s->protocol_type, s->payload_type,
+                                  s->socket_name, s->interface_id);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Configuration parsing failed: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EINVAL);
+        goto exit_delete_conn;
+    }
+
+    err = mesh_apply_connection_config_audio(s->conn, &cfg);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Failed to apply connection config: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EIO);
+        goto exit_delete_conn;
+    }
+
+    err = mesh_establish_connection(s->conn, kind);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Cannot establish connection: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EIO);
+        goto exit_delete_conn;
     }
 
     av_log(avctx, AV_LOG_INFO, "codec:%s sampling:%d ch:%d ptime:%s\n",
            avcodec_get_name(codecpar->codec_id), s->sample_rate, s->channels,
            s->ptime);
     return 0;
+
+exit_delete_conn:
+    mesh_delete_connection(&s->conn);
+
+exit_put_client:
+    mcm_put_client(&s->mc);
+    return err;
 }
 
 static int mcm_audio_write_packet(AVFormatContext* avctx, AVPacket* pkt)
 {
     McmAudioMuxerContext *s = avctx->priv_data;
-    size_t frame_size = s->tx_handle->frame_size;
     const uint8_t *data = pkt->data;
     int size = pkt->size;
     int len, err = 0;
 
     while (size > 0) {
+        size_t max_len;
         char *dest;
 
-        if (!s->unsent_mcm_buf) {
-            s->unsent_mcm_buf = mcm_dequeue_buffer(s->tx_handle, -1, &err);
-            if (s->unsent_mcm_buf == NULL) {
-                av_log(avctx, AV_LOG_ERROR, "Initial dequeue buffer error %d\n", err);
+        if (!s->unsent_buf) {
+            err = mesh_get_buffer(s->conn, &s->unsent_buf);
+
+            if (err) {
+                av_log(avctx, AV_LOG_ERROR, "Get buffer error: %s (%d)\n",
+                       mesh_err2str(err), err);
                 return AVERROR(EIO);
             }
         }
 
-        len = FFMIN(frame_size, size + s->unsent_len);
+        max_len = s->unsent_buf->conn->buf_size;
+        len = FFMIN(max_len, size + s->unsent_len);
 
-        if (len < frame_size) {
-            memcpy((char *)s->unsent_mcm_buf->data + s->unsent_len, data, size);
+        if (len < max_len) {
+            memcpy((char *)s->unsent_buf->data + s->unsent_len, data, size);
             s->unsent_len += size;
             break;
         }
 
-        dest = s->unsent_mcm_buf->data;
+        dest = s->unsent_buf->data;
 
         if (s->unsent_len) {
             dest += s->unsent_len;
@@ -153,13 +175,12 @@ static int mcm_audio_write_packet(AVFormatContext* avctx, AVPacket* pkt)
         data += len;
         size -= len;
 
-        err = mcm_enqueue_buffer(s->tx_handle, s->unsent_mcm_buf);
+        err = mesh_put_buffer(&s->unsent_buf);
         if (err) {
-            av_log(avctx, AV_LOG_ERROR, "Enqueue buffer error %d\n", err);
+            av_log(avctx, AV_LOG_ERROR, "Put buffer error: %s (%d)\n",
+                   mesh_err2str(err), err);
             return AVERROR(EIO);
         }
-
-        s->unsent_mcm_buf = NULL;
     }
 
     return 0;
@@ -168,29 +189,28 @@ static int mcm_audio_write_packet(AVFormatContext* avctx, AVPacket* pkt)
 static int mcm_audio_write_trailer(AVFormatContext* avctx)
 {
     McmAudioMuxerContext *s = avctx->priv_data;
+    int err;
 
-    if (s->unsent_mcm_buf) {
-        int err;
-
+    if (s->unsent_buf) {
         /* zero the unused rest of the buffer */
-        memset((char *)s->unsent_mcm_buf->data + s->unsent_len, 0,
-               s->unsent_mcm_buf->len - s->unsent_len);
+        memset((char *)s->unsent_buf->data + s->unsent_len, 0,
+               s->unsent_buf->data_len - s->unsent_len);
 
-        err = mcm_enqueue_buffer(s->tx_handle, s->unsent_mcm_buf);
-        if (err) {
-            av_log(avctx, AV_LOG_ERROR, "Enqueue buffer error %d\n", err);
-            return AVERROR(EIO);
-        }
+        err = mesh_put_buffer(&s->unsent_buf);
+        if (err)
+            av_log(avctx, AV_LOG_ERROR, "Enqueue buffer error: %s (%d)\n",
+                   mesh_err2str(err), err);
     }
 
-    /* Delay for 50ms to allow Media Proxy to complete transmission of all
-     * buffers sitting in the memif queue before destroying the connection.
-     *
-     * TODO: Replace the delay with an API call when it is implemented in SDK.
-     */
-    usleep(50000);
+    err = mesh_delete_connection(&s->conn);
+    if (err)
+        av_log(avctx, AV_LOG_ERROR, "Delete mesh connection failed: %s (%d)\n",
+               mesh_err2str(err), err);
 
-    mcm_destroy_connection(s->tx_handle);
+    err = mcm_put_client(&s->mc);
+    if (err)
+        av_log(avctx, AV_LOG_ERROR, "Put mesh client failed (%d)\n", err);
+
     return 0;
 }
 

--- a/ffmpeg-plugin/mcm_common.c
+++ b/ffmpeg-plugin/mcm_common.c
@@ -4,76 +4,168 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <pthread.h>
 #include "mcm_common.h"
 #include <bsd/string.h>
+#include <stdatomic.h>
+#include "libavutil/pixdesc.h"
 
-/* Parse MCM connection parameters and fill the structure */
-int mcm_parse_conn_param(AVFormatContext* avctx, mcm_conn_param *param,
-                         transfer_type type, char *ip_addr, char *port,
+static pthread_mutex_t mx = PTHREAD_MUTEX_INITIALIZER;
+static MeshClient *client;
+static int refcnt;
+
+/**
+ * Get MCM client. Create one if needed.
+ * Thread-safe.
+ */
+int mcm_get_client(MeshClient **mc)
+{
+    int err;
+
+    err = pthread_mutex_lock(&mx);
+    if (err)
+        return err;
+
+    if (!client) {
+        MeshClientConfig config = { 0 };
+
+        err = mesh_create_client(&client, &config);
+        if (err)
+            client = NULL;
+        else
+            refcnt = 1;
+    } else {
+        refcnt++;
+    }
+
+    pthread_mutex_unlock(&mx);
+
+    *mc = client;
+
+    return err;
+}
+
+/**
+ * Put MCM client, or release the client.
+ * Thread-safe.
+ */
+int mcm_put_client(MeshClient **mc)
+{
+    int err;
+
+    err = pthread_mutex_lock(&mx);
+    if (err)
+        return err;
+
+    if (!client) {
+        err = -EINVAL;
+    } else {
+        if (--refcnt == 0)
+            mesh_delete_client(&client);
+
+        *mc = NULL;
+    }
+
+    pthread_mutex_unlock(&mx);
+
+    return err;
+}
+
+/**
+ * Parse MCM connection parameters and fill the structure.
+ */
+int mcm_parse_conn_param(AVFormatContext* avctx, MeshConnection *conn,
+                         int kind, char *ip_addr, char *port,
                          char *protocol_type, char *payload_type,
                          char *socket_name, int interface_id)
 {
-    param->type = type;
-
-    strlcpy(param->remote_addr.ip, ip_addr, sizeof(param->remote_addr.ip));
-
-    if (type == is_tx)
-        strlcpy(param->remote_addr.port, port, sizeof(param->remote_addr.port));
-    else
-        strlcpy(param->local_addr.port, port, sizeof(param->local_addr.port));
+    int err;
 
     /* protocol type */
     if (!strcmp(protocol_type, "memif")) {
-        param->protocol = PROTO_MEMIF;
-        snprintf(param->memif_interface.socket_path, sizeof(param->memif_interface.socket_path),
-            "/run/mcm/mcm_memif_%s.sock", socket_name ? socket_name : "0");
-        param->memif_interface.interface_id = interface_id;
-        param->memif_interface.is_master = (type == is_tx) ? 1 : 0;
-    } else if (!strcmp(protocol_type, "udp")) {
-        param->protocol = PROTO_UDP;
-    } else if (!strcmp(protocol_type, "tcp")) {
-        param->protocol = PROTO_TCP;
-    } else if (!strcmp(protocol_type, "http")) {
-        param->protocol = PROTO_HTTP;
-    } else if (!strcmp(protocol_type, "grpc")) {
-        param->protocol = PROTO_GRPC;
-    } else {
-        param->protocol = PROTO_AUTO;
-    }
+        MeshConfig_Memif cfg;
 
-    /* payload type */
-    if (!strcmp(payload_type, "st20")) {
-        param->payload_type = PAYLOAD_TYPE_ST20_VIDEO;
-    } else if (!strcmp(payload_type, "st22")) {
-        param->payload_type = PAYLOAD_TYPE_ST22_VIDEO;
-        param->payload_codec = PAYLOAD_CODEC_JPEGXS;
-    } else if (!strcmp(payload_type, "st30")) {
-        param->payload_type = PAYLOAD_TYPE_ST30_AUDIO;
-    } else if (!strcmp(payload_type, "st40")) {
-        param->payload_type = PAYLOAD_TYPE_ST40_ANCILLARY;
-    } else if (!strcmp(payload_type, "rtsp")) {
-        param->payload_type = PAYLOAD_TYPE_RTSP_VIDEO;
+        snprintf(cfg.socket_path, sizeof(cfg.socket_path),
+            "/run/mcm/mcm_memif_%s.sock", socket_name ? socket_name : "0");
+        cfg.interface_id = interface_id;
+
+        err = mesh_apply_connection_config_memif(conn, &cfg);
+        if (err)
+            return err;
     } else {
-        av_log(avctx, AV_LOG_ERROR, "Unknown payload type\n");
-        return AVERROR(EINVAL);
+        MeshConfig_ST2110 cfg;
+
+        strlcpy(cfg.remote_ip_addr, ip_addr, sizeof(cfg.remote_ip_addr));
+        
+        if (kind == MESH_CONN_KIND_SENDER)
+            cfg.remote_port = atoi(port);
+        else
+            cfg.local_port = atoi(port);
+
+        /* transport type */
+        if (!strcmp(payload_type, "st20")) {
+            cfg.transport = MESH_CONN_TRANSPORT_ST2110_20;
+        } else if (!strcmp(payload_type, "st22")) {
+            cfg.transport = MESH_CONN_TRANSPORT_ST2110_22;
+        } else if (!strcmp(payload_type, "st30")) {
+            cfg.transport = MESH_CONN_TRANSPORT_ST2110_30;
+        } else {
+            av_log(avctx, AV_LOG_ERROR, "Unknown payload type\n");
+            return -MESH_ERR_CONN_CONFIG_INVAL;
+        }
+
+        err = mesh_apply_connection_config_st2110(conn, &cfg);
+        if (err)
+            return err;
     }
 
     return 0;
 }
 
-/* Parse MCM audio sampling rate */
-int mcm_parse_audio_sample_rate(AVFormatContext* avctx, mcm_audio_sampling *sample_rate,
+/**
+ * Parse MCM video pixel format
+ */
+int mcm_parse_video_pix_fmt(AVFormatContext* avctx, int *pix_fmt,
+                            enum AVPixelFormat value)
+{
+    switch (value) {
+    case AV_PIX_FMT_NV12:
+        *pix_fmt = MESH_VIDEO_PIXEL_FORMAT_NV12;
+        return 0;
+    case AV_PIX_FMT_YUV422P:
+        *pix_fmt = MESH_VIDEO_PIXEL_FORMAT_YUV422P;
+        return 0;
+    case AV_PIX_FMT_YUV444P10LE:
+        *pix_fmt = MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE;
+        return 0;
+    case AV_PIX_FMT_RGB8:
+        *pix_fmt = MESH_VIDEO_PIXEL_FORMAT_RGB8;
+        return 0;
+    case AV_PIX_FMT_YUV422P10LE:
+        *pix_fmt = MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE;
+        return 0;
+    default:
+        av_log(avctx, AV_LOG_ERROR, "Unknown pixel format (%s)\n",
+               av_get_pix_fmt_name(value));
+        return AVERROR(EINVAL);
+    }
+}
+
+/**
+ * Parse MCM audio sampling rate
+ */
+int mcm_parse_audio_sample_rate(AVFormatContext* avctx, int *sample_rate,
                                 int value)
 {
     switch (value) {
     case 44100:
-        *sample_rate = AUDIO_SAMPLING_44K;
+        *sample_rate = MESH_AUDIO_SAMPLE_RATE_44100;
         return 0;
     case 48000:
-        *sample_rate = AUDIO_SAMPLING_48K;
+        *sample_rate = MESH_AUDIO_SAMPLE_RATE_48000;
         return 0;
     case 96000:
-        *sample_rate = AUDIO_SAMPLING_96K;
+        *sample_rate = MESH_AUDIO_SAMPLE_RATE_96000;
         return 0;
     default:
         av_log(avctx, AV_LOG_ERROR, "Audio sample rate not supported\n");
@@ -81,79 +173,48 @@ int mcm_parse_audio_sample_rate(AVFormatContext* avctx, mcm_audio_sampling *samp
     }
 }
 
-/* Parse MCM audio packet time */
-int mcm_parse_audio_packet_time(AVFormatContext* avctx, mcm_audio_ptime *ptime,
-                                char *str)
+/**
+ * Parse MCM audio packet time
+ */
+int mcm_parse_audio_packet_time(AVFormatContext* avctx, int *ptime, char *str)
 {
     if (!str || !strcmp(str, "1ms")) {
-        *ptime = AUDIO_PTIME_1MS;
+        *ptime = MESH_AUDIO_PACKET_TIME_1MS;
         return 0;
     }
     if (!strcmp(str, "125us")) {
-        *ptime = AUDIO_PTIME_125US;
+        *ptime = MESH_AUDIO_PACKET_TIME_125US;
         return 0;
     }
     if (!strcmp(str, "250us")) {
-        *ptime = AUDIO_PTIME_250US;
+        *ptime = MESH_AUDIO_PACKET_TIME_250US;
         return 0;
     }
     if (!strcmp(str, "333us")) {
-        *ptime = AUDIO_PTIME_333US;
+        *ptime = MESH_AUDIO_PACKET_TIME_333US;
         return 0;
     }
     if (!strcmp(str, "4ms")) {
-        *ptime = AUDIO_PTIME_4MS;
+        *ptime = MESH_AUDIO_PACKET_TIME_4MS;
         return 0;
     }
     if (!strcmp(str, "80us")) {
-        *ptime = AUDIO_PTIME_80US;
+        *ptime = MESH_AUDIO_PACKET_TIME_80US;
         return 0;
     }
     if (!strcmp(str, "1.09ms")) {
-        *ptime = AUDIO_PTIME_1_09MS;
+        *ptime = MESH_AUDIO_PACKET_TIME_1_09MS;
         return 0;
     }
     if (!strcmp(str, "0.14ms")) {
-        *ptime = AUDIO_PTIME_0_14MS;
+        *ptime = MESH_AUDIO_PACKET_TIME_0_14MS;
         return 0;
     }
     if (!strcmp(str, "0.09ms")) {
-        *ptime = AUDIO_PTIME_0_09MS;
+        *ptime = MESH_AUDIO_PACKET_TIME_0_09MS;
         return 0;
     }
 
     av_log(avctx, AV_LOG_ERROR, "Audio packet time not supported\n");
     return AVERROR(EINVAL);
-}
-
-/* Check compatibility of ST2110-30 related audio parameters */
-int mcm_check_audio_params_compat(mcm_audio_sampling sample_rate,
-                                  mcm_audio_ptime ptime)
-{
-    switch (sample_rate) {
-    case AUDIO_SAMPLING_48K:
-    case AUDIO_SAMPLING_96K:
-        switch (ptime) {
-        case AUDIO_PTIME_1MS:
-        case AUDIO_PTIME_125US:
-        case AUDIO_PTIME_250US:
-        case AUDIO_PTIME_333US:
-        case AUDIO_PTIME_4MS:
-        case AUDIO_PTIME_80US:
-            return 0;
-        default:
-            return AVERROR(EINVAL);
-        }
-    case AUDIO_SAMPLING_44K:
-        switch (ptime) {
-        case AUDIO_PTIME_1_09MS:
-        case AUDIO_PTIME_0_14MS:
-        case AUDIO_PTIME_0_09MS:
-            return 0;
-        default:
-            return AVERROR(EINVAL);
-        }
-    default:
-        return AVERROR(EINVAL);
-    }
 }

--- a/ffmpeg-plugin/mcm_common.h
+++ b/ffmpeg-plugin/mcm_common.h
@@ -12,24 +12,26 @@ extern "C" {
 #endif
 
 #include "libavformat/avformat.h"
-#include <mcm_dp.h>
 #include "libavdevice/version.h"
+#include <mesh_dp.h>
 #if LIBAVDEVICE_VERSION_MAJOR <= 60
 #define MCM_FFMPEG_6_1
 #else /* LIBAVDEVICE_VERSION_MAJOR <= 60 */
 #define MCM_FFMPEG_7_0
 #endif /* LIBAVDEVICE_VERSION_MAJOR <= 60 */
 
-int mcm_parse_conn_param(AVFormatContext* avctx, mcm_conn_param *param,
-                         transfer_type type, char *ip_addr, char *port,
+int mcm_put_client(MeshClient **mc);
+int mcm_get_client(MeshClient **mc);
+int mcm_parse_conn_param(AVFormatContext* avctx, MeshConnection *conn,
+                         int kind, char *ip_addr, char *port,
                          char *protocol_type, char *payload_type,
                          char *socket_name, int interface_id);
-int mcm_parse_audio_sample_rate(AVFormatContext* avctx, mcm_audio_sampling *sample_rate,
+int mcm_parse_video_pix_fmt(AVFormatContext* avctx, int *pix_fmt,
+                            enum AVPixelFormat value);
+int mcm_parse_audio_sample_rate(AVFormatContext* avctx, int *sample_rate,
                                 int value);
-int mcm_parse_audio_packet_time(AVFormatContext* avctx, mcm_audio_ptime *ptime,
-                                char *str);
-int mcm_check_audio_params_compat(mcm_audio_sampling sample_rate,
-                                  mcm_audio_ptime ptime);
+int mcm_parse_audio_packet_time(AVFormatContext* avctx, int *ptime, char *str);
+
 
 #ifdef __cplusplus
 }

--- a/ffmpeg-plugin/mcm_video_rx.c
+++ b/ffmpeg-plugin/mcm_video_rx.c
@@ -35,7 +35,6 @@ typedef struct McmVideoDemuxerContext {
     MeshClient *mc;
     MeshConnection *conn;
     bool first_frame;
-
 } McmVideoDemuxerContext;
 
 static int mcm_video_read_header(AVFormatContext* avctx)

--- a/ffmpeg-plugin/mcm_video_rx.c
+++ b/ffmpeg-plugin/mcm_video_rx.c
@@ -7,12 +7,11 @@
 #include "libavutil/log.h"
 #include "libavutil/opt.h"
 #include "libavutil/internal.h"
-#include "libavutil/pixdesc.h"
 #include "libavformat/avformat.h"
 #include "libavformat/mux.h"
 #include "libavformat/internal.h"
+#include "libavutil/pixdesc.h"
 #include "libavdevice/mcm_common.h"
-#include <mcm_dp.h>
 #ifdef MCM_FFMPEG_7_0
 #include "libavformat/demux.h"
 #endif /* MCM_FFMPEG_7_0 */
@@ -33,103 +32,75 @@ typedef struct McmVideoDemuxerContext {
     enum AVPixelFormat pixel_format;
     AVRational frame_rate;
 
-    mcm_conn_context *rx_handle;
+    MeshClient *mc;
+    MeshConnection *conn;
     bool first_frame;
-    int frame_size;
-} McmVideoDemuxerContext;
 
-static int getFrameSize(video_pixel_format fmt, uint32_t width, uint32_t height, bool interlaced)
-{
-    size_t size = 0;
-    size_t pixels = (size_t)(width*height);
-    switch (fmt) {
-        case PIX_FMT_YUV422P: /* YUV 422 packed 8bit(aka ST20_FMT_YUV_422_8BIT, aka ST_FRAME_FMT_UYVY) */
-            size = pixels * 2;
-            break;
-        case PIX_FMT_RGB8:
-            size = pixels * 3; /* 8 bits RGB pixel in a 24 bits (aka ST_FRAME_FMT_RGB8) */
-            break;
-/* Customized YUV 420 8bit, set transport format as ST20_FMT_YUV_420_8BIT. For direct transport of
-none-RFC4175 formats like I420/NV12. When this input/output format is set, the frame is identical to
-transport frame without conversion. The frame should not have lines padding) */
-        case PIX_FMT_NV12: /* PIX_FMT_NV12, YUV 420 planar 8bits (aka ST_FRAME_FMT_YUV420CUSTOM8, aka ST_FRAME_FMT_YUV420PLANAR8) */
-            size = pixels * 3 / 2;
-            break;
-        case PIX_FMT_YUV444P_10BIT_LE:
-            size = pixels * 2 * 3;
-            break;
-        case PIX_FMT_YUV422P_10BIT_LE: /* YUV 422 planar 10bits little indian, in two bytes (aka ST_FRAME_FMT_YUV422PLANAR10LE) */
-        default:
-            size = pixels * 2 * 2;
-            break;
-    }
-    if (interlaced) size /= 2; /* if all fmt support interlace? */
-    return (int)size;
-}
+} McmVideoDemuxerContext;
 
 static int mcm_video_read_header(AVFormatContext* avctx)
 {
     McmVideoDemuxerContext *s = avctx->priv_data;
-    mcm_conn_param param = { 0 };
+    int kind = MESH_CONN_KIND_RECEIVER;
+    MeshConfig_Video cfg;
     AVStream *st;
     int err;
 
-    err = mcm_parse_conn_param(avctx, &param, is_rx, s->ip_addr, s->port,
-                               s->protocol_type, s->payload_type, s->socket_name,
-                               s->interface_id);
+    /* video format */
+    cfg.width = s->width;
+    cfg.height = s->height;
+    cfg.fps = av_q2d(s->frame_rate);
+
+    err = mcm_parse_video_pix_fmt(avctx, &cfg.pixel_format, s->pixel_format);
     if (err)
         return err;
 
-    switch (param.payload_type) {
-    case PAYLOAD_TYPE_RTSP_VIDEO:
-    case PAYLOAD_TYPE_ST20_VIDEO:
-    case PAYLOAD_TYPE_ST22_VIDEO:
-        /* video format */
-        param.payload_args.video_args.width   = param.width = s->width;
-        param.payload_args.video_args.height  = param.height = s->height;
-        param.payload_args.video_args.fps     = param.fps = av_q2d(s->frame_rate);
-
-        switch (s->pixel_format) {
-        case AV_PIX_FMT_NV12:
-            param.pix_fmt = PIX_FMT_NV12;
-            break;
-        case AV_PIX_FMT_YUV422P:
-            param.pix_fmt = PIX_FMT_YUV422P;
-            break;
-        case AV_PIX_FMT_YUV444P10LE:
-            param.pix_fmt = PIX_FMT_YUV444P_10BIT_LE;
-            break;
-        case AV_PIX_FMT_RGB24:
-            param.pix_fmt = PIX_FMT_RGB8;
-            break;
-        case AV_PIX_FMT_YUV422P10LE:
-        default:
-            param.pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
-        }
-
-        param.payload_args.video_args.pix_fmt = param.pix_fmt;
-        break;
-
-    default:
-        av_log(avctx, AV_LOG_ERROR, "Unknown payload type\n");
+    err = mcm_get_client(&s->mc);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Get mesh client failed: %s (%d)\n",
+               mesh_err2str(err), err);
         return AVERROR(EINVAL);
     }
 
-    s->frame_size = getFrameSize(param.pix_fmt, s->width, s->height, false);
-    if (s->frame_size <= 0) {
-        av_log(avctx, AV_LOG_ERROR, "calculate frame size failed\n");
-        return AVERROR(EIO);
+    err = mesh_create_connection(s->mc, &s->conn);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Create connection failed: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EIO);
+        goto exit_put_client;
     }
 
-    s->rx_handle = mcm_create_connection(&param);
-    if (!s->rx_handle) {
-        av_log(avctx, AV_LOG_ERROR, "create connection failed\n");
-        return AVERROR(EIO);
+    err = mcm_parse_conn_param(avctx, s->conn, kind, s->ip_addr, s->port,
+                                  s->protocol_type, s->payload_type,
+                                  s->socket_name, s->interface_id);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Configuration parsing failed: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EINVAL);
+        goto exit_delete_conn;
+    }
+
+    err = mesh_apply_connection_config_video(s->conn, &cfg);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Failed to apply connection config: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EIO);
+        goto exit_delete_conn;
+    }
+
+    err = mesh_establish_connection(s->conn, kind);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Cannot establish connection: %s (%d)\n",
+               mesh_err2str(err), err);
+        err = AVERROR(EIO);
+        goto exit_delete_conn;
     }
 
     st = avformat_new_stream(avctx, NULL);
-    if (!st)
-        return AVERROR(ENOMEM);
+    if (!st) {
+        err = AVERROR(ENOMEM);
+        goto exit_delete_conn;
+    }
 
     avpriv_set_pts_info(st, 64, s->frame_rate.den, s->frame_rate.num);
 
@@ -146,47 +117,65 @@ static int mcm_video_read_header(AVFormatContext* avctx)
            s->width, s->height, av_get_pix_fmt_name(s->pixel_format),
            (int)av_q2d(s->frame_rate));
     return 0;
+
+exit_delete_conn:
+    mesh_delete_connection(&s->conn);
+
+exit_put_client:
+    mcm_put_client(&s->mc);
+    return err;
 }
 
 static int mcm_video_read_packet(AVFormatContext* avctx, AVPacket* pkt)
 {
     McmVideoDemuxerContext *s = avctx->priv_data;
-    mcm_buffer *buf = NULL;
-    int timeout = s->first_frame ? -1 : 1000;
-    int err = 0;
-    int ret;
+    MeshBuffer *buf;
+    int timeout = s->first_frame ? MESH_TIMEOUT_INFINITE : 1000;
+    int err, ret;
 
     s->first_frame = false;
 
-    buf = mcm_dequeue_buffer(s->rx_handle, timeout, &err);
-    if (buf == NULL) {
-        if (!err)
-            return AVERROR_EOF;
+    err = mesh_get_buffer_timeout(s->conn, &buf, timeout);
+    if (err == -MESH_ERR_CONN_CLOSED)
+        return AVERROR_EOF;
 
-        av_log(avctx, AV_LOG_ERROR, "dequeue buffer error %d\n", err);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Get buffer error: %s (%d)\n",
+               mesh_err2str(err), err);
         return AVERROR(EIO);
     }
 
-    if ((ret = av_new_packet(pkt, s->frame_size)) < 0)
+    if ((ret = av_new_packet(pkt, s->conn->buf_size)) < 0)
         return ret;
 
-    memcpy(pkt->data, buf->data, FFMIN(s->frame_size, buf->len));
+    memcpy(pkt->data, buf->data, FFMIN(s->conn->buf_size, buf->data_len));
 
     pkt->pts = pkt->dts = AV_NOPTS_VALUE;
 
-    if ((err = mcm_enqueue_buffer(s->rx_handle, buf)) != 0) {
-        av_log(avctx, AV_LOG_ERROR, "enqueue buffer error %d\n", err);
+    err = mesh_put_buffer(&buf);
+    if (err) {
+        av_log(avctx, AV_LOG_ERROR, "Put buffer error: %s (%d)\n",
+               mesh_err2str(err), err);
         return AVERROR(EIO);
     }
 
-    return s->frame_size;
+    return s->conn->buf_size;
 }
 
 static int mcm_video_read_close(AVFormatContext* avctx)
 {
     McmVideoDemuxerContext* s = avctx->priv_data;
+    int err;
 
-    mcm_destroy_connection(s->rx_handle);
+    err = mesh_delete_connection(&s->conn);
+    if (err)
+        av_log(avctx, AV_LOG_ERROR, "Delete mesh connection failed: %s (%d)\n",
+               mesh_err2str(err), err);
+
+    err = mcm_put_client(&s->mc);
+    if (err)
+        av_log(avctx, AV_LOG_ERROR, "Put mesh client failed (%d)\n", err);
+
     return 0;
 }
 

--- a/ffmpeg-plugin/mcm_video_tx.c
+++ b/ffmpeg-plugin/mcm_video_tx.c
@@ -30,8 +30,7 @@ typedef struct McmVideoMuxerContext {
 
     MeshClient *mc;
     MeshConnection *conn;
-
- } McmVideoMuxerContext;
+} McmVideoMuxerContext;
 
 static int mcm_video_write_header(AVFormatContext* avctx)
 {

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -68,7 +68,7 @@ set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)
 
 list(APPEND SDK_HEADERS
-    include/mcm_dp.h
+    # include/mcm_dp.h
     include/mesh_dp.h
 )
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -69,6 +69,7 @@ include(CPack)
 
 list(APPEND SDK_HEADERS
     include/mcm_dp.h
+    include/mesh_dp.h
 )
 
 foreach(file ${SDK_HEADERS})

--- a/sdk/include/mesh_dp.h
+++ b/sdk/include/mesh_dp.h
@@ -1,0 +1,352 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __MESH_DP_H
+#define __MESH_DP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "libmemif.h"
+
+/**
+ * Mesh SDK API version
+ */
+#define MESH_VERSION "24.09"
+#define MESH_VERSION_MAJOR  24
+#define MESH_VERSION_MINOR  9
+#define MESH_VERSION_HOTFIX 0
+
+/**
+ * Mesh client structure
+ */
+typedef struct{} MeshClient;
+
+/**
+ * Mesh client configuration structure
+ */
+typedef struct MeshClientConfig {
+    /**
+     * Default timeout interval for any API call
+     */
+    int timeout_ms;
+
+    /**
+     * Max number of connections
+     */
+    int max_conn_num;
+
+} MeshClientConfig;
+
+/**
+ * Mesh connection structure
+ */
+typedef struct MeshConnection {
+    /**
+     * Parent mesh client;
+     */
+    MeshClient * const client;
+    /**
+     * Buffer size, or frame size, configured for the connection.
+     * This value is the maximum length of data the buffer may contain.
+     * It is calculated once before the connection is created and cannot be
+     * altered thereafter. The calculation is based on the payload type and
+     * payload parameters.
+     * For video payload, this value is the video frame size.
+     * For audio payload, this value is the audio packet size.
+     */
+    const size_t buf_size;
+
+} MeshConnection;
+
+/**
+ * Define configuration string field sizes
+ */
+#define MESH_SOCKET_PATH_SIZE   108
+#define MESH_IP_ADDRESS_SIZE    46
+
+/**
+ * Mesh configuration for Single node direct connection via memif
+ */
+typedef struct MeshConfig_Memif {
+    /**
+     * Memif socket path.
+     * Example: /run/mcm/mcm_memif_0.sock
+     */
+    char socket_path[MESH_SOCKET_PATH_SIZE];
+    /**
+     * Memif interface id.
+     * Default: 0
+     */
+    int interface_id;
+
+} MeshConfig_Memif;
+
+/**
+ * Mesh configuration for SMPTE ST2110-xx connection via Media Proxy
+ */
+typedef struct MeshConfig_ST2110 {
+    /**
+     * Remote IP address
+     */
+    char remote_ip_addr[MESH_IP_ADDRESS_SIZE];
+    /**
+     * Remote port
+     */
+    uint16_t remote_port;
+    /**
+     * Local IP address
+     */
+    char local_ip_addr[MESH_IP_ADDRESS_SIZE];
+    /**
+     * Local port
+     */
+    uint16_t local_port;
+    /**
+     * SMPTE ST2110-xx transport type.
+     * Must be aligned with the payload type.
+     * Any value of the MESH_CONN_TRANSPORT_ST2110_* constants.
+     */
+    int transport;
+#define MESH_CONN_TRANSPORT_ST2110_20 0 ///< SMPTE ST2110-20 Uncompressed Video transport
+#define MESH_CONN_TRANSPORT_ST2110_22 1 ///< SMPTE ST2110-22 Constant Bit-Rate Compressed Video transport
+#define MESH_CONN_TRANSPORT_ST2110_30 2 ///< SMPTE ST2110-30 Audio transport
+
+} MeshConfig_ST2110;
+
+/**
+ * Mesh configuration for RDMA connection via Media Proxy
+ */
+typedef struct MeshConfig_RDMA {
+            /**
+             * Remote IP address
+             */
+            char remote_ip_addr[MESH_IP_ADDRESS_SIZE];
+            /**
+             * Remote port
+             */
+            uint16_t remote_port;
+            /**
+             * Local IP address
+             */
+            char local_ip_addr[MESH_IP_ADDRESS_SIZE];
+            /**
+             * Local port
+             */
+            uint16_t local_port;
+
+} MeshConfig_RDMA;
+
+/**
+ * Mesh payload configuration for Video frames
+ */
+typedef struct MeshConfig_Video {
+    /**
+     * Video frame width in pixels.
+     */
+    int width;
+    /**
+     * Video frame height in pixels.
+     */
+    int height;
+    /**
+     * Video frames per second.
+     */
+    double fps;
+    /**
+     * Video frame pixel format.
+     * Any value of the MESH_VIDEO_PIXEL_FORMAT_* constants.
+     */
+    int pixel_format;
+#define MESH_VIDEO_PIXEL_FORMAT_NV12        0 ///< planar YUV 4:2:0, 12bpp
+#define MESH_VIDEO_PIXEL_FORMAT_YUV422P     1 ///< planar YUV 4:2:2, 16bpp
+#define MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE 2 ///< planar YUV 4:2:2, 20bpp
+#define MESH_VIDEO_PIXEL_FORMAT_YUV444P10LE 3 ///< planar YUV 4:4:4, 30bpp
+#define MESH_VIDEO_PIXEL_FORMAT_RGB8        4 ///< packed RGB 3:3:2,  8bpp
+
+} MeshConfig_Video;
+
+/**
+ * Mesh payload configuration for Audio packets
+ */
+typedef struct MeshConfig_Audio {
+    /**
+     * Number of audio channels (1, 2, 4, etc.)
+     */
+    int channels;
+    /**
+     * Audio sample rate.
+     * Any value of the MESH_AUDIO_SAMPLE_RATE_* constants.
+     */
+    int sample_rate;
+#define MESH_AUDIO_SAMPLE_RATE_48000 0 ///< Audio sample rate 48000 Hz
+#define MESH_AUDIO_SAMPLE_RATE_96000 1 ///< Audio sample rate 96000 Hz
+#define MESH_AUDIO_SAMPLE_RATE_44100 2 ///< Audio sample rate 44100 Hz
+
+    /**
+     * Audio sample format.
+     * Any value of the MESH_AUDIO_FORMAT_* constants.
+     */
+    int format;
+#define MESH_AUDIO_FORMAT_PCM_S8    0 ///< PCM 8 bits per channel
+#define MESH_AUDIO_FORMAT_PCM_S16BE 1 ///< PCM 16 bits per channel, big endian
+#define MESH_AUDIO_FORMAT_PCM_S24BE 2 ///< PCM 24 bits per channel, big endian
+
+    /**
+     * Audio packet time.
+     * Any value of the MESH_AUDIO_PACKET_TIME_* constants.
+     */
+    int packet_time;
+/** Constants for 48kHz and 96kHz sample rates */
+#define MESH_AUDIO_PACKET_TIME_1MS      0 ///< Audio packet time 1ms
+#define MESH_AUDIO_PACKET_TIME_125US    1 ///< Audio packet time 125us
+#define MESH_AUDIO_PACKET_TIME_250US    2 ///< Audio packet time 250us
+#define MESH_AUDIO_PACKET_TIME_333US    3 ///< Audio packet time 333us
+#define MESH_AUDIO_PACKET_TIME_4MS      4 ///< Audio packet time 4ms
+#define MESH_AUDIO_PACKET_TIME_80US     5 ///< Audio packet time 80us
+/** Constants for 44.1kHz sample rate */
+#define MESH_AUDIO_PACKET_TIME_1_09MS   6 ///< Audio packet time 1.09ms
+#define MESH_AUDIO_PACKET_TIME_0_14MS   7 ///< Audio packet time 0.14ms
+#define MESH_AUDIO_PACKET_TIME_0_09MS   8 ///< Audio packet time 0.09ms
+
+} MeshConfig_Audio;
+
+/**
+ * Mesh shared memory buffer type
+ */
+typedef struct{
+    /**
+     * Parent mesh connection
+     */
+    MeshConnection * const conn;
+    /**
+     * Pointer to shared memory area storing data
+     */
+    void * const data;
+    /**
+     * Actual length of data in the buffer
+     */
+    const size_t data_len;
+
+} MeshBuffer;
+
+/**
+ * Connection kind constants (sender, receiver).
+ */
+#define MESH_CONN_KIND_SENDER   0 ///< Unidirectional connection for sending data
+#define MESH_CONN_KIND_RECEIVER 1 ///< Unidirectional connection for receiving data
+
+/**
+ * Timeout configuration constants
+ */
+#define MESH_TIMEOUT_DEFAULT  -2 ///< Use default timeout defined for mesh client
+#define MESH_TIMEOUT_INFINITE -1 ///< No timeout, block until success or error
+#define MESH_TIMEOUT_ZERO      0 ///< Polling mode, return immediately
+
+/**
+ * Error codes
+ */
+#define MESH_ERR_BAD_CLIENT_PTR       1000 ///< Bad client pointer
+#define MESH_ERR_BAD_CONN_PTR         1001 ///< Bad connection pointer
+#define MESH_ERR_BAD_CONFIG_PTR       1002 ///< Bad configuration pointer
+#define MESH_ERR_BAD_BUF_PTR          1003 ///< Bad buffer pointer
+#define MESH_ERR_MAX_CONN             1004 ///< Reached max connections number
+#define MESH_ERR_CONN_FAILED          1005 ///< Connection creation failed
+#define MESH_ERR_CONN_CONFIG_INVAL    1006 ///< Invalid connection config
+#define MESH_ERR_CONN_CONFIG_INCOMPAT 1007 ///< Incompatible connection config
+#define MESH_ERR_CONN_CLOSED          1008 ///< Connection is closed
+#define MESH_ERR_TIMEOUT              1009 ///< Timeout occurred
+
+/**
+ * Create a new mesh client
+ */
+int mesh_create_client(MeshClient **mc, MeshClientConfig *cfg);
+
+/**
+ * Delete mesh client
+ */
+int mesh_delete_client(MeshClient **mc);
+
+/**
+ * Create a new mesh connection
+ */
+int mesh_create_connection(MeshClient *mc, MeshConnection **conn);
+
+/**
+ * Apply configuration to setup Single node direct connection via memif
+ */
+int mesh_apply_connection_config_memif(MeshConnection *conn, MeshConfig_Memif *cfg);
+
+/**
+ * Apply configuration to setup SMPTE ST2110-xx connection via Media Proxy
+ */
+int mesh_apply_connection_config_st2110(MeshConnection *conn, MeshConfig_ST2110 *cfg);
+
+/**
+ * Apply configuration to setup RDMA connection via Media Proxy
+ */
+int mesh_apply_connection_config_rdma(MeshConnection *conn, MeshConfig_RDMA *cfg);
+
+/**
+ * Apply configuration to setup connection payload for Video frames
+ */
+int mesh_apply_connection_config_video(MeshConnection *conn, MeshConfig_Video *cfg);
+
+/**
+ * Apply configuration to setup connection payload for Audio packets
+ */
+int mesh_apply_connection_config_audio(MeshConnection *conn, MeshConfig_Audio *cfg);
+
+/**
+ * Establish a mesh connection
+ */
+int mesh_establish_connection(MeshConnection *conn, int kind);
+
+/**
+ * Shutdown a mesh connection
+ */
+int mesh_shutdown_connection(MeshConnection *conn);
+
+/**
+ * Delete mesh connection
+ */
+int mesh_delete_connection(MeshConnection **conn);
+
+/**
+ * Get buffer from mesh connection
+ */
+int mesh_get_buffer(MeshConnection *conn, MeshBuffer **buf);
+
+/**
+ * Get buffer from mesh connection with timeout
+ */
+int mesh_get_buffer_timeout(MeshConnection *conn, MeshBuffer **buf,
+                            int timeout_ms);
+
+/**
+ * Put buffer to mesh connection
+ */
+int mesh_put_buffer(MeshBuffer **buf);
+
+/**
+ * Put buffer to mesh connection with timeout
+ */
+int mesh_put_buffer_timeout(MeshBuffer **buf, int timeout_ms);
+
+/**
+ * Get text description of an error code.
+ */
+const char *mesh_err2str(int err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MESH_DP_H */

--- a/sdk/include/mesh_dp.h
+++ b/sdk/include/mesh_dp.h
@@ -70,7 +70,7 @@ typedef struct MeshConnection {
  * Define configuration string field sizes
  */
 #define MESH_SOCKET_PATH_SIZE   108
-#define MESH_IP_ADDRESS_SIZE    46
+#define MESH_IP_ADDRESS_SIZE    253 /* max of [IPv4, IPv6, FQDN] */
 
 /**
  * Mesh configuration for Single node direct connection via memif
@@ -258,90 +258,180 @@ typedef struct{
 #define MESH_ERR_BAD_CONFIG_PTR       1002 ///< Bad configuration pointer
 #define MESH_ERR_BAD_BUF_PTR          1003 ///< Bad buffer pointer
 #define MESH_ERR_MAX_CONN             1004 ///< Reached max connections number
-#define MESH_ERR_CONN_FAILED          1005 ///< Connection creation failed
-#define MESH_ERR_CONN_CONFIG_INVAL    1006 ///< Invalid connection config
-#define MESH_ERR_CONN_CONFIG_INCOMPAT 1007 ///< Incompatible connection config
-#define MESH_ERR_CONN_CLOSED          1008 ///< Connection is closed
-#define MESH_ERR_TIMEOUT              1009 ///< Timeout occurred
+#define MESH_ERR_FOUND_ALLOCATED      1005 ///< Found allocated resources
+#define MESH_ERR_CONN_FAILED          1006 ///< Connection creation failed
+#define MESH_ERR_CONN_CONFIG_INVAL    1007 ///< Invalid connection config
+#define MESH_ERR_CONN_CONFIG_INCOMPAT 1008 ///< Incompatible connection config
+#define MESH_ERR_CONN_CLOSED          1009 ///< Connection is closed
+#define MESH_ERR_TIMEOUT              1010 ///< Timeout occurred
 
 /**
- * Create a new mesh client
+ * @brief Create a new mesh client.
+ * 
+ * Creates a new mesh client from the given configuration structure.
+ * 
+ * @param [out] mc Address of a pointer to a mesh client structure.
+ * @param [in] cfg Pointer to a mesh client configuration structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_create_client(MeshClient **mc, MeshClientConfig *cfg);
 
 /**
- * Delete mesh client
+ * @brief Delete mesh client.
+ * 
+ * Deletes the mesh client and its resources.
+ * 
+ * @param [in,out] mc Address of a pointer to a mesh client structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_delete_client(MeshClient **mc);
 
 /**
- * Create a new mesh connection
+ * @brief Create a new mesh connection.
+ * 
+ * Creates a new media connection for the given mesh client.
+ * 
+ * @param [in] mc Pointer to a parent mesh client.
+ * @param [out] conn Address of a pointer to the connection structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_create_connection(MeshClient *mc, MeshConnection **conn);
 
 /**
- * Apply configuration to setup Single node direct connection via memif
+ * @brief Apply configuration to setup Single node direct connection via memif.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [in] cfg Pointer to a configuration structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_apply_connection_config_memif(MeshConnection *conn, MeshConfig_Memif *cfg);
 
 /**
- * Apply configuration to setup SMPTE ST2110-xx connection via Media Proxy
+ * @brief Apply configuration to setup SMPTE ST2110-xx connection via Media Proxy.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [in] cfg Pointer to a configuration structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_apply_connection_config_st2110(MeshConnection *conn, MeshConfig_ST2110 *cfg);
 
 /**
- * Apply configuration to setup RDMA connection via Media Proxy
+ * @brief Apply configuration to setup RDMA connection via Media Proxy.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [in] cfg Pointer to a configuration structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_apply_connection_config_rdma(MeshConnection *conn, MeshConfig_RDMA *cfg);
 
 /**
- * Apply configuration to setup connection payload for Video frames
+ * @brief Apply configuration to setup connection payload for Video frames.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [in] cfg Pointer to a configuration structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_apply_connection_config_video(MeshConnection *conn, MeshConfig_Video *cfg);
 
 /**
- * Apply configuration to setup connection payload for Audio packets
+ * @brief Apply configuration to setup connection payload for Audio packets.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [in] cfg Pointer to a configuration structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_apply_connection_config_audio(MeshConnection *conn, MeshConfig_Audio *cfg);
 
 /**
- * Establish a mesh connection
+ * @brief Establish a mesh connection.
+ * 
+ * Checks the previously applied configuration for parameter compatibility
+ * and establishes a mesh connection of the given kind (sender or receiver).
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [in] kind Connection kind: Sender or Receiver.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_establish_connection(MeshConnection *conn, int kind);
 
 /**
- * Shutdown a mesh connection
+ * @brief Shutdown a mesh connection.
+ * 
+ * Closes the active mesh connection.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_shutdown_connection(MeshConnection *conn);
 
 /**
- * Delete mesh connection
+ * @brief Delete mesh connection.
+ * 
+ * Deletes the connection and its resources.
+ * 
+ * @param [in,out] conn Address of a pointer to the connection structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_delete_connection(MeshConnection **conn);
 
 /**
- * Get buffer from mesh connection
+ * @brief Get buffer from mesh connection.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [out] buf Address of a pointer to a mesh buffer structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_get_buffer(MeshConnection *conn, MeshBuffer **buf);
 
 /**
- * Get buffer from mesh connection with timeout
+ * @brief Get buffer from mesh connection with timeout.
+ * 
+ * @param [in] conn Pointer to a connection structure.
+ * @param [out] buf Address of a pointer to a mesh buffer structure.
+ * @param [in] timeout_ms Timeout interval in milliseconds.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_get_buffer_timeout(MeshConnection *conn, MeshBuffer **buf,
                             int timeout_ms);
 
 /**
- * Put buffer to mesh connection
+ * @brief Put buffer to mesh connection.
+ * 
+ * @param [in,out] buf Address of a pointer to a mesh buffer structure.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_put_buffer(MeshBuffer **buf);
 
 /**
- * Put buffer to mesh connection with timeout
+ * @brief Put buffer to mesh connection with timeout.
+ * 
+ * @param [in,out] buf Address of a pointer to a mesh buffer structure.
+ * @param [in] timeout_ms Timeout interval in milliseconds.
+ * 
+ * @return 0 on success; an error code otherwise.
  */
 int mesh_put_buffer_timeout(MeshBuffer **buf, int timeout_ms);
 
 /**
- * Get text description of an error code.
+ * @brief Get text description of an error code.
+ * 
+ * @param [in] err Error code returned from any Mesh Data Plane API call.
+ * 
+ * @return NULL-terminated string describing the error code.
  */
 const char *mesh_err2str(int err);
 

--- a/sdk/include/mesh_dp_internal.h
+++ b/sdk/include/mesh_dp_internal.h
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __MESH_DP_INTERNAL_H
+#define __MESH_DP_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mesh_dp.h"
+#include "mcm_dp.h"
+#include <sys/queue.h>
+
+/**
+ * Mesh connection context structure
+ */
+typedef struct MeshConnectionContext {
+    /**
+     * NOTE: The __public structure is directly mapped in the memory to the
+     * MeshConnection structure, which is publicly accessible to the user.
+     * Therefore, the __public structure _MUST_ be placed first here.
+     */
+    MeshConnection __public;
+
+    /**
+     * NOTE: All declarations below this point are hidden from the user.
+     */
+
+    /**
+     * Connections list entry registered in the Mesh client.
+     */
+    LIST_ENTRY(MeshConnectionContext) conns;
+
+    /**
+     * MCM connection handle.
+     */
+    mcm_conn_context *handle;
+
+    /**
+     * Configuration structure
+     */
+    struct {
+        /**
+         * Connection kind (sender, receiver).
+         * Any value of the MESH_CONN_KIND_* constants.
+         */
+        int kind;
+
+        /**
+         * Connection type (memif, SMPTE ST2110-XX, RDMA).
+         * Any value of the MESH_CONN_TYPE_* constants.
+         */
+        int conn_type;
+#define MESH_CONN_TYPE_MEMIF  0 ///< Single node direct connection via memif
+#define MESH_CONN_TYPE_ST2110 1 ///< SMPTE ST2110-xx connection via Media Proxy
+#define MESH_CONN_TYPE_RDMA   2 ///< RDMA connection via Media Proxy
+
+        /**
+         * Configuration structures of all connection types
+         */
+        union {
+            MeshConfig_Memif memif;
+            MeshConfig_ST2110 st2110;
+            MeshConfig_RDMA rdma;
+        } conn;
+
+        /**
+         * Payload type (video, audio).
+         * Any value of the MESH_PAYLOAD_TYPE_* constants.
+         */
+        int payload_type;
+#define MESH_PAYLOAD_TYPE_VIDEO 0 ///< payload: video frames
+#define MESH_PAYLOAD_TYPE_AUDIO 1 ///< payload: audio packets
+
+        /**
+         * Configuration structures of all payload types
+         */
+        union {
+            MeshConfig_Video video;
+            MeshConfig_Audio audio;
+        } payload;
+    } cfg;
+
+} MeshConnectionContext;
+
+/**
+ * Heap zeroed allocation function definition
+ */
+#define mesh_calloc(size) calloc(1, size)
+
+/**
+ * Heap memory deallocation function definition
+ */
+#define mesh_free(ptr) free(ptr)
+
+/**
+ * Memory copy function definition
+ */
+#define mesh_memcpy(dst, src, size) memcpy(dst, src, size)
+
+/**
+ * String size-bounded copy function definition
+ */
+#define mesh_strlcpy(dst, src, size) strlcpy(dst, src, size)
+
+/**
+ * Max number of connections handled by mesh client by default
+ */
+#define MESH_CLIENT_DEFAULT_MAX_CONN 1024
+
+/**
+ * Default timeout applied to all mesh client operations
+ */
+#define MESH_CLIENT_DEFAULT_TIMEOUT_MS (MESH_TIMEOUT_INFINITE)
+
+/**
+ * Constants for marking uninitialized resources
+ */
+#define MESH_CONN_TYPE_UNINITIALIZED    -1 ///< Connection type is uninitialized
+#define MESH_PAYLOAD_TYPE_UNINITIALIZED -1 ///< Payload type is uninitialized
+
+/**
+ * Isolation interface for testability. Accessed from unit tests only.
+ */
+struct mesh_internal_ops_t {
+    mcm_conn_context * (*create_conn)(mcm_conn_param *param);
+    void (*destroy_conn)(mcm_conn_context *pctx);
+    mcm_buffer * (*dequeue_buf)(mcm_conn_context *pctx, int timeout, int *error_code);
+    int (*enqueue_buf)(mcm_conn_context *pctx, mcm_buffer *buf);
+};
+
+extern struct mesh_internal_ops_t mesh_internal_ops;
+
+/**
+ * Parse payload configuration
+ */
+int mesh_parse_payload_config(MeshConnectionContext *conn, mcm_conn_param *param);
+/**
+ * Parse connection configuration and check for for wrong or incompatible
+ * parameter values.
+ */
+int mesh_parse_conn_config(MeshConnectionContext *ctx, mcm_conn_param *param);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MESH_DP_INTERNAL_H */

--- a/sdk/include/mesh_dp_internal.h
+++ b/sdk/include/mesh_dp_internal.h
@@ -88,26 +88,6 @@ typedef struct MeshConnectionContext {
 } MeshConnectionContext;
 
 /**
- * Heap zeroed allocation function definition
- */
-#define mesh_calloc(size) calloc(1, size)
-
-/**
- * Heap memory deallocation function definition
- */
-#define mesh_free(ptr) free(ptr)
-
-/**
- * Memory copy function definition
- */
-#define mesh_memcpy(dst, src, size) memcpy(dst, src, size)
-
-/**
- * String size-bounded copy function definition
- */
-#define mesh_strlcpy(dst, src, size) strlcpy(dst, src, size)
-
-/**
  * Max number of connections handled by mesh client by default
  */
 #define MESH_CLIENT_DEFAULT_MAX_CONN 1024

--- a/sdk/src/mcm_dp.c
+++ b/sdk/src/mcm_dp.c
@@ -146,6 +146,10 @@ static void parse_memif_param(mcm_conn_param* request, memif_socket_args_t* memi
             log_error("Invalid audio parameters.");
         break;
 
+    case PAYLOAD_TYPE_RDMA_VIDEO:
+        request->payload_args.rdma_args.transfer_size = (size_t)request->payload_args.video_args.width * request->payload_args.video_args.height * 4;
+        /* NOTE: fall through here intentionally */
+
     case PAYLOAD_TYPE_ST20_VIDEO:
     case PAYLOAD_TYPE_ST22_VIDEO:
     case PAYLOAD_TYPE_RTSP_VIDEO:

--- a/sdk/src/mesh_dp.c
+++ b/sdk/src/mesh_dp.c
@@ -1,0 +1,779 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <pthread.h>
+#include "mesh_dp_internal.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <bsd/string.h>
+#include <stdatomic.h>
+#include <unistd.h>
+
+/**
+ * Isolation interface for testability. Accessed from unit tests only.
+ */
+struct mesh_internal_ops_t mesh_internal_ops = {
+    .create_conn = mcm_create_connection,
+    .destroy_conn = mcm_destroy_connection,
+    .dequeue_buf = mcm_dequeue_buffer,
+    .enqueue_buf = mcm_enqueue_buffer,
+};
+
+/**
+ * Connection list head type definition
+ */
+LIST_HEAD(MeshConnectionListHead, MeshConnectionContext);
+
+/**
+ * Mesh client context structure
+ */
+typedef struct MeshClientContext {
+    MeshClientConfig config;
+
+    struct MeshConnectionListHead conn_list_head;
+    pthread_mutex_t mx;
+
+    atomic_int conn_num;
+
+} MeshClientContext;
+
+/**
+ * Mesh connection buffer structure
+ */
+typedef struct MeshBufferContext {
+    /**
+     * NOTE: The __public structure is directly mapped in the memory to the
+     * MeshBuffer structure, which is publicly accessible to the user.
+     * Therefore, the __public structure _MUST_ be placed first here.
+     */
+    MeshBuffer __public;
+
+    /**
+     * NOTE: All declarations below this point are hidden from the user.
+     */
+    mcm_buffer *buf;
+
+} MeshBufferContext;
+
+/**
+ * Create a new mesh client
+ */
+int mesh_create_client(MeshClient **mc, MeshClientConfig *cfg)
+{
+    MeshClientContext *mc_ctx;
+    int err;
+
+    if (!mc)
+        return -MESH_ERR_BAD_CLIENT_PTR;
+
+    mc_ctx = mesh_calloc(sizeof(MeshClientContext));
+    if (!mc_ctx) {
+        *mc = NULL;
+        return -ENOMEM;
+    }
+
+    atomic_init(&mc_ctx->conn_num, 0);
+
+    err = pthread_mutex_init(&mc_ctx->mx, NULL);
+    if (err) {
+        mesh_free(mc_ctx);
+        *mc = NULL;
+        return err;
+    }
+
+    LIST_INIT(&mc_ctx->conn_list_head);
+
+    if (cfg)
+        mesh_memcpy(&mc_ctx->config, cfg, sizeof(MeshClientConfig));
+
+    if (mc_ctx->config.max_conn_num == 0)
+        mc_ctx->config.max_conn_num = MESH_CLIENT_DEFAULT_MAX_CONN;
+
+    if (mc_ctx->config.timeout_ms == 0)
+        mc_ctx->config.timeout_ms = MESH_CLIENT_DEFAULT_TIMEOUT_MS;
+
+    *mc = (MeshClient *)mc_ctx;
+
+    return 0;
+}
+
+/**
+ * Delete mesh client
+ */
+int mesh_delete_client(MeshClient **mc)
+{
+    MeshClientContext *mc_ctx;
+
+    if (!mc)
+        return -MESH_ERR_BAD_CLIENT_PTR;
+
+    mc_ctx = (MeshClientContext *)(*mc);
+
+    if (!mc_ctx)
+        return -MESH_ERR_BAD_CLIENT_PTR;
+
+    pthread_mutex_destroy(&mc_ctx->mx);
+
+    /**
+     * TODO: Shutdown and deallocate connections here
+     */
+
+    mesh_free(mc_ctx);
+    *mc = NULL;
+
+    return 0;
+}
+
+/**
+ * Create a new mesh connection
+ */
+int mesh_create_connection(MeshClient *mc, MeshConnection **conn)
+{
+    MeshConnectionContext *conn_ctx;
+    MeshClientContext *mc_ctx;
+    int conn_num, err;
+
+    if (!mc)
+        return -MESH_ERR_BAD_CLIENT_PTR;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    mc_ctx = (MeshClientContext *)mc;
+
+    conn_num = atomic_load_explicit(&mc_ctx->conn_num, memory_order_relaxed);
+    while (conn_num < mc_ctx->config.max_conn_num) {
+        if (atomic_compare_exchange_weak_explicit(&mc_ctx->conn_num, &conn_num,
+                                                  conn_num + 1,
+                                                  memory_order_release,
+                                                  memory_order_relaxed))
+            break;
+    }
+    if (!(conn_num < mc_ctx->config.max_conn_num))
+        return -MESH_ERR_MAX_CONN;
+
+    conn_ctx = mesh_calloc(sizeof(MeshConnectionContext));
+    if (!conn_ctx) {
+        err = -ENOMEM;
+        goto exit_dec_conn_num;
+    }
+
+    *(MeshClient **)&conn_ctx->__public.client = mc;
+
+    conn_ctx->cfg.conn_type = MESH_CONN_TYPE_UNINITIALIZED;
+    conn_ctx->cfg.payload_type = MESH_PAYLOAD_TYPE_UNINITIALIZED;
+
+    err = pthread_mutex_lock(&mc_ctx->mx);
+    if (err)
+        goto exit_dealloc_conn;
+
+    LIST_INSERT_HEAD(&mc_ctx->conn_list_head, conn_ctx, conns);
+
+    pthread_mutex_unlock(&mc_ctx->mx);
+
+    *conn = (MeshConnection *)conn_ctx;
+
+    return 0;
+
+exit_dealloc_conn:
+    mesh_free(conn_ctx);
+
+exit_dec_conn_num:
+    atomic_fetch_sub(&mc_ctx->conn_num, 1);
+
+    return err;
+}
+
+/**
+ * Apply configuration to setup Single node direct connection via memif
+ */
+int mesh_apply_connection_config_memif(MeshConnection *conn, MeshConfig_Memif *cfg)
+{
+    MeshConnectionContext *conn_ctx;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    if (!cfg)
+        return -MESH_ERR_BAD_CONFIG_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+    conn_ctx->cfg.conn_type = MESH_CONN_TYPE_MEMIF;
+    mesh_memcpy(&conn_ctx->cfg.conn.memif, cfg, sizeof(MeshConfig_Memif));
+
+    return 0;
+}
+
+/**
+ * Apply configuration to setup SMPTE ST2110-xx connection via Media Proxy
+ */
+int mesh_apply_connection_config_st2110(MeshConnection *conn, MeshConfig_ST2110 *cfg)
+{
+    MeshConnectionContext *conn_ctx;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    if (!cfg)
+        return -MESH_ERR_BAD_CONFIG_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+    conn_ctx->cfg.conn_type = MESH_CONN_TYPE_ST2110;
+    mesh_memcpy(&conn_ctx->cfg.conn.st2110, cfg, sizeof(MeshConfig_ST2110));
+
+    return 0;
+}
+
+/**
+ * Apply configuration to setup RDMA connection via Media Proxy
+ */
+int mesh_apply_connection_config_rdma(MeshConnection *conn, MeshConfig_RDMA *cfg)
+{
+    MeshConnectionContext *conn_ctx;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    if (!cfg)
+        return -MESH_ERR_BAD_CONFIG_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+    conn_ctx->cfg.conn_type = MESH_CONN_TYPE_RDMA;
+    mesh_memcpy(&conn_ctx->cfg.conn.rdma, cfg, sizeof(MeshConfig_RDMA));
+
+    return 0;
+}
+
+/**
+ * Apply configuration to setup connection payload for Video frames
+ */
+int mesh_apply_connection_config_video(MeshConnection *conn, MeshConfig_Video *cfg)
+{
+    MeshConnectionContext *conn_ctx;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    if (!cfg)
+        return -MESH_ERR_BAD_CONFIG_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+    conn_ctx->cfg.payload_type = MESH_PAYLOAD_TYPE_VIDEO;
+    mesh_memcpy(&conn_ctx->cfg.payload.video, cfg, sizeof(MeshConfig_Video));
+
+    return 0;
+}
+
+/**
+ * Apply configuration to setup connection payload for Audio packets
+ */
+int mesh_apply_connection_config_audio(MeshConnection *conn, MeshConfig_Audio *cfg)
+{
+    MeshConnectionContext *conn_ctx;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    if (!cfg)
+        return -MESH_ERR_BAD_CONFIG_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+    conn_ctx->cfg.payload_type = MESH_PAYLOAD_TYPE_AUDIO;
+    mesh_memcpy(&conn_ctx->cfg.payload.audio, cfg, sizeof(MeshConfig_Audio));
+
+    return 0;
+}
+
+/**
+ * Parse payload configuration
+ */
+int mesh_parse_payload_config(MeshConnectionContext *conn, mcm_conn_param *param)
+{
+    /**
+     * Parse video payload parameters
+     */
+    if (conn->cfg.payload_type == MESH_PAYLOAD_TYPE_VIDEO) {
+
+        switch (conn->cfg.payload.video.pixel_format) {
+        case MESH_VIDEO_PIXEL_FORMAT_NV12:
+            param->pix_fmt = PIX_FMT_NV12;
+            break;            
+        case MESH_VIDEO_PIXEL_FORMAT_YUV422P:
+            param->pix_fmt = PIX_FMT_YUV422P;
+            break;            
+        case MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE:
+            param->pix_fmt = PIX_FMT_YUV422P_10BIT_LE;
+            break;
+        case MESH_VIDEO_PIXEL_FORMAT_YUV444P10LE:
+            param->pix_fmt = PIX_FMT_YUV444P_10BIT_LE;
+            break;
+        case MESH_VIDEO_PIXEL_FORMAT_RGB8:
+            param->pix_fmt = PIX_FMT_RGB8;
+            break;
+        default:
+            return -MESH_ERR_CONN_CONFIG_INVAL;
+        }
+
+        param->payload_args.video_args.pix_fmt = param->pix_fmt;
+        param->payload_args.video_args.width   = conn->cfg.payload.video.width;
+        param->width                           = conn->cfg.payload.video.width;
+        param->payload_args.video_args.height  = conn->cfg.payload.video.height;
+        param->height                          = conn->cfg.payload.video.height;
+        param->payload_args.video_args.fps     = param->fps = conn->cfg.payload.video.fps;
+
+        return 0;
+    }
+
+    /**
+     * Parse audio payload parameters
+     */
+    if (conn->cfg.payload_type == MESH_PAYLOAD_TYPE_AUDIO) {
+
+        switch (conn->cfg.payload.audio.sample_rate) {
+        case MESH_AUDIO_SAMPLE_RATE_44100:
+            param->payload_args.audio_args.sampling = AUDIO_SAMPLING_44K;
+            break; 
+        case MESH_AUDIO_SAMPLE_RATE_48000:
+            param->payload_args.audio_args.sampling = AUDIO_SAMPLING_48K;
+            break;
+        case MESH_AUDIO_SAMPLE_RATE_96000:
+            param->payload_args.audio_args.sampling = AUDIO_SAMPLING_96K;
+            break;
+        default:
+            return -MESH_ERR_CONN_CONFIG_INVAL;
+        }
+
+        switch (conn->cfg.payload.audio.sample_rate) {
+        case MESH_AUDIO_SAMPLE_RATE_48000:
+        case MESH_AUDIO_SAMPLE_RATE_96000:
+            switch (conn->cfg.payload.audio.packet_time) {
+            case MESH_AUDIO_PACKET_TIME_1MS:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_1MS;
+                break;
+            case MESH_AUDIO_PACKET_TIME_125US:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_125US;
+                break;
+            case MESH_AUDIO_PACKET_TIME_250US:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_250US;
+                break;
+            case MESH_AUDIO_PACKET_TIME_333US:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_333US;
+                break;
+            case MESH_AUDIO_PACKET_TIME_4MS:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_4MS;
+                break;
+            case MESH_AUDIO_PACKET_TIME_80US:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_80US;
+                break;
+            default:
+                return -MESH_ERR_CONN_CONFIG_INCOMPAT;
+            }
+            break;
+        case MESH_AUDIO_SAMPLE_RATE_44100:
+            switch (conn->cfg.payload.audio.packet_time) {
+            case MESH_AUDIO_PACKET_TIME_1_09MS:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_1_09MS;
+                break;
+            case MESH_AUDIO_PACKET_TIME_0_14MS:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_0_14MS;
+                break;
+            case MESH_AUDIO_PACKET_TIME_0_09MS:
+                param->payload_args.audio_args.ptime = AUDIO_PTIME_0_09MS;
+                break;
+            default:
+                return -MESH_ERR_CONN_CONFIG_INCOMPAT;
+            }
+            break;
+        default:
+            /**
+             * Default case cannot happen here by design.
+             */
+        }
+
+        switch (conn->cfg.payload.audio.format) {
+        case MESH_AUDIO_FORMAT_PCM_S8:
+            param->payload_args.audio_args.format = AUDIO_FMT_PCM8;
+            break;
+        case MESH_AUDIO_FORMAT_PCM_S16BE:
+            param->payload_args.audio_args.format = AUDIO_FMT_PCM16;
+            break;
+        case MESH_AUDIO_FORMAT_PCM_S24BE:
+            param->payload_args.audio_args.format = AUDIO_FMT_PCM24;
+            break;
+        default:
+            return -MESH_ERR_CONN_CONFIG_INVAL;
+        }
+
+        param->payload_args.audio_args.type = AUDIO_TYPE_FRAME_LEVEL;
+        param->payload_args.audio_args.channel = conn->cfg.payload.audio.channels;
+
+        return 0;
+    }
+
+    return -MESH_ERR_CONN_CONFIG_INVAL;
+}
+
+/**
+ * Parse connection configuration and check for for wrong or incompatible
+ * parameter values.
+ */
+int mesh_parse_conn_config(MeshConnectionContext *ctx, mcm_conn_param *param)
+{
+    switch (ctx->cfg.kind) {
+    case MESH_CONN_KIND_SENDER:
+        param->type = is_tx;
+        break;
+    case MESH_CONN_KIND_RECEIVER:
+        param->type = is_rx;
+        break;
+    default:
+        return -MESH_ERR_CONN_CONFIG_INVAL;
+    }
+
+    switch (ctx->cfg.conn_type) {
+    /**
+     * Parse parameters of memif connection.
+     */
+    case MESH_CONN_TYPE_MEMIF:
+        param->protocol = PROTO_MEMIF;
+
+        mesh_strlcpy(param->memif_interface.socket_path,
+                     ctx->cfg.conn.memif.socket_path,
+                     sizeof(param->memif_interface.socket_path));
+
+        param->memif_interface.interface_id = ctx->cfg.conn.memif.interface_id;
+        param->memif_interface.is_master = (param->type == is_tx) ? 1 : 0;
+
+        if (ctx->cfg.payload_type == MESH_PAYLOAD_TYPE_VIDEO)
+            param->payload_type = PAYLOAD_TYPE_ST20_VIDEO;
+        else if (ctx->cfg.payload_type == MESH_PAYLOAD_TYPE_AUDIO)
+            param->payload_type = PAYLOAD_TYPE_ST30_AUDIO;
+        break;
+    /**
+     * Parse and check parameters of SMPTE ST2110-XX connection.
+     */
+    case MESH_CONN_TYPE_ST2110:
+        param->protocol = PROTO_AUTO;
+
+        mesh_strlcpy(param->local_addr.ip, ctx->cfg.conn.st2110.local_ip_addr,
+                     sizeof(param->local_addr.ip));
+        snprintf(param->local_addr.port, sizeof(param->local_addr.port),
+                 "%u", ctx->cfg.conn.st2110.local_port);
+
+        mesh_strlcpy(param->remote_addr.ip, ctx->cfg.conn.st2110.remote_ip_addr,
+                     sizeof(param->remote_addr.ip));
+        snprintf(param->remote_addr.port, sizeof(param->remote_addr.port),
+                 "%u", ctx->cfg.conn.st2110.remote_port);
+
+        switch (ctx->cfg.conn.st2110.transport) {
+        /**
+         * SMPTE ST2110-20 Uncompressed video transport
+         */
+        case MESH_CONN_TRANSPORT_ST2110_20:
+            if (ctx->cfg.payload_type != MESH_PAYLOAD_TYPE_VIDEO)
+                return -MESH_ERR_CONN_CONFIG_INCOMPAT;
+
+            param->payload_type = PAYLOAD_TYPE_ST20_VIDEO;
+            break;
+        /**
+         * SMPTE ST2110-22 Constant Bit-Rate Compressed Video transport
+         */
+        case MESH_CONN_TRANSPORT_ST2110_22:
+            if (ctx->cfg.payload_type != MESH_PAYLOAD_TYPE_VIDEO)
+                return -MESH_ERR_CONN_CONFIG_INCOMPAT;
+
+            param->payload_type = PAYLOAD_TYPE_ST22_VIDEO;
+            param->payload_codec = PAYLOAD_CODEC_JPEGXS;
+            break;
+        /**
+         * SMPTE ST2110-30 Audio transport
+         */
+        case MESH_CONN_TRANSPORT_ST2110_30:
+            if (ctx->cfg.payload_type != MESH_PAYLOAD_TYPE_AUDIO)
+                return -MESH_ERR_CONN_CONFIG_INCOMPAT;
+
+            param->payload_type = PAYLOAD_TYPE_ST30_AUDIO;
+            break;
+        /**
+         * Unknown transport
+         */
+        default:
+            return -MESH_ERR_CONN_CONFIG_INVAL;
+        }
+        break;
+    /**
+     * Parse parameters of RDMA connection.
+     */
+    case MESH_CONN_TYPE_RDMA:
+        param->protocol = PROTO_AUTO;
+
+        mesh_strlcpy(param->local_addr.ip, ctx->cfg.conn.rdma.local_ip_addr,
+                     sizeof(param->local_addr.ip));
+        snprintf(param->local_addr.port, sizeof(param->local_addr.port),
+                 "%u", ctx->cfg.conn.rdma.local_port);
+
+        mesh_strlcpy(param->remote_addr.ip, ctx->cfg.conn.rdma.remote_ip_addr,
+                     sizeof(param->remote_addr.ip));
+        snprintf(param->remote_addr.port, sizeof(param->remote_addr.port),
+                 "%u", ctx->cfg.conn.rdma.remote_port);
+
+        /**
+         * TODO: Rework this to enable both video and audio payloads.
+         */
+        param->payload_type = PAYLOAD_TYPE_RDMA_VIDEO;
+        break;
+    /**
+     * Unknown connection type
+     */
+    default:
+        return -MESH_ERR_CONN_CONFIG_INVAL;
+    }
+
+    return 0;
+}
+
+/**
+ * Establish a mesh connection
+ */
+int mesh_establish_connection(MeshConnection *conn, int kind)
+{
+    MeshConnectionContext *conn_ctx;
+    mcm_conn_param param = { 0 };
+    MeshClientContext *mc_ctx;
+    int err;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+
+    if (conn_ctx->handle)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    mc_ctx = (MeshClientContext *)conn_ctx->__public.client;
+    if (!mc_ctx)
+        return -MESH_ERR_BAD_CLIENT_PTR;
+
+    if (conn_ctx->cfg.conn_type == MESH_CONN_TYPE_UNINITIALIZED ||
+        conn_ctx->cfg.payload_type == MESH_PAYLOAD_TYPE_UNINITIALIZED)
+        return -MESH_ERR_CONN_CONFIG_INVAL;
+
+    conn_ctx->cfg.kind = kind;
+
+    err = mesh_parse_payload_config(conn_ctx, &param);
+    if (err)
+        return err;
+
+    err = mesh_parse_conn_config(conn_ctx, &param);
+    if (err)
+        return err;
+
+    conn_ctx->handle = mesh_internal_ops.create_conn(&param);
+    if (!conn_ctx->handle)
+        return -MESH_ERR_CONN_FAILED;
+
+    *(size_t *)&conn_ctx->__public.buf_size = conn_ctx->handle->frame_size;
+
+    return 0;
+}
+
+/**
+ * Shutdown a mesh connection
+ */
+int mesh_shutdown_connection(MeshConnection *conn)
+{
+    MeshConnectionContext *conn_ctx;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+
+    if (conn_ctx->handle) {
+        /** In Sender mode, delay for 50ms to allow for completing
+         * transmission of all buffers sitting in the memif queue
+         * before destroying the connection.
+         *
+         * TODO: Replace the delay with polling of the actual memif
+         * queue status.
+         */
+        if (conn_ctx->cfg.kind == MESH_CONN_KIND_SENDER)
+            usleep(50000);
+
+        mesh_internal_ops.destroy_conn(conn_ctx->handle);
+        conn_ctx->handle = NULL;
+    }
+
+    return 0;
+}
+
+/**
+ * Delete mesh connection
+ */
+int mesh_delete_connection(MeshConnection **conn)
+{
+    MeshConnectionContext *conn_ctx;
+    MeshClientContext *mc_ctx;
+    int err;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    err = mesh_shutdown_connection(*conn);
+    if (err)
+        return err;
+
+    conn_ctx = (MeshConnectionContext *)(*conn);
+
+    if (conn_ctx->handle) {
+        mesh_internal_ops.destroy_conn(conn_ctx->handle);
+        conn_ctx->handle = NULL;
+    }
+
+    mc_ctx = (MeshClientContext *)conn_ctx->__public.client;
+    if (!mc_ctx)
+        return -MESH_ERR_BAD_CLIENT_PTR;
+
+    err = pthread_mutex_lock(&mc_ctx->mx);
+    if (err)
+        return err;
+
+    LIST_REMOVE(conn_ctx, conns);
+
+    pthread_mutex_unlock(&mc_ctx->mx);
+
+    atomic_fetch_sub(&mc_ctx->conn_num, 1);
+
+    mesh_free(conn_ctx);
+    *conn = NULL;
+
+    return 0;
+}
+
+/**
+ * Get buffer from mesh connection
+ */
+inline int mesh_get_buffer(MeshConnection *conn, MeshBuffer **buf)
+{
+    return mesh_get_buffer_timeout(conn, buf, MESH_TIMEOUT_DEFAULT);
+}
+
+/**
+ * Get buffer from mesh connection with timeout
+ */
+int mesh_get_buffer_timeout(MeshConnection *conn, MeshBuffer **buf,
+                            int timeout_ms)
+{
+    MeshConnectionContext *conn_ctx;
+    MeshBufferContext *buf_ctx;
+    int err;
+
+    if (!conn)
+        return -MESH_ERR_BAD_CONN_PTR;
+
+    if (!buf)
+        return -MESH_ERR_BAD_BUF_PTR;
+
+    conn_ctx = (MeshConnectionContext *)conn;
+
+    buf_ctx = mesh_calloc(sizeof(MeshBufferContext));
+    
+    if (!buf_ctx)
+        return -ENOMEM;
+
+    if (timeout_ms == MESH_TIMEOUT_DEFAULT && conn && conn->client)
+        timeout_ms = ((MeshClientContext *)conn->client)->config.timeout_ms;
+
+    buf_ctx->buf = mesh_internal_ops.dequeue_buf(conn_ctx->handle, timeout_ms, &err);
+    if (!buf_ctx->buf) {
+        mesh_free(buf_ctx);
+
+        if (!err)
+            return -MESH_ERR_CONN_CLOSED;
+
+        return err;
+    }
+
+    *(MeshConnection **)&buf_ctx->__public.conn = conn;
+    *(void **)&buf_ctx->__public.data = buf_ctx->buf->data;
+    *(size_t *)&buf_ctx->__public.data_len = buf_ctx->buf->len;
+
+    *buf = (MeshBuffer *)buf_ctx;
+
+    return 0;
+}
+
+/**
+ * Put buffer to mesh connection
+ */
+inline int mesh_put_buffer(MeshBuffer **buf)
+{
+    return mesh_put_buffer_timeout(buf, MESH_TIMEOUT_DEFAULT);
+}
+
+/**
+ * Put buffer to mesh connection with timeout
+ */
+int mesh_put_buffer_timeout(MeshBuffer **buf, int timeout_ms)
+{
+    MeshBufferContext *buf_ctx;
+    mcm_conn_context *handle;
+    int err;
+
+    if (!buf)
+        return -MESH_ERR_BAD_BUF_PTR;
+
+    buf_ctx = (MeshBufferContext *)(*buf);
+
+    if (!buf_ctx)
+        return -MESH_ERR_BAD_BUF_PTR;
+
+    /**
+     * TODO: Add timeout handling
+     */
+
+    handle = ((MeshConnectionContext *)(buf_ctx->__public.conn))->handle;
+    err = mesh_internal_ops.enqueue_buf(handle, buf_ctx->buf);
+    if (err)
+        return err;
+
+    mesh_free(buf_ctx);
+    *buf = NULL;
+
+    return 0;
+}
+
+/**
+ * Get text description of an error code.
+ */
+const char *mesh_err2str(int err)
+{
+    switch (err) {
+    case -MESH_ERR_BAD_CLIENT_PTR:
+        return "Bad client pointer";
+    case -MESH_ERR_BAD_CONN_PTR:
+        return "Bad connection pointer";
+    case -MESH_ERR_BAD_CONFIG_PTR:
+        return "Bad configuration pointer";
+    case -MESH_ERR_BAD_BUF_PTR:
+        return "Bad buffer pointer";
+    case -MESH_ERR_MAX_CONN:
+        return "Reached max number of connections";
+    case -MESH_ERR_CONN_FAILED:
+        return "Connection creation failed";
+    case -MESH_ERR_CONN_CONFIG_INVAL:
+        return "Invalid parameters in connection configuration";
+    case -MESH_ERR_CONN_CONFIG_INCOMPAT:
+        return "Incompatible parameters in connection configuration";
+    case -MESH_ERR_CONN_CLOSED:
+        return "Connection is closed";
+    case -MESH_ERR_TIMEOUT:
+        return "Timeout occurred";
+    default:
+        return "Unknown error code";
+    }
+}

--- a/tests/unit/mesh_dp_api_tests.cc
+++ b/tests/unit/mesh_dp_api_tests.cc
@@ -104,6 +104,28 @@ void APITests_Setup()
 }
 
 /**
+ * Test negative scenarios of deleting a client with live connections
+ */
+TEST(APITests_MeshConnection, TestNegative_DeleteClientLiveConnections) {
+    MeshConfig_Memif memif_config = { 0 };
+    MeshConfig_Video video_config = { 0 };
+    MeshConnection *conn = NULL;
+    MeshClient *mc, *mc_copy = NULL;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, NULL);
+    mesh_create_connection(mc, &conn);
+
+    mc_copy = mc;
+
+    err = mesh_delete_client(&mc);
+    EXPECT_EQ(err, -MESH_ERR_FOUND_ALLOCATED) << mesh_err2str(err);
+    EXPECT_EQ(mc, mc_copy);
+}
+
+/**
  * Test creation, establishing, shutting down, and deletion of a mesh connection
  */
 TEST(APITests_MeshConnection, Test_CreateEstablishShutdownDeleteConnection) {
@@ -1470,21 +1492,22 @@ TEST(APITests_MeshBuffer, TestNegative_PutBuffer_NulledBuf) {
  * Test important constants
  */
 TEST(APITests_MeshBuffer, Test_ImportantConstants) {
-    ASSERT_EQ(MESH_SOCKET_PATH_SIZE, 108);
-    ASSERT_EQ(MESH_IP_ADDRESS_SIZE,   46);
+    EXPECT_EQ(MESH_SOCKET_PATH_SIZE, 108);
+    EXPECT_EQ(MESH_IP_ADDRESS_SIZE,   253);
 
-    ASSERT_EQ(MESH_ERR_BAD_CLIENT_PTR,       1000);
-    ASSERT_EQ(MESH_ERR_BAD_CONN_PTR,         1001);
-    ASSERT_EQ(MESH_ERR_BAD_CONFIG_PTR,       1002);
-    ASSERT_EQ(MESH_ERR_BAD_BUF_PTR,          1003);
-    ASSERT_EQ(MESH_ERR_MAX_CONN,             1004);
-    ASSERT_EQ(MESH_ERR_CONN_FAILED,          1005);
-    ASSERT_EQ(MESH_ERR_CONN_CONFIG_INVAL,    1006);
-    ASSERT_EQ(MESH_ERR_CONN_CONFIG_INCOMPAT, 1007);
-    ASSERT_EQ(MESH_ERR_CONN_CLOSED,          1008);
-    ASSERT_EQ(MESH_ERR_TIMEOUT,              1009);
+    EXPECT_EQ(MESH_ERR_BAD_CLIENT_PTR,       1000);
+    EXPECT_EQ(MESH_ERR_BAD_CONN_PTR,         1001);
+    EXPECT_EQ(MESH_ERR_BAD_CONFIG_PTR,       1002);
+    EXPECT_EQ(MESH_ERR_BAD_BUF_PTR,          1003);
+    EXPECT_EQ(MESH_ERR_MAX_CONN,             1004);
+    EXPECT_EQ(MESH_ERR_FOUND_ALLOCATED,      1005);
+    EXPECT_EQ(MESH_ERR_CONN_FAILED,          1006);
+    EXPECT_EQ(MESH_ERR_CONN_CONFIG_INVAL,    1007);
+    EXPECT_EQ(MESH_ERR_CONN_CONFIG_INCOMPAT, 1008);
+    EXPECT_EQ(MESH_ERR_CONN_CLOSED,          1009);
+    EXPECT_EQ(MESH_ERR_TIMEOUT,              1010);
 
-    ASSERT_EQ(MESH_TIMEOUT_DEFAULT,  -2);
-    ASSERT_EQ(MESH_TIMEOUT_INFINITE, -1);
-    ASSERT_EQ(MESH_TIMEOUT_ZERO,      0);
+    EXPECT_EQ(MESH_TIMEOUT_DEFAULT,  -2);
+    EXPECT_EQ(MESH_TIMEOUT_INFINITE, -1);
+    EXPECT_EQ(MESH_TIMEOUT_ZERO,      0);
 }

--- a/tests/unit/mesh_dp_api_tests.cc
+++ b/tests/unit/mesh_dp_api_tests.cc
@@ -1,0 +1,1490 @@
+#include <gtest/gtest.h>
+#include "mesh_dp_internal.h"
+#include <bsd/string.h>
+
+/**
+ * Test creation and deletion of a mesh client
+ */
+TEST(APITests_MeshClient, Test_CreateDeleteClient) {
+    MeshClient *mc = NULL;
+    int err;
+
+    err = mesh_create_client(&mc, NULL);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_NE(mc, (MeshClient *)NULL);
+
+    err = mesh_delete_client(&mc);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(mc, (MeshClient *)NULL);
+}
+
+/**
+ * Test negative scenario of creating a mesh client
+ */
+TEST(APITests_MeshClient, TestNegative_CreateClient) {
+    int err = mesh_create_client(NULL, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CLIENT_PTR) << mesh_err2str(err);
+}
+
+/**
+ * Test negative scenario of deteling a mesh client
+ */
+TEST(APITests_MeshClient, TestNegative_DeleteClient) {
+    int err = mesh_delete_client(NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CLIENT_PTR) << mesh_err2str(err);
+}
+
+/**
+ * Create a mock mesh connection
+ */
+mcm_conn_context * mock_create_connection(mcm_conn_param* param)
+{
+    mcm_conn_context *conn;
+    
+    conn = (mcm_conn_context *)calloc(1, sizeof(mcm_conn_context));
+    conn->frame_size = 1024; /* Magic number for checking frame size */
+
+    return conn;
+}
+
+/**
+ * Destroy a mock mesh connection
+ */
+void mock_destroy_connection(mcm_conn_context *pctx)
+{
+    free(pctx);
+}
+
+/**
+ * Variable to hold the last timeout value passed to any API function
+ */
+int __last_timeout;
+
+/**
+ * Dequeue a mock mesh buffer
+ */
+mcm_buffer * mock_dequeue_buf(mcm_conn_context *pctx, int timeout, int *error_code)
+{
+    mcm_buffer *buf;
+
+    *error_code = 0;
+    __last_timeout = timeout;
+
+    /* Magic number for simulating that the connection is closed */
+    if (timeout == 12345)
+        return NULL;
+
+    buf = (mcm_buffer *)calloc(1, sizeof(mcm_buffer));
+    if (buf) {
+        buf->len = 192;         /* Magic number for checking buf data len */
+        pctx->frame_size = 384; /* Magic number for checking buf size */
+    }
+
+    return buf;
+}
+
+/**
+ * Enqueue a mock mesh buffer
+ */
+int mock_enqueue_buf(mcm_conn_context *pctx, mcm_buffer *buf)
+{
+    free(buf);
+    return 0;
+}
+
+/**
+ * APITests setup
+ */
+void APITests_Setup()
+{
+    mesh_internal_ops.create_conn = mock_create_connection;
+    mesh_internal_ops.destroy_conn = mock_destroy_connection;
+    mesh_internal_ops.dequeue_buf = mock_dequeue_buf;
+    mesh_internal_ops.enqueue_buf = mock_enqueue_buf;
+}
+
+/**
+ * Test creation, establishing, shutting down, and deletion of a mesh connection
+ */
+TEST(APITests_MeshConnection, Test_CreateEstablishShutdownDeleteConnection) {
+    MeshConfig_Memif memif_config = {
+        .socket_path = "/run/mcm/mcm_memif_0.sock",
+        .interface_id = 123,
+    };
+    MeshConfig_ST2110 st2110_config = {
+        .remote_ip_addr = "192.168.95.2",
+        .remote_port = 9002,
+        .local_ip_addr = "192.168.95.1",
+        .local_port = 9001,
+        .transport = MESH_CONN_TRANSPORT_ST2110_22,
+    };
+    MeshConfig_RDMA rdma_config = {
+        .remote_ip_addr = "192.168.95.2",
+        .remote_port = 9002,
+        .local_ip_addr = "192.168.95.1",
+        .local_port = 9001,
+    };
+    MeshConfig_Video video_config = {
+        .width = 1920,
+        .height = 1080,
+        .fps = 60,
+        .pixel_format = MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE,
+    };
+    MeshConfig_Audio audio_config = {
+        .channels = 2,
+        .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+        .format = MESH_AUDIO_FORMAT_PCM_S24BE,
+        .packet_time = MESH_AUDIO_PACKET_TIME_1_09MS,
+    };
+    MeshConnection *conn = NULL;
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    err = mesh_create_client(&mc, NULL);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_NE(mc, (MeshClient *)NULL);
+
+    err = mesh_create_connection(mc, &conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(conn, (MeshConnection *)NULL);
+    EXPECT_EQ(conn->client, mc);
+    if (err || !conn)
+        goto exit;
+
+    /**
+     * Case A - Transmit video over memif
+     */
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn->buf_size, 1024); /* Magic number hardcoded in mock function */
+    EXPECT_EQ(conn->client, mc);
+
+    err = mesh_shutdown_connection(conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn->client, mc);
+
+    /**
+     * Case B - Receive video over ST2110-30
+     */
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_RECEIVER);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn->buf_size, 1024); /* Magic number hardcoded in mock function */
+    EXPECT_EQ(conn->client, mc);
+
+    err = mesh_shutdown_connection(conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn->client, mc);
+
+    /**
+     * Case B - Transmit audio over RDMA
+     */
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn->buf_size, 1024); /* Magic number hardcoded in mock function */
+    EXPECT_EQ(conn->client, mc);
+
+    err = mesh_shutdown_connection(conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn->client, mc);
+
+    err = mesh_delete_connection(&conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn, (MeshConnection *)NULL);
+
+exit:
+    err = mesh_delete_client(&mc);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(mc, (MeshClient *)NULL);
+}
+
+/**
+ * Test apply connection configuration functions
+ */
+TEST(APITests_MeshConnection, Test_ApplyConfig) {
+    MeshConfig_Memif memif_config_empty = { 0 };
+    MeshConfig_Memif memif_config = {
+        .socket_path = "/run/mcm/mcm_memif_0.sock",
+        .interface_id = 123,
+    };
+    MeshConfig_ST2110 st2110_config_empty = { 0 };
+    MeshConfig_ST2110 st2110_config = {
+        .remote_ip_addr = "192.168.95.2",
+        .remote_port = 9002,
+        .local_ip_addr = "192.168.95.1",
+        .local_port = 9001,
+        .transport = MESH_CONN_TRANSPORT_ST2110_22,
+    };
+    MeshConfig_RDMA rdma_config_empty = { 0 };
+    MeshConfig_RDMA rdma_config = {
+        .remote_ip_addr = "192.168.95.2",
+        .remote_port = 9002,
+        .local_ip_addr = "192.168.95.1",
+        .local_port = 9001,
+    };
+    MeshConfig_Video video_config_empty = { 0 };
+    MeshConfig_Video video_config = {
+        .width = 1920,
+        .height = 1080,
+        .fps = 60,
+        .pixel_format = MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE,
+    };
+    MeshConfig_Audio audio_config_empty = { 0 };
+    MeshConfig_Audio audio_config = {
+        .channels = 2,
+        .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+        .format = MESH_AUDIO_FORMAT_PCM_S24BE,
+        .packet_time = MESH_AUDIO_PACKET_TIME_1_09MS,
+    };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    /**
+     * Case A - memif connection type
+     */
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.conn_type, MESH_CONN_TYPE_MEMIF);
+    ASSERT_EQ(memcmp(&ctx.cfg.conn.memif, &memif_config,
+        sizeof(MeshConfig_Memif)), 0);
+
+    memset(&ctx.cfg.conn.memif, 0, sizeof(MeshConfig_Memif));
+    err = mesh_apply_connection_config_memif(conn, &memif_config_empty);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.conn_type, MESH_CONN_TYPE_MEMIF);
+    ASSERT_EQ(memcmp(&ctx.cfg.conn.memif, &memif_config_empty,
+        sizeof(MeshConfig_Memif)), 0);
+
+    /**
+     * Case B - SMPTE ST2110-XX connection type
+     */
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.conn_type, MESH_CONN_TYPE_ST2110);
+    ASSERT_EQ(memcmp(&ctx.cfg.conn.st2110, &st2110_config,
+        sizeof(MeshConfig_ST2110)), 0);
+
+    memset(&ctx.cfg.conn.st2110, 0, sizeof(MeshConfig_ST2110));
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config_empty);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.conn_type, MESH_CONN_TYPE_ST2110);
+    ASSERT_EQ(memcmp(&ctx.cfg.conn.st2110, &st2110_config_empty,
+        sizeof(MeshConfig_ST2110)), 0);
+
+    /**
+     * Case C - RDMA connection type
+     */
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.conn_type, MESH_CONN_TYPE_RDMA);
+    ASSERT_EQ(memcmp(&ctx.cfg.conn.rdma, &rdma_config,
+        sizeof(MeshConfig_RDMA)), 0);
+
+    memset(&ctx.cfg.conn.rdma, 0, sizeof(MeshConfig_RDMA));
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config_empty);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.conn_type, MESH_CONN_TYPE_RDMA);
+    ASSERT_EQ(memcmp(&ctx.cfg.conn.rdma, &rdma_config_empty,
+        sizeof(MeshConfig_RDMA)), 0);
+
+    /**
+     * Case D - Video type
+     */
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.payload_type, MESH_PAYLOAD_TYPE_VIDEO);
+    ASSERT_EQ(memcmp(&ctx.cfg.payload.video, &video_config,
+        sizeof(MeshConfig_Video)), 0);
+
+    memset(&ctx.cfg.payload.video, 0, sizeof(MeshConfig_Video));
+    err = mesh_apply_connection_config_video(conn, &video_config_empty);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.payload_type, MESH_PAYLOAD_TYPE_VIDEO);
+    ASSERT_EQ(memcmp(&ctx.cfg.payload.video, &video_config_empty,
+        sizeof(MeshConfig_Video)), 0);
+
+    /**
+     * Case E - Audio type
+     */
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.payload_type, MESH_PAYLOAD_TYPE_AUDIO);
+    ASSERT_EQ(memcmp(&ctx.cfg.payload.audio, &audio_config,
+        sizeof(MeshConfig_Audio)), 0);
+
+    memset(&ctx.cfg.payload.audio, 0, sizeof(MeshConfig_Audio));
+    err = mesh_apply_connection_config_audio(conn, &audio_config_empty);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(ctx.cfg.payload_type, MESH_PAYLOAD_TYPE_AUDIO);
+    ASSERT_EQ(memcmp(&ctx.cfg.payload.audio, &audio_config_empty,
+        sizeof(MeshConfig_Audio)), 0);
+}
+
+/**
+ * Test negative scenarios of applying connection configuration
+ */
+TEST(APITests_MeshConnection, TestNegative_ApplyConfig) {
+    MeshConfig_Memif memif_config = { 0 };
+    MeshConfig_ST2110 st2110_config = { 0 };
+    MeshConfig_RDMA rdma_config = { 0 };
+    MeshConfig_Video video_config = { 0 };
+    MeshConfig_Audio audio_config = { 0 };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    /**
+     * Case A - memif connection type
+     */
+    err = mesh_apply_connection_config_memif(NULL, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_memif(conn, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONFIG_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    /**
+     * Case B - SMPTE ST2110-XX connection type
+     */
+    err = mesh_apply_connection_config_st2110(NULL, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_st2110(conn, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONFIG_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    /**
+     * Case C - RDMA connection type
+     */
+    err = mesh_apply_connection_config_rdma(NULL, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_rdma(conn, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONFIG_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    /**
+     * Case D - Video type
+     */
+    err = mesh_apply_connection_config_video(NULL, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_video(conn, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONFIG_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    /**
+     * Case E - Audio type
+     */
+    err = mesh_apply_connection_config_audio(NULL, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_audio(conn, NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONFIG_PTR) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_memif(conn, &memif_config);
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_st2110(conn, &st2110_config);
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_rdma(conn, &rdma_config);
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_apply_connection_config_audio(conn, &audio_config);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+}
+
+/**
+ * Test parsing connection configuration
+ */
+TEST(APITests_MeshConnection, Test_ParseConnectionConfig) {
+    MeshConfig_Memif memif_config = {
+        .socket_path = "/run/mcm/mcm_memif_0.sock",
+        .interface_id = 123,
+    };
+    MeshConfig_ST2110 st2110_config = {
+        .remote_ip_addr = "192.168.95.2",
+        .remote_port = 9002,
+        .local_ip_addr = "192.168.95.1",
+        .local_port = 9001,
+        .transport = MESH_CONN_TRANSPORT_ST2110_22,
+    };
+    MeshConfig_RDMA rdma_config = {
+        .remote_ip_addr = "192.168.95.2",
+        .remote_port = 9002,
+        .local_ip_addr = "192.168.95.1",
+        .local_port = 9001,
+    };
+    MeshConfig_Video video_config = { 0 };
+    MeshConfig_Audio audio_config = { 0 };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    mcm_conn_param param;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    /**
+     * Case A - memif connection type
+     */
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    mesh_apply_connection_config_memif(conn, &memif_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_tx);
+    ASSERT_EQ(param.protocol, PROTO_MEMIF);
+    ASSERT_STREQ(param.memif_interface.socket_path, "/run/mcm/mcm_memif_0.sock");
+    ASSERT_EQ(param.memif_interface.interface_id, 123);
+    ASSERT_EQ(param.memif_interface.is_master, 1);
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST20_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_RECEIVER;
+    mesh_apply_connection_config_memif(conn, &memif_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_rx);
+    ASSERT_EQ(param.protocol, PROTO_MEMIF);
+    ASSERT_STREQ(param.memif_interface.socket_path, "/run/mcm/mcm_memif_0.sock");
+    ASSERT_EQ(param.memif_interface.interface_id, 123);
+    ASSERT_EQ(param.memif_interface.is_master, 0);
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST20_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    mesh_apply_connection_config_memif(conn, &memif_config);
+    mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_tx);
+    ASSERT_EQ(param.protocol, PROTO_MEMIF);
+    ASSERT_STREQ(param.memif_interface.socket_path, "/run/mcm/mcm_memif_0.sock");
+    ASSERT_EQ(param.memif_interface.interface_id, 123);
+    ASSERT_EQ(param.memif_interface.is_master, 1);
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST30_AUDIO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_RECEIVER;
+    mesh_apply_connection_config_memif(conn, &memif_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_rx);
+    ASSERT_EQ(param.protocol, PROTO_MEMIF);
+    ASSERT_STREQ(param.memif_interface.socket_path, "/run/mcm/mcm_memif_0.sock");
+    ASSERT_EQ(param.memif_interface.interface_id, 123);
+    ASSERT_EQ(param.memif_interface.is_master, 0);
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST30_AUDIO);
+
+    /**
+     * Case B - SMPTE ST2110-XX connection type
+     */
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_tx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST22_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_RECEIVER;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_rx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST22_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    st2110_config.transport = MESH_CONN_TRANSPORT_ST2110_20,
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_tx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST20_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_RECEIVER;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_rx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST20_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    st2110_config.transport = MESH_CONN_TRANSPORT_ST2110_30,
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_tx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST30_AUDIO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_RECEIVER;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_rx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_ST30_AUDIO);
+
+    /**
+     * Case C - RDMA connection type
+     */
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    mesh_apply_connection_config_rdma(conn, &rdma_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_tx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_RDMA_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_RECEIVER;
+    mesh_apply_connection_config_rdma(conn, &rdma_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_rx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_RDMA_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    mesh_apply_connection_config_rdma(conn, &rdma_config);
+    mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_tx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    /**
+     * TODO: Rework this to enable both video and audio payloads.
+     */
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_RDMA_VIDEO);
+
+    ctx.cfg.kind = MESH_CONN_KIND_RECEIVER;
+    mesh_apply_connection_config_rdma(conn, &rdma_config);
+    mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.type, is_rx);
+    ASSERT_EQ(param.protocol, PROTO_AUTO);
+    ASSERT_STREQ(param.local_addr.ip, "192.168.95.1");
+    ASSERT_STREQ(param.local_addr.port, "9001");
+    ASSERT_STREQ(param.remote_addr.ip, "192.168.95.2");
+    ASSERT_STREQ(param.remote_addr.port, "9002");
+    /**
+     * TODO: Rework this to enable both video and audio payloads.
+     */
+    ASSERT_EQ(param.payload_type, PAYLOAD_TYPE_RDMA_VIDEO);
+}
+
+/**
+ * Test negative scenarios of parsing connection configuration - invalid config
+ */
+TEST(APITests_MeshConnection, TestNegative_ParseConnectionConfigInval) {
+    MeshConfig_ST2110 st2110_config = { 0 };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    mcm_conn_param param;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    ctx.cfg.kind = 2;
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+
+    ctx.cfg.kind = MESH_CONN_KIND_SENDER;
+    ctx.cfg.conn_type = 3,
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+
+    st2110_config.transport = 3;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+}
+
+/**
+ * Test negative scenarios of parsing connection configuration - incompatible config
+ */
+TEST(APITests_MeshConnection, TestNegative_ParseConnectionConfigIncompat) {
+    MeshConfig_ST2110 st2110_config = { 0 };
+    MeshConfig_Video video_config = { 0 };
+    MeshConfig_Audio audio_config = { 0 };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    mcm_conn_param param;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    st2110_config.transport = MESH_CONN_TRANSPORT_ST2110_20;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INCOMPAT) << mesh_err2str(err);
+
+    st2110_config.transport = MESH_CONN_TRANSPORT_ST2110_22;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_audio(conn, &audio_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INCOMPAT) << mesh_err2str(err);
+
+    st2110_config.transport = MESH_CONN_TRANSPORT_ST2110_30;
+    mesh_apply_connection_config_st2110(conn, &st2110_config);
+    mesh_apply_connection_config_video(conn, &video_config);
+    err = mesh_parse_conn_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INCOMPAT) << mesh_err2str(err);
+}
+
+/**
+ * Test parsing video payload configuration
+ */
+TEST(APITests_MeshConnection, Test_ParseVideoPayloadConfig) {
+    MeshConfig_Video cfg = {
+        .width = 1920,
+        .height = 1080,
+        .fps = 60,
+        .pixel_format = MESH_VIDEO_PIXEL_FORMAT_YUV444P10LE,
+    };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    mcm_conn_param param;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    mesh_apply_connection_config_video(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.width, 1920);
+    ASSERT_EQ(param.payload_args.video_args.width, 1920);
+    ASSERT_EQ(param.height, 1080);
+    ASSERT_EQ(param.payload_args.video_args.height, 1080);
+    ASSERT_EQ(param.fps, 60);
+    ASSERT_EQ(param.payload_args.video_args.fps, 60);
+    ASSERT_EQ(param.pix_fmt, PIX_FMT_YUV444P_10BIT_LE);
+    ASSERT_EQ(param.payload_args.video_args.pix_fmt, PIX_FMT_YUV444P_10BIT_LE);
+
+    cfg.pixel_format = MESH_VIDEO_PIXEL_FORMAT_NV12;
+    mesh_apply_connection_config_video(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.pix_fmt, PIX_FMT_NV12);
+    ASSERT_EQ(param.payload_args.video_args.pix_fmt, PIX_FMT_NV12);
+
+    cfg.pixel_format = MESH_VIDEO_PIXEL_FORMAT_YUV422P;
+    mesh_apply_connection_config_video(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.pix_fmt, PIX_FMT_YUV422P);
+    ASSERT_EQ(param.payload_args.video_args.pix_fmt, PIX_FMT_YUV422P);
+
+    cfg.pixel_format = MESH_VIDEO_PIXEL_FORMAT_YUV422P10LE;
+    mesh_apply_connection_config_video(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.pix_fmt, PIX_FMT_YUV422P_10BIT_LE);
+    ASSERT_EQ(param.payload_args.video_args.pix_fmt, PIX_FMT_YUV422P_10BIT_LE);
+
+    cfg.pixel_format = MESH_VIDEO_PIXEL_FORMAT_RGB8;
+    mesh_apply_connection_config_video(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.pix_fmt, PIX_FMT_RGB8);
+    ASSERT_EQ(param.payload_args.video_args.pix_fmt, PIX_FMT_RGB8);
+}
+
+/**
+ * Test parsing audio payload configuration
+ */
+TEST(APITests_MeshConnection, Test_ParseAudioPayloadConfig) {
+    MeshConfig_Audio cfg = {
+        .channels = 2,
+        .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+        .format = MESH_AUDIO_FORMAT_PCM_S24BE,
+        .packet_time = MESH_AUDIO_PACKET_TIME_1_09MS,
+    };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    mcm_conn_param param;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.type, AUDIO_TYPE_FRAME_LEVEL);
+    ASSERT_EQ(param.payload_args.audio_args.channel, 2);
+    ASSERT_EQ(param.payload_args.audio_args.sampling, AUDIO_SAMPLING_44K);
+    ASSERT_EQ(param.payload_args.audio_args.format, AUDIO_FMT_PCM24);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_1_09MS);
+
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_0_14MS;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_0_14MS);
+
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_0_09MS;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_0_09MS);
+
+    cfg.sample_rate = MESH_AUDIO_SAMPLE_RATE_48000;
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_1MS;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.sampling, AUDIO_SAMPLING_48K);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_1MS);
+
+    cfg.sample_rate = MESH_AUDIO_SAMPLE_RATE_96000;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.sampling, AUDIO_SAMPLING_96K);
+
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_125US;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_125US);
+
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_250US;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_250US);
+
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_333US;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_333US);
+
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_4MS;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_4MS);
+
+    cfg.packet_time = MESH_AUDIO_PACKET_TIME_80US;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.ptime, AUDIO_PTIME_80US);
+
+    cfg.format = MESH_AUDIO_FORMAT_PCM_S8;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.format, AUDIO_FMT_PCM8);
+
+    cfg.format = MESH_AUDIO_FORMAT_PCM_S16BE;
+    mesh_apply_connection_config_audio(conn, &cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_EQ(param.payload_args.audio_args.format, AUDIO_FMT_PCM16);
+}
+
+/**
+ * Test negative scenarios of parsing payload configuration - invalid parameters
+ */
+TEST(APITests_MeshConnection, TestNegative_ParsePayloadConfigInval) {
+    MeshConfig_Video video_cfg = { .pixel_format = 5 };
+    MeshConfig_Audio audio_cfg = { .sample_rate = 3 };
+    MeshConnectionContext ctx = { 0 };
+    MeshConnection *conn;
+    mcm_conn_param param;
+    int err;
+
+    conn = (MeshConnection *)&ctx;
+
+    mesh_apply_connection_config_video(conn, &video_cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+
+    mesh_apply_connection_config_audio(conn, &audio_cfg);
+    err = mesh_parse_payload_config(&ctx, &param);
+    ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+}
+
+/**
+ * Test negative scenarios of parsing payload configuration - incompatible parameters
+ */
+TEST(APITests_MeshConnection, TestNegative_ParsePayloadConfigIncompat) {
+    int i;
+
+    MeshConfig_Audio cases[] = {
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_48000,
+            .packet_time = MESH_AUDIO_PACKET_TIME_1_09MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_48000,
+            .packet_time = MESH_AUDIO_PACKET_TIME_0_14MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_48000,
+            .packet_time = MESH_AUDIO_PACKET_TIME_0_09MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_48000,
+            .packet_time = 9,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_96000,
+            .packet_time = MESH_AUDIO_PACKET_TIME_1_09MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_96000,
+            .packet_time = MESH_AUDIO_PACKET_TIME_0_14MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_96000,
+            .packet_time = MESH_AUDIO_PACKET_TIME_0_09MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_96000,
+            .packet_time = 9,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+            .packet_time = MESH_AUDIO_PACKET_TIME_1MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+            .packet_time = MESH_AUDIO_PACKET_TIME_125US,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+            .packet_time = MESH_AUDIO_PACKET_TIME_250US,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+            .packet_time = MESH_AUDIO_PACKET_TIME_333US,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+            .packet_time = MESH_AUDIO_PACKET_TIME_4MS,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+            .packet_time = MESH_AUDIO_PACKET_TIME_80US,
+        },
+        {
+            .sample_rate = MESH_AUDIO_SAMPLE_RATE_44100,
+            .packet_time = 9,
+        },
+    };
+
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        MeshConfig_Audio *cfg = &cases[i];
+        MeshConnectionContext ctx = { 0 };
+        MeshConnection *conn;
+        mcm_conn_param param;
+        int err;
+
+        conn = (MeshConnection *)&ctx;
+
+        mesh_apply_connection_config_audio(conn, cfg);
+        err = mesh_parse_payload_config(&ctx, &param);
+        ASSERT_EQ(err, -MESH_ERR_CONN_CONFIG_INCOMPAT) << mesh_err2str(err);
+    }
+}
+
+/**
+ * Test negative scenario of establishing a mesh connection with invalid config
+ */
+TEST(APITests_MeshConnection, TestNegative_EstablishConnectionConfigInval) {
+    MeshConfig_Memif memif_cfg = { 0 };
+    MeshConfig_Video video_cfg = { 0 };
+    MeshConnection *conn = NULL;
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, NULL);
+    mesh_create_connection(mc, &conn);
+
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+
+    mesh_apply_connection_config_memif(conn, &memif_cfg);
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+
+    mesh_apply_connection_config_video(conn, &video_cfg);
+    err = mesh_establish_connection(conn, 2);
+    EXPECT_EQ(err, -MESH_ERR_CONN_CONFIG_INVAL) << mesh_err2str(err);
+
+    mesh_delete_connection(&conn);
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test negative scenario of establishing a mesh connection with incompatible config
+ */
+TEST(APITests_MeshConnection, TestNegative_CreateConnectionConfigIncompat) {
+    MeshConfig_Memif memif_cfg = { 0 };
+    MeshConfig_Audio audio_cfg = { 
+        .sample_rate = MESH_AUDIO_SAMPLE_RATE_48000,
+        .packet_time = MESH_AUDIO_PACKET_TIME_1_09MS,
+    };
+    MeshConnection *conn = NULL;
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, NULL);
+    mesh_create_connection(mc, &conn);
+
+    mesh_apply_connection_config_memif(conn, &memif_cfg);
+    mesh_apply_connection_config_audio(conn, &audio_cfg);
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, -MESH_ERR_CONN_CONFIG_INCOMPAT) << mesh_err2str(err);
+
+    mesh_delete_connection(&conn);
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test negative scenario of creating a mesh connection - nulled client and conn
+ */
+TEST(APITests_MeshConnection, TestNegative_CreateConnection_NulledClientAndConn) {
+    int err;
+
+    APITests_Setup();
+
+    err = mesh_create_connection(NULL, NULL);
+    EXPECT_EQ(err, -MESH_ERR_BAD_CLIENT_PTR) << mesh_err2str(err);
+}
+
+/**
+ * Test negative scenario of creating a mesh connection - nulled conn
+ */
+TEST(APITests_MeshConnection, TestNegative_CreateConnection_NulledConn) {
+    MeshConnection *conn = NULL;
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, NULL);
+
+    err = mesh_create_connection(mc, NULL);
+    EXPECT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+    EXPECT_EQ(conn, (MeshConnection *)NULL);
+
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test creation of a mesh connection - two connections & max conn number
+ */
+TEST(APITests_MeshConnection, Test_CreateConnection_MaxConnNumber) {
+    MeshConnection *conn = NULL;
+    MeshClientConfig mc_cfg = { .max_conn_num = 1 };
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, &mc_cfg);
+
+    err = mesh_create_connection(mc, &conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(conn, (MeshConnection *)NULL);
+    if (err || !conn)
+        goto exit;
+
+    mesh_delete_connection(&conn);
+
+    err = mesh_create_connection(mc, &conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(conn, (MeshConnection *)NULL);
+    if (err || !conn)
+        goto exit;
+
+    mesh_delete_connection(&conn);
+
+exit:
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test negative scenario of creating a mesh connection - max conn number
+ */
+TEST(APITests_MeshConnection, TestNegative_CreateConnection_MaxConnNumber) {
+    MeshConnection *conn = NULL;
+    MeshClientConfig mc_cfg = { .max_conn_num = -1 };
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, &mc_cfg);
+
+    err = mesh_create_connection(mc, &conn);
+    EXPECT_EQ(err, -MESH_ERR_MAX_CONN) << mesh_err2str(err);
+    EXPECT_EQ(conn, (MeshConnection *)NULL);
+
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test negative scenario of shutting down a mesh connection - nulled conn
+ */
+TEST(APITests_MeshConnection, TestNegative_ShutdownConnection_NulledConn) {
+    int err;
+
+    APITests_Setup();
+
+    err = mesh_shutdown_connection(NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+}
+
+/**
+ * Test negative scenario of deleting a mesh connection - nulled conn
+ */
+TEST(APITests_MeshConnection, TestNegative_DeleteConnection_NulledConn) {
+    MeshConnection *conn = NULL;
+    int err;
+
+    APITests_Setup();
+
+    err = mesh_delete_connection(NULL);
+    ASSERT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+
+    err = mesh_delete_connection(&conn);
+    EXPECT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+    EXPECT_EQ(conn, (MeshConnection *)NULL);
+}
+
+/**
+ * Test getting and putting of a mesh buffer
+ */
+TEST(APITests_MeshBuffer, Test_GetPutBuffer) {
+    MeshConfig_Memif memif_cfg = { 0 };
+    MeshConfig_Video video_cfg = { 0 };
+    MeshConnection *conn = NULL;
+    MeshBuffer *buf = NULL;
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    err = mesh_create_client(&mc, NULL);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+    ASSERT_NE(mc, (MeshClient *)NULL);
+
+    err = mesh_create_connection(mc, &conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(conn, (MeshConnection *)NULL);
+    if (err || !conn)
+        goto exit_delete_client;
+
+    err = mesh_apply_connection_config_memif(conn, &memif_cfg);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    if (err)
+        goto exit_delete_conn;
+
+    err = mesh_apply_connection_config_video(conn, &video_cfg);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    if (err)
+        goto exit_delete_conn;
+
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    if (err)
+        goto exit_delete_conn;
+
+    /**
+     * Case A - Get buffer with default timeout
+     */
+    err = mesh_get_buffer(conn, &buf);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(buf, (MeshBuffer *)NULL);
+    EXPECT_EQ(buf->conn, conn);
+    EXPECT_EQ(buf->data, (void *)NULL);
+    EXPECT_EQ(buf->data_len, 192); /* Magic number hardcoded in mock function */
+    EXPECT_EQ(__last_timeout, -1);
+    if (err || !buf)
+        goto exit_delete_conn;
+
+    err = mesh_put_buffer(&buf);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(buf, (MeshBuffer *)NULL);
+
+    /**
+     * Case B - Get buffer with an infinite timeout
+     */
+    err = mesh_get_buffer_timeout(conn, &buf, MESH_TIMEOUT_INFINITE);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(buf, (MeshBuffer *)NULL);
+    EXPECT_EQ(buf->conn, conn);
+    EXPECT_EQ(buf->data, (void *)NULL);
+    EXPECT_EQ(buf->data_len, 192); /* Magic number hardcoded in mock function */
+    EXPECT_EQ(__last_timeout, -1);
+    if (err || !buf)
+        goto exit_delete_conn;
+
+    err = mesh_put_buffer(&buf);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(buf, (MeshBuffer *)NULL);
+
+    /**
+     * Case C - Get buffer with a zero timeout
+     */
+    err = mesh_get_buffer_timeout(conn, &buf, MESH_TIMEOUT_ZERO);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(buf, (MeshBuffer *)NULL);
+    EXPECT_EQ(buf->conn, conn);
+    EXPECT_EQ(buf->data, (void *)NULL);
+    EXPECT_EQ(buf->data_len, 192); /* Magic number hardcoded in mock function */
+    EXPECT_EQ(__last_timeout, 0);
+    if (err || !buf)
+        goto exit_delete_conn;
+
+    err = mesh_put_buffer(&buf);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(buf, (MeshBuffer *)NULL);
+
+    /**
+     * Case D - Get buffer with a 5000ms timeout
+     */
+    err = mesh_get_buffer_timeout(conn, &buf, 5000);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_NE(buf, (MeshBuffer *)NULL);
+    EXPECT_EQ(buf->conn, conn);
+    EXPECT_EQ(buf->data, (void *)NULL);
+    EXPECT_EQ(buf->data_len, 192); /* Magic number hardcoded in mock function */
+    EXPECT_EQ(__last_timeout, 5000);
+    if (err || !buf)
+        goto exit_delete_conn;
+
+    err = mesh_put_buffer(&buf);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(buf, (MeshBuffer *)NULL);
+
+exit_delete_conn:
+    err = mesh_delete_connection(&conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(conn, (MeshConnection *)NULL);
+
+exit_delete_client:
+    err = mesh_delete_client(&mc);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(mc, (MeshClient *)NULL);
+}
+
+/**
+ * Test getting a mesh buffer when connection is closed
+ */
+TEST(APITests_MeshBuffer, Test_GetBufferConnClosed) {
+    MeshConfig_Memif memif_cfg = { 0 };
+    MeshConfig_Video video_cfg = { 0 };
+    MeshConnection *conn = NULL;
+    MeshBuffer *buf = NULL;
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, NULL);
+    mesh_create_connection(mc, &conn);
+    mesh_apply_connection_config_memif(conn, &memif_cfg);
+    mesh_apply_connection_config_video(conn, &video_cfg);
+    mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+
+    /**
+     * Magic number 12345 is used below as a timeout value to tell
+     * the mock function to simulate that the connection is closed.
+     */
+    err = mesh_get_buffer_timeout(conn, &buf, 12345);
+    EXPECT_EQ(err, -MESH_ERR_CONN_CLOSED) << mesh_err2str(err);
+    EXPECT_EQ(buf, (MeshBuffer *)NULL);
+
+    mesh_delete_connection(&conn);
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test getting a mesh buffer with default timeout
+ */
+TEST(APITests_MeshBuffer, Test_GetBufferDefaultTimeout) {
+    MeshConfig_Memif memif_cfg = { 0 };
+    MeshConfig_Video video_cfg = { 0 };
+    MeshClientConfig mc_cfg = { 0 };
+    MeshConnection *conn = NULL;
+    MeshBuffer *buf = NULL;
+    MeshClient *mc = NULL;
+    int err;
+
+    APITests_Setup();
+
+    /**
+     * Case A - Get buffer with implicitly specified default timeout
+     */
+    mc_cfg.timeout_ms = 1000;
+    err = mesh_create_client(&mc, &mc_cfg);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_create_connection(mc, &conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    if (err || !conn)
+        goto exit;
+
+    mesh_apply_connection_config_memif(conn, &memif_cfg);
+    mesh_apply_connection_config_video(conn, &video_cfg);
+    
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    if (err || !conn)
+        goto exit;
+
+    err = mesh_get_buffer(conn, &buf);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(__last_timeout, 1000);
+
+    mesh_put_buffer(&buf);
+    mesh_delete_connection(&conn);
+    mesh_delete_client(&mc);
+
+    /**
+     * Case B - Get buffer with explicitly specified default timeout
+     */
+    mc_cfg.timeout_ms = 2000;
+    err = mesh_create_client(&mc, &mc_cfg);
+    ASSERT_EQ(err, 0) << mesh_err2str(err);
+
+    err = mesh_create_connection(mc, &conn);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    if (err || !conn)
+        goto exit;
+
+    mesh_apply_connection_config_memif(conn, &memif_cfg);
+    mesh_apply_connection_config_video(conn, &video_cfg);
+    
+    err = mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    if (err || !conn)
+        goto exit;
+
+    err = mesh_get_buffer_timeout(conn, &buf, MESH_TIMEOUT_DEFAULT);
+    EXPECT_EQ(err, 0) << mesh_err2str(err);
+    EXPECT_EQ(__last_timeout, 2000);
+
+    mesh_put_buffer(&buf);
+    mesh_delete_connection(&conn);
+
+exit:
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test negative scenario of getting a mesh buffer - nulled conn and buffer
+ */
+TEST(APITests_MeshBuffer, TestNegative_GetBuffer_NulledConnAndBuf) {
+    int err;
+
+    APITests_Setup();
+
+    err = mesh_get_buffer(NULL, NULL);
+    EXPECT_EQ(err, -MESH_ERR_BAD_CONN_PTR) << mesh_err2str(err);
+}
+
+/**
+ * Test negative scenario of getting a mesh buffer - nulled buffer
+ */
+TEST(APITests_MeshBuffer, TestNegative_GetBuffer_NulledBuf) {
+    MeshConfig_Memif memif_cfg = { 0 };
+    MeshConfig_Video video_cfg = { 0 };
+    MeshConnection *conn;
+    MeshClient *mc;
+    int err;
+
+    APITests_Setup();
+
+    mesh_create_client(&mc, NULL);
+    mesh_create_connection(mc, &conn);
+    mesh_apply_connection_config_memif(conn, &memif_cfg);
+    mesh_apply_connection_config_video(conn, &video_cfg);
+    mesh_establish_connection(conn, MESH_CONN_KIND_SENDER);
+
+    err = mesh_get_buffer(conn, NULL);
+    EXPECT_EQ(err, -MESH_ERR_BAD_BUF_PTR) << mesh_err2str(err);
+
+    mesh_delete_connection(&conn);
+    mesh_delete_client(&mc);
+}
+
+/**
+ * Test negative scenario of putting a mesh buffer - nulled buffer
+ */
+TEST(APITests_MeshBuffer, TestNegative_PutBuffer_NulledBuf) {
+    int err;
+
+    APITests_Setup();
+
+    err = mesh_put_buffer(NULL);
+    EXPECT_EQ(err, -MESH_ERR_BAD_BUF_PTR) << mesh_err2str(err);
+}
+
+/**
+ * Test important constants
+ */
+TEST(APITests_MeshBuffer, Test_ImportantConstants) {
+    ASSERT_EQ(MESH_SOCKET_PATH_SIZE, 108);
+    ASSERT_EQ(MESH_IP_ADDRESS_SIZE,   46);
+
+    ASSERT_EQ(MESH_ERR_BAD_CLIENT_PTR,       1000);
+    ASSERT_EQ(MESH_ERR_BAD_CONN_PTR,         1001);
+    ASSERT_EQ(MESH_ERR_BAD_CONFIG_PTR,       1002);
+    ASSERT_EQ(MESH_ERR_BAD_BUF_PTR,          1003);
+    ASSERT_EQ(MESH_ERR_MAX_CONN,             1004);
+    ASSERT_EQ(MESH_ERR_CONN_FAILED,          1005);
+    ASSERT_EQ(MESH_ERR_CONN_CONFIG_INVAL,    1006);
+    ASSERT_EQ(MESH_ERR_CONN_CONFIG_INCOMPAT, 1007);
+    ASSERT_EQ(MESH_ERR_CONN_CLOSED,          1008);
+    ASSERT_EQ(MESH_ERR_TIMEOUT,              1009);
+
+    ASSERT_EQ(MESH_TIMEOUT_DEFAULT,  -2);
+    ASSERT_EQ(MESH_TIMEOUT_INFINITE, -1);
+    ASSERT_EQ(MESH_TIMEOUT_ZERO,      0);
+}


### PR DESCRIPTION
This PR includes the following commits
* Refactor Mesh Data Plane SDK API.
* Upgrade sample apps to the new SDK API.
* Upgrade FFmpeg video and audio plugins to the new SDK API.
* Remove dependency on mcm_dp.h.
* Resolve API review discussions.
* Calculate RDMA transfer size before creating connection.