### PR TITLE
Remove doubled lines of code in recver_app

### DIFF
--- a/sdk/samples/recver_app.c
+++ b/sdk/samples/recver_app.c
@@ -379,9 +379,6 @@ int main(int argc, char** argv)
 
             latency = 1000.0 * (ts_recv.tv_sec - ts_send.tv_sec);
             latency += (ts_recv.tv_nsec - ts_send.tv_nsec) / 1000000.0;
-            latency = 1000.0 * (ts_recv.tv_sec - ts_send.tv_sec);
-            latency += (ts_recv.tv_nsec - ts_send.tv_nsec) / 1000000.0;
-
         }
 
         if (frame_count % stat_interval == 0) {


### PR DESCRIPTION
Commit a4f5e3d673dc ("Refactor MCM Data Plane SDK API + upgrade FFmpeg plugins and sample apps (#213)") occassionally doubled two lines of code in recver_app.c. It might happened due to manual rebase mistakes.

Remove the doubled lines.

Fixes: a4f5e3d673dc ("Refactor MCM Data Plane SDK API + upgrade FFmpeg plugins and sample apps (#213)")

Change-type: DefectResolution