### PR TITLE
Remove dependency on memif from SDK API header

### DIFF
--- a/sdk/include/mesh_dp.h
+++ b/sdk/include/mesh_dp.h
@@ -14,7 +14,6 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include "libmemif.h"
 
 /**
  * Mesh SDK API version

--- a/sdk/src/mesh_dp.c
+++ b/sdk/src/mesh_dp.c
@@ -12,6 +12,7 @@
 #include <bsd/string.h>
 #include <stdatomic.h>
 #include <unistd.h>
+#include "libmemif.h"
 
 /**
  * Isolation interface for testability. Accessed from unit tests only.


### PR DESCRIPTION
This is a quick fix to remove libmemif.h from includes in the SDK API header.