### PR TITLE
zLukas/trivy-raporting upgrade

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,14 +31,23 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ inputs.branch }}
-      - name: Run Trivy vulnerability scanner for 'config'
+      - name: Run Trivy vulnerability scanner for 'config' with sarif output
         uses: aquasecurity/trivy-action@7c2007bcb556501da015201bcba5aa14069b74e2 # v0.23.0
         with:
           scan-type: config
           skip-dirs: deployment #helm charts not supported 
-          exit-code: '1'
+          exit-code: '0'
           format: 'sarif'
           output: 'trivy-results.sarif'
+      - name: Run Trivy vulnerability scanner for 'config' with table output
+        if: always()
+        uses: aquasecurity/trivy-action@7c2007bcb556501da015201bcba5aa14069b74e2 # v0.23.0
+        with:
+          scan-type: config
+          skip-dirs: deployment #helm charts not supported 
+          exit-code: '0'
+          format: 'table'
+          output: 'trivy-results.txt'
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
         uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
@@ -48,4 +57,4 @@ jobs:
         if: always()
         with:
           name: trivy-results
-          path: 'trivy-results.sarif'
+          path: 'trivy-results.txt'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-22.04
-    name: Checkout code
+    name: scan
     steps:
 
       - name: Harden Runner

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,6 +40,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
         uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ubuntu-docker.yml
+++ b/.github/workflows/ubuntu-docker.yml
@@ -34,6 +34,7 @@ jobs:
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           file: sdk/Dockerfile
+          allow: network.host
           context: .
           push: false
           tags: "mcm/sdk:${{ github.sha }}"
@@ -42,6 +43,7 @@ jobs:
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           file: ffmpeg-plugin/Dockerfile
+          allow: network.host
           context: .
           push: false
           tags: "mcm/ffmpeg:${{ github.sha }}"
@@ -50,6 +52,7 @@ jobs:
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           file: media-proxy/Dockerfile
+          allow: network.host
           context: .
           push: false
           tags: "mcm/media-proxy:${{ github.sha }}"


### PR DESCRIPTION
ADD:
* Trivy will fail if it find any errors, and by default, it stops the rest of the pipeline, set upload steps, upload SARIF and update security tab regardless, the Trivy scan status
* add second trivy status with table output (human redable)