### PR TITLE
Wait for shared mem before receiving RDMA buffer

### DIFF
--- a/media-proxy/include/rdma_session.h
+++ b/media-proxy/include/rdma_session.h
@@ -18,6 +18,12 @@ extern "C" {
 #include "shm_memif.h"
 #include "utils.h"
 #include "libfabric_ep.h"
+#ifdef __cplusplus
+#include <atomic>
+using namespace std;
+#else
+#include <stdatomic.h>
+#endif
 
 typedef struct {
     size_t transfer_size;
@@ -54,7 +60,7 @@ typedef struct {
 
     memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
-    uint8_t shm_ready;
+    atomic_bool shm_ready;
 
     char name[32];
     memif_socket_args_t memif_socket_args;
@@ -89,7 +95,7 @@ typedef struct {
 
     memif_buffer_t *shm_bufs;
     uint16_t shm_buf_num;
-    uint8_t shm_ready;
+    atomic_bool shm_ready;
 
     char name[32];
     pthread_t memif_event_thread;

--- a/media-proxy/src/shm_memif_rdma.c
+++ b/media-proxy/src/shm_memif_rdma.c
@@ -38,7 +38,7 @@ int rx_rdma_on_connect(memif_conn_handle_t conn, void *priv_data)
 
     print_memif_details(conn);
 
-    rx_ctx->shm_ready = 1;
+    atomic_store(&rx_ctx->shm_ready, true);
 
     return 0;
 }
@@ -57,10 +57,10 @@ int rx_rdma_on_disconnect(memif_conn_handle_t conn, void *priv_data)
     }
 
     // release session
-    if (!rx_ctx->shm_ready) {
+    if (!atomic_load(&rx_ctx->shm_ready)) {
         return 0;
     }
-    rx_ctx->shm_ready = 0;
+    atomic_store(&rx_ctx->shm_ready, false);
 
     /* stop event polling thread */
     INFO("RX RDMA Stop poll event");
@@ -91,7 +91,7 @@ int tx_rdma_on_connect(memif_conn_handle_t conn, void *priv_data)
         return err;
     }
 
-    tx_ctx->shm_ready = 1;
+    atomic_store(&tx_ctx->shm_ready, true);
 
     print_memif_details(conn);
 
@@ -113,10 +113,10 @@ int tx_rdma_on_disconnect(memif_conn_handle_t conn, void *priv_data)
     }
 
     // release session
-    if (!tx_ctx->shm_ready) {
+    if (!atomic_load(&tx_ctx->shm_ready)) {
         return 0;
     }
-    tx_ctx->shm_ready = 0;
+    atomic_store(&tx_ctx->shm_ready, false);
 
     /* stop event polling thread */
     INFO("TX Stop poll event");

--- a/media-proxy/src/shm_memif_rdma.c
+++ b/media-proxy/src/shm_memif_rdma.c
@@ -38,7 +38,7 @@ int rx_rdma_on_connect(memif_conn_handle_t conn, void *priv_data)
 
     print_memif_details(conn);
 
-    atomic_store(&rx_ctx->shm_ready, true);
+    atomic_store_explicit(&rx_ctx->shm_ready, true, memory_order_release);
 
     return 0;
 }
@@ -56,11 +56,11 @@ int rx_rdma_on_disconnect(memif_conn_handle_t conn, void *priv_data)
         return -EINVAL;
     }
 
-    // release session
-    if (!atomic_load(&rx_ctx->shm_ready)) {
+    /* release session */
+    if (!atomic_load_explicit(&rx_ctx->shm_ready, memory_order_relaxed)) {
         return 0;
     }
-    atomic_store(&rx_ctx->shm_ready, false);
+    atomic_store_explicit(&rx_ctx->shm_ready, false, memory_order_relaxed);
 
     /* stop event polling thread */
     INFO("RX RDMA Stop poll event");
@@ -91,7 +91,7 @@ int tx_rdma_on_connect(memif_conn_handle_t conn, void *priv_data)
         return err;
     }
 
-    atomic_store(&tx_ctx->shm_ready, true);
+    atomic_store_explicit(&tx_ctx->shm_ready, true, memory_order_release);
 
     print_memif_details(conn);
 
@@ -112,11 +112,11 @@ int tx_rdma_on_disconnect(memif_conn_handle_t conn, void *priv_data)
         return -EINVAL;
     }
 
-    // release session
-    if (!atomic_load(&tx_ctx->shm_ready)) {
+    /* release session */
+    if (!atomic_load_explicit(&tx_ctx->shm_ready, memory_order_relaxed)) {
         return 0;
     }
-    atomic_store(&tx_ctx->shm_ready, false);
+    atomic_store_explicit(&tx_ctx->shm_ready, false, memory_order_relaxed);
 
     /* stop event polling thread */
     INFO("TX Stop poll event");

--- a/sdk/samples/recver_app.c
+++ b/sdk/samples/recver_app.c
@@ -315,11 +315,6 @@ int main(int argc, char** argv)
     strlcpy(param.local_addr.port, recv_port, sizeof(param.local_addr.port));
     strlcpy(param.local_addr.ip, recv_addr, sizeof(param.local_addr.ip));
 
-    dp_ctx = mcm_create_connection(&param);
-    if (dp_ctx == NULL) {
-        printf("Fail to connect to MCM data plane\n");
-        exit(-1);
-    }
     signal(SIGINT, intHandler);
 
     uint32_t frame_count = 0;
@@ -340,6 +335,12 @@ int main(int argc, char** argv)
 
     if (strlen(file_name) > 0) {
         dump_fp = fopen(file_name, "wb");
+    }
+
+    dp_ctx = mcm_create_connection(&param);
+    if (dp_ctx == NULL) {
+        printf("Fail to connect to MCM data plane\n");
+        exit(-1);
     }
 
     while (keepRunning) {


### PR DESCRIPTION
There was a possibility that rx_rdma_consume_frame() was called from rx_rdma_frame_thread() before shared memory was ready. This caused timeout on memif_buffer_alloc_timeout() and frame was dropped.


