### PR TITLE
Fix multiple Coverity issues

### DIFF
--- a/media-proxy/include/session-mtl.h
+++ b/media-proxy/include/session-mtl.h
@@ -60,7 +60,7 @@ class RxSt20MtlSession : public MtlSession
     size_t source_begin_iova_map_sz;
 #endif
 
-    void copy_connection_params(const mcm_conn_param &request, std::string dev_port);
+    void copy_connection_params(const mcm_conn_param &request, std::string &dev_port);
     void consume_frame(struct st_frame *frame);
     void frame_thread();
 
@@ -94,7 +94,7 @@ class TxSt20MtlSession : public MtlSession
     size_t source_begin_iova_map_sz;
 #endif
 
-    void copy_connection_params(const mcm_conn_param &request, std::string dev_port);
+    void copy_connection_params(const mcm_conn_param &request, std::string &dev_port);
     int on_receive_cb(memif_conn_handle_t conn, uint16_t qid);
 
 #if defined(MTL_ZERO_COPY)
@@ -128,7 +128,7 @@ class RxSt22MtlSession : public MtlSession
     size_t source_begin_iova_map_sz;
 #endif
 
-    void copy_connection_params(const mcm_conn_param &request, std::string dev_port);
+    void copy_connection_params(const mcm_conn_param &request, std::string &dev_port);
     void consume_frame(struct st_frame *frame);
     void frame_thread();
 
@@ -162,7 +162,7 @@ class TxSt22MtlSession : public MtlSession
     size_t source_begin_iova_map_sz;
 #endif
 
-    void copy_connection_params(const mcm_conn_param &request, std::string dev_port);
+    void copy_connection_params(const mcm_conn_param &request, std::string &dev_port);
     int on_receive_cb(memif_conn_handle_t conn, uint16_t qid);
 
 #if defined(MTL_ZERO_COPY)
@@ -188,7 +188,7 @@ class RxSt30MtlSession : public MtlSession
     std::thread *frame_thread_handle;
 
     void consume_frame(struct st30_frame *frame);
-    void copy_connection_params(const mcm_conn_param &request, std::string dev_port);
+    void copy_connection_params(const mcm_conn_param &request, std::string &dev_port);
     void frame_thread();
 
   public:
@@ -205,7 +205,7 @@ class TxSt30MtlSession : public MtlSession
 
     int fb_send;
 
-    void copy_connection_params(const mcm_conn_param &request, std::string dev_port);
+    void copy_connection_params(const mcm_conn_param &request, std::string &dev_port);
     int on_receive_cb(memif_conn_handle_t conn, uint16_t qid);
 
   public:

--- a/media-proxy/src/session-mtl-st2110-20-rx.cc
+++ b/media-proxy/src/session-mtl-st2110-20-rx.cc
@@ -243,12 +243,13 @@ void RxSt20MtlSession::consume_frame(struct st_frame *frame)
     }
 
 #if defined(MTL_ZERO_COPY)
+    fifo_mtx.lock();
     if (fifo.empty()) {
+        fifo_mtx.unlock();
         ERROR("%s FIFO empty \n", __func__);
         return;
     }
 
-    fifo_mtx.lock();
     rx_buf = fifo.front();
     fifo.pop();
     fifo_mtx.unlock();

--- a/media-proxy/src/session-mtl-st2110-20-rx.cc
+++ b/media-proxy/src/session-mtl-st2110-20-rx.cc
@@ -180,6 +180,7 @@ RxSt20MtlSession::RxSt20MtlSession(mtl_handle dev_handle, const mcm_conn_param &
     ops.flags |= ST20P_RX_FLAG_EXT_FRAME;
     ops.flags |= ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
     ops.query_ext_frame = query_ext_frame_callback_wrapper;
+    source_begin_iova_map_sz = 0;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-20-rx.cc
+++ b/media-proxy/src/session-mtl-st2110-20-rx.cc
@@ -114,7 +114,7 @@ void RxSt20MtlSession::frame_thread()
     }
 }
 
-void RxSt20MtlSession::copy_connection_params(const mcm_conn_param &request, std::string dev_port)
+void RxSt20MtlSession::copy_connection_params(const mcm_conn_param &request, std::string &dev_port)
 {
     char session_name[NAME_MAX] = "";
     snprintf(session_name, NAME_MAX, "mcm_rx_st20_%d", get_id());

--- a/media-proxy/src/session-mtl-st2110-20-rx.cc
+++ b/media-proxy/src/session-mtl-st2110-20-rx.cc
@@ -181,6 +181,8 @@ RxSt20MtlSession::RxSt20MtlSession(mtl_handle dev_handle, const mcm_conn_param &
     ops.flags |= ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
     ops.query_ext_frame = query_ext_frame_callback_wrapper;
     source_begin_iova_map_sz = 0;
+    source_begin_iova = {0};
+    source_begin = nullptr;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-20-tx.cc
+++ b/media-proxy/src/session-mtl-st2110-20-tx.cc
@@ -131,6 +131,7 @@ TxSt20MtlSession::TxSt20MtlSession(mtl_handle dev_handle, const mcm_conn_param &
 #if defined(MTL_ZERO_COPY)
     ops.notify_frame_done = tx_frame_done_callback_wrapper;
     ops.flags |= ST20P_TX_FLAG_EXT_FRAME;
+    source_begin_iova_map_sz = 0;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-20-tx.cc
+++ b/media-proxy/src/session-mtl-st2110-20-tx.cc
@@ -132,6 +132,8 @@ TxSt20MtlSession::TxSt20MtlSession(mtl_handle dev_handle, const mcm_conn_param &
     ops.notify_frame_done = tx_frame_done_callback_wrapper;
     ops.flags |= ST20P_TX_FLAG_EXT_FRAME;
     source_begin_iova_map_sz = 0;
+    source_begin_iova = {0};
+    source_begin = nullptr;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-20-tx.cc
+++ b/media-proxy/src/session-mtl-st2110-20-tx.cc
@@ -71,7 +71,7 @@ int TxSt20MtlSession::on_disconnect_cb(memif_conn_handle_t conn)
 }
 #endif
 
-void TxSt20MtlSession::copy_connection_params(const mcm_conn_param &request, std::string dev_port)
+void TxSt20MtlSession::copy_connection_params(const mcm_conn_param &request, std::string &dev_port)
 {
     char session_name[NAME_MAX] = "";
 

--- a/media-proxy/src/session-mtl-st2110-22 rx.cc
+++ b/media-proxy/src/session-mtl-st2110-22 rx.cc
@@ -244,12 +244,13 @@ void RxSt22MtlSession::consume_frame(struct st_frame *frame)
     }
 
 #if defined(MTL_ZERO_COPY)
+    fifo_mtx.lock();
     if (fifo.empty()) {
+        fifo_mtx.unlock();
         ERROR("%s FIFO empty \n", __func__);
         return;
     }
 
-    fifo_mtx.lock();
     rx_buf = fifo.front();
     fifo.pop();
     fifo_mtx.unlock();

--- a/media-proxy/src/session-mtl-st2110-22 rx.cc
+++ b/media-proxy/src/session-mtl-st2110-22 rx.cc
@@ -184,6 +184,8 @@ RxSt22MtlSession::RxSt22MtlSession(mtl_handle dev_handle, const mcm_conn_param &
     ops.flags |= ST22P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
     ops.query_ext_frame = query_ext_frame_callback_wrapper;
     source_begin_iova_map_sz = 0;
+    source_begin_iova = {0};
+    source_begin = nullptr;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-22 rx.cc
+++ b/media-proxy/src/session-mtl-st2110-22 rx.cc
@@ -183,6 +183,7 @@ RxSt22MtlSession::RxSt22MtlSession(mtl_handle dev_handle, const mcm_conn_param &
     ops.flags |= ST22P_RX_FLAG_EXT_FRAME;
     ops.flags |= ST22P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
     ops.query_ext_frame = query_ext_frame_callback_wrapper;
+    source_begin_iova_map_sz = 0;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-22 rx.cc
+++ b/media-proxy/src/session-mtl-st2110-22 rx.cc
@@ -114,7 +114,7 @@ void RxSt22MtlSession::frame_thread()
     }
 }
 
-void RxSt22MtlSession::copy_connection_params(const mcm_conn_param &request, std::string dev_port)
+void RxSt22MtlSession::copy_connection_params(const mcm_conn_param &request, std::string &dev_port)
 {
     char session_name[NAME_MAX] = "";
     snprintf(session_name, NAME_MAX, "mcm_rx_st22_%d", get_id());

--- a/media-proxy/src/session-mtl-st2110-22-tx.cc
+++ b/media-proxy/src/session-mtl-st2110-22-tx.cc
@@ -135,6 +135,7 @@ TxSt22MtlSession::TxSt22MtlSession(mtl_handle dev_handle, const mcm_conn_param &
 #if defined(MTL_ZERO_COPY)
     ops.notify_frame_done = tx_frame_done_callback_wrapper;
     ops.flags |= ST22P_TX_FLAG_EXT_FRAME;
+    source_begin_iova_map_sz = 0;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-22-tx.cc
+++ b/media-proxy/src/session-mtl-st2110-22-tx.cc
@@ -136,6 +136,8 @@ TxSt22MtlSession::TxSt22MtlSession(mtl_handle dev_handle, const mcm_conn_param &
     ops.notify_frame_done = tx_frame_done_callback_wrapper;
     ops.flags |= ST22P_TX_FLAG_EXT_FRAME;
     source_begin_iova_map_sz = 0;
+    source_begin_iova = {0};
+    source_begin = nullptr;
 #endif
 }
 

--- a/media-proxy/src/session-mtl-st2110-22-tx.cc
+++ b/media-proxy/src/session-mtl-st2110-22-tx.cc
@@ -71,7 +71,7 @@ int TxSt22MtlSession::on_disconnect_cb(memif_conn_handle_t conn)
 }
 #endif
 
-void TxSt22MtlSession::copy_connection_params(const mcm_conn_param &request, std::string dev_port)
+void TxSt22MtlSession::copy_connection_params(const mcm_conn_param &request, std::string &dev_port)
 {
     char session_name[NAME_MAX] = "";
 

--- a/media-proxy/src/session-mtl-st2110-30-rx.cc
+++ b/media-proxy/src/session-mtl-st2110-30-rx.cc
@@ -23,7 +23,7 @@ void RxSt30MtlSession::frame_thread()
     }
 }
 
-void RxSt30MtlSession::copy_connection_params(const mcm_conn_param &request, std::string dev_port)
+void RxSt30MtlSession::copy_connection_params(const mcm_conn_param &request, std::string &dev_port)
 {
     char session_name[NAME_MAX] = "";
     snprintf(session_name, NAME_MAX, "mcm_rx_st30_%d", get_id());

--- a/media-proxy/src/session-mtl-st2110-30-tx.cc
+++ b/media-proxy/src/session-mtl-st2110-30-tx.cc
@@ -6,7 +6,7 @@
 
 #include "session-mtl.h"
 
-void TxSt30MtlSession::copy_connection_params(const mcm_conn_param &request, std::string dev_port)
+void TxSt30MtlSession::copy_connection_params(const mcm_conn_param &request, std::string &dev_port)
 {
     char session_name[NAME_MAX] = "";
 

--- a/media-proxy/src/session-rdma-rx.cc
+++ b/media-proxy/src/session-rdma-rx.cc
@@ -85,7 +85,7 @@ void RxRdmaSession::frame_thread()
 RxRdmaSession::RxRdmaSession(libfabric_ctx *dev_handle, const mcm_conn_param &request,
                              memif_ops_t &memif_ops)
     : Session(memif_ops, request.payload_type, RX), ep_cfg{0}, ep_ctx(0), stop(false),
-      frame_thread_handle(0), fb_recv(0), shm_bufs(0)
+      frame_thread_handle(0), fb_recv(0), shm_bufs(0), shm_buf_num(0)
 {
     transfer_size = request.payload_args.rdma_args.transfer_size;
 


### PR DESCRIPTION
1. Add initialization of source_begin_iova_map_sz, shm_buf_num
2. Pass dev_port by reference 
3.  Apply lock before accesing fifo.empty()