### PR TITLE
Ci/Cd: Added Docker Buildx Caching

### DIFF
--- a/.github/workflows/ubuntu-docker.yml
+++ b/.github/workflows/ubuntu-docker.yml
@@ -22,34 +22,50 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@5927c834f5b4fdf503fca6f4c7eccda82949e1ee # v3.1.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
         with:
-          buildkitd-flags: --debug
+          buildkitd-flags: --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
+          cache-binary: true
+          driver-opts: |
+            image=moby/buildkit:master
+            network=host
+          install: true
+          platforms: linux/amd64
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push SDK sample apps
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           file: sdk/Dockerfile
-          context: .
-          push: false
           tags: "mcm/sdk:${{ github.sha }}"
+          context: .
+          push: true
+          cache-from: type=registry,ref=mcm/sdk:buildcache
+          cache-to: type=registry,ref=mcm/sdk:buildcache,mode=max
 
       - name: Build and push ffmpeg and plugins
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           file: ffmpeg-plugin/Dockerfile
-          context: .
-          push: false
           tags: "mcm/ffmpeg:${{ github.sha }}"
+          context: .
+          push: true
+          cache-from: type=registry,ref=mcm/ffmpeg:buildcache
+          cache-to: type=registry,ref=mcm/ffmpeg:buildcache,mode=max
 
       - name: Build and push media proxy application
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           file: media-proxy/Dockerfile
-          context: .
-          push: false
           tags: "mcm/media-proxy:${{ github.sha }}"
+          context: .
+          push: true
+          cache-from: type=registry,ref=mcm/media-proxy:buildcache
+          cache-to: type=registry,ref=mcm/media-proxy:buildcache,mode=max


### PR DESCRIPTION
Ci/Cd: Added Docker Buildx Caching:
- each stage have now a cache reference added
- each image can now be pushed to namespaced registry
- removed unused architectures and QEMU builder