### PR TITLE
Fixed: Crone job in workflows. codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
   schedule:
-    - cron: '42 8 * * 1'
+    - cron: '0 18 * * 1-5'
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,11 +2,11 @@ name: Scan Coverity Ubuntu Scan
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 18 * * *'
   workflow_dispatch:
     inputs:
       branch:
-        description: 'branch to run scans on'
+        description: 'Branch to run scans on'
         default: 'main'
         type: string
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,7 +10,7 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '16 4 * * 6'
+    - cron: '0 18 * * *'
   workflow_dispatch:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Fixes in: `codeql.yml`
- Unification of build and scan schedules `codeql.yml`.
- Set to cron:  `0 18 * * 1-5`
Fix: Cron job update in `coverity.yml`
- Scan Coverity on Ubuntu set to schedule:
- `cron: '0 18 * * *'`
Fix: Cron jo update in `scorecard.yml`
- Scan Coverity on Ubuntu set to schedule:
- `cron: '0 18 * * *'`
