### PR TITLE
[MCM] Adjust setup-script to `dnf`/`yum`. Fix fail on errors:

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,4 +28,4 @@ run_as_root_user ln -s /usr/lib64/libbpf.so.1 /usr/lib/x86_64-linux-gnu/libbpf.s
 run_as_root_user ldconfig
 
 # Run unit tests
-LD_LIBRARY_PATH="${PREFIX_DIR}/usr/local/lib:/usr/local/lib" "${BUILD_DIR}/bin/mcm_unit_tests"
+LD_LIBRARY_PATH="${PREFIX_DIR}/usr/local/lib:/usr/local/lib64" "${BUILD_DIR}/bin/mcm_unit_tests"

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ The Media Communications Mesh (MCM) enables efficient, low-latency media transpo
 
 3. **Install Dependencies**, choose between options `a)` or `b)`.
 
-    a) Use all-in-one environment preparation script. The script is designed for Debian and was tested under `Ubuntu 20.04` and `Ubuntu 22.04`, kernel version 5.15 environments.
+    a) Use all-in-one environment preparation script. The script was tested under `Ubuntu 20.04`, `Ubuntu 22.04`, `Ubuntu 24.04`, `CentOS Stream8`, `CentOS Stream9` and kernel version `5.15` environments.
 
     To use this option run the following command:
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -413,6 +413,32 @@ function config_intel_rdma_driver() {
     prompt "Configuration of iRDMA finished."
 }
 
+# Example usage:
+#    PM="$(setup_package_manager)" && \
+#    $PM install python3
+function setup_package_manager()
+{
+    TIBER_USE_PM="${PM:-$1}"
+    if [[ -x "$(command -v "$TIBER_USE_PM")" ]]; then
+        export PM="${TIBER_USE_PM}"
+    elif [[ -x "$(command -v yum)" ]]; then
+        export PM='yum'
+    elif [[ -x "$(command -v dnf)" ]]; then
+        export PM='dnf'
+    elif [[ -x "$(command -v apt-get)" ]]; then
+        export PM='apt-get'
+    elif [[ -x "$(command -v apt)" ]]; then
+        export PM='apt'
+    else
+        error "No known pkg manager found. Try to re-run with variable, example:"
+        error "export PM=\"apt\""
+        return 1
+    fi
+    prompt "Setting pkg manager to ${PM}."
+    echo "${PM}"
+    return 0
+}
+
 function exec_command()
 {
     # One of: yes|no|accept-new

--- a/scripts/setup_build_env.sh
+++ b/scripts/setup_build_env.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-set -eo pipefail
+set -eEo pipefail
 
 SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
 REPO_DIR="$(readlink -f "${SCRIPT_DIR}/..")"
 
 . "${SCRIPT_DIR}/common.sh"
 
+export PM="${PM:-apt-get}"
 export MCM_DIR="${BUILD_DIR}/mcm"
 export MTL_VER="${MTL_VER:-maint-24.09}" # maint-24.09
 export MTL_DIR="${BUILD_DIR}/mtl"
@@ -24,9 +25,22 @@ export JPEGXS_DIR="${BUILD_DIR}/jpegxs"
 export LIBFABRIC_VER="${LIBFABRIC_VER:-v1.22.0}"
 export LIBFABRIC_DIR="${BUILD_DIR}/libfabric"
 
+nproc="$(nproc)"
+export MAKEFLAGS="-j${nproc:-100}"
+
+KERNEL_VERSION="$(uname -r)"
+export KERNEL_VERSION
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/lib/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib/x86_64-linux-gnu/pkgconfig"
+export NASM_RPM_LINK="https://rpmfind.net/linux/centos-stream/9-stream/CRB/x86_64/os/Packages/nasm-2.15.03-7.el9.x86_64.rpm"
+export LIBFDT_DIR="${BUILD_DIR}/libfdt"
+export LIBFDT_REPO="https://github.com/dgibson/dtc/archive/refs/tags/v1.7.2.tar.gz"
+export JSONC_DIR="${BUILD_DIR}/json-c"
+export JSONC_REPO="https://github.com/json-c/json-c/archive/refs/tags/json-c-0.18-20240915.tar.gz"
+export LIBSDL2_DIR="${BUILD_DIR}/libsdl2"
+export LIBSDL2_REPO="https://github.com/libsdl-org/SDL/releases/download/release-2.30.9/SDL2-2.30.9.tar.gz"
+
 function get_and_patch_intel_drivers()
 {
-    set -x
     if [ ! -d "${MTL_DIR}/patches/ice_drv/${ICE_VER}/" ]; then
         error "MTL patch for ICE=v${ICE_VER} could not be found: ${MTL_DIR}/patches/ice_drv/${ICE_VER}"
         return 1
@@ -38,12 +52,10 @@ function get_and_patch_intel_drivers()
     pushd "${ICE_DIR}"
     patch -p1 -i <(cat "${MTL_DIR}/patches/ice_drv/${ICE_VER}/"*.patch)
     popd
-    set +x
 }
 
 function build_install_and_config_intel_drivers()
 {
-    set -x
     make -j "${NPROC}" -C "${IAVF_DIR}/src" install
     make -j "${NPROC}" -C "${ICE_DIR}/src" install
     pushd "${IRDMA_DIR}"
@@ -51,16 +63,26 @@ function build_install_and_config_intel_drivers()
     popd
     config_intel_rdma_driver
     modprobe irdma
-    set +x
 }
 
+function install_package_dependencies()
+{
+    setup_package_manager "apt-get"
+    if [[ "${PM}" == "apt" || "${PM}" == "apt-get" ]]; then
+        install_ubuntu_package_dependencies
+    elif [[ "${PM}" == "yum" || "${PM}" == "dnf" ]]; then
+        install_yum_package_dependencies
+    else
+        error No supported package manager found
+        exit 1
+    fi
+}
 function install_ubuntu_package_dependencies()
 {
-    set -x
-    APT_LINUX_HEADERS="linux-headers-$(uname -r)"
-    APT_LINUX_MOD_EXTRA="linux-modules-extra-$(uname -r)"
-    apt-get update --fix-missing && \
-    apt-get install --no-install-recommends -y \
+    APT_LINUX_HEADERS="linux-headers-${KERNEL_VERSION}"
+    APT_LINUX_MOD_EXTRA="linux-modules-extra-${KERNEL_VERSION}"
+    "${PM}" update --fix-missing && \
+    "${PM}" install --no-install-recommends -y \
         apt-transport-https \
         autoconf \
         automake \
@@ -99,124 +121,190 @@ function install_ubuntu_package_dependencies()
         zlib1g-dev \
         "${APT_LINUX_HEADERS}" \
         "${APT_LINUX_MOD_EXTRA}"
-    set +x
     return 0
+}
+
+function install_yum_package_dependencies()
+{
+    "${PM}" -y update
+    "${PM}" -y install epel-release
+    "${PM}" -y makecache --refresh
+    "${PM}" -y distro-sync
+    "${PM}" -y group install "Development Tools"
+    "${PM}" -y install \
+        autoconf \
+        automake \
+        bzip2 \
+        ca-certificates \
+        clang \
+        cmake \
+        dracut \
+        dtc \
+        elfutils-libelf-devel \
+        git \
+        glibc-devel.i686 \
+        glibc-devel.x86_64 \
+        gtest-devel \
+        intel-ipp-crypto-mb \
+        intel-ipsec-mb \
+        kernel-headers \
+        kernel-modules-extra \
+        libbpf \
+        libbsd-devel \
+        libcap-ng-devel \
+        libfdt \
+        libibverbs-devel \
+        libjson* \
+        libpcap-devel \
+        librdmacm-devel \
+        libtool \
+        llvm \
+        libxdp \
+        m4 \
+        nss \
+        numactl-devel \
+        openssl-devel \
+        pkg-config \
+        python3 \
+        python3-devel \
+        python3-pyelftools \
+        rdma-core \
+        sudo \
+        systemtap-sdt-devel \
+        SDL2-devel \
+        SDL2_net-devel \
+        SDL2_ttf-devel \
+        texinfo \
+        wget \
+        zlib-devel && \
+    wget --tries=5 --progress=dot:giga "${NASM_RPM_LINK}" && \
+    "${PM}" -y localinstall nasm-*.rpm && \
+    rm -f "${NASM_RPM_LINK}" && \
+    python3 -m pip install meson ninja && \
+    mkdir -p "${LIBFDT_DIR}" "${JSONC_DIR}" "${LIBSDL2_DIR}" && \
+    curl -Lf "${LIBFDT_REPO}" | tar -zx --strip-components=1 -C "${LIBFDT_DIR}" && \
+    make -C "${LIBFDT_DIR}" install && \
+    curl -Lf "${JSONC_REPO}" | tar -zx --strip-components=1 -C "${JSONC_DIR}" && \
+    mkdir -p "${JSONC_DIR}/json-c-build" && \
+    cmake -S "${JSONC_DIR}" -B "${JSONC_DIR}/json-c-build" -DCMAKE_BUILD_TYPE=Release && \
+    make -C "${JSONC_DIR}/json-c-build" install && \
+    return 0 || return 1
 }
 
 # Build the xdp-tools project with ebpf
 function lib_install_xdp_bpf_tools()
 {
-    git_download_strip_unpack "xdp-project/xdp-tools" "${XDP_VER}" "${XDP_DIR}"
-    git_download_strip_unpack "libbpf/libbpf" "${BPF_VER}" "${BPF_DIR}"
-
-    pushd "${XDP_DIR}"
+    git_download_strip_unpack "xdp-project/xdp-tools" "${XDP_VER}" "${XDP_DIR}" && \
+    git_download_strip_unpack "libbpf/libbpf" "${BPF_VER}" "${BPF_DIR}" && \
+    pushd "${XDP_DIR}" && \
     ./configure && \
     make && \
     make install && \
     make -C "${XDP_DIR}/lib/libbpf/src" && \
-    make -C "${XDP_DIR}/lib/libbpf/src" install
-    popd
+    make -C "${XDP_DIR}/lib/libbpf/src" install && \
+    popd && \
+    { ln -s /usr/local/include/xdp/xsk.h /usr/include/bpf/xsk.h || true; } && \
+    return 0 || return 1
 }
 
 # Build and install the libfabrics
 function lib_install_fabrics()
 {
-    git_download_strip_unpack "ofiwg/libfabric" "${LIBFABRIC_VER}" "${LIBFABRIC_DIR}"
-
-    pushd "${LIBFABRIC_DIR}"
+    git_download_strip_unpack "ofiwg/libfabric" "${LIBFABRIC_VER}" "${LIBFABRIC_DIR}" && \
+    pushd "${LIBFABRIC_DIR}" && \
     ./autogen.sh && \
     ./configure --enable-verbs && \
     make -j "${NPROC}" && \
-    make install
-    ldconfig
-    popd
+    make install && \
+    ldconfig && \
+    popd && \
+    return 0 || return 1
 }
 
 # Download the MTL and DPDK source code
 function lib_download_mtl_and_dpdk()
 {
-    git_download_strip_unpack "${MTL_REPO}" "${MTL_VER}" "${MTL_DIR}"
-    git_download_strip_unpack "dpdk/dpdk" "refs/tags/v${DPDK_VER}" "${DPDK_DIR}"
+    git_download_strip_unpack "${MTL_REPO}" "${MTL_VER}" "${MTL_DIR}" && \
+    git_download_strip_unpack "dpdk/dpdk" "refs/tags/v${DPDK_VER}" "${DPDK_DIR}" && \
+    return 0 || return 1
 }
 
 # Build and install the MTL and DPDK
 function lib_install_mtl_and_dpdk()
 {
     # Patch and build the DPDK
-    pushd "${DPDK_DIR}"
-    patch -p1 -i <(cat "${MTL_DIR}/patches/dpdk/${DPDK_VER}/"*.patch)
+    pushd "${DPDK_DIR}" && \
+    patch -p1 -i <(cat "${MTL_DIR}/patches/dpdk/${DPDK_VER}/"*.patch) && \
     meson setup build && \
     ninja -C build && \
-    meson install -C build
-    popd
-
+    meson install -C build && \
+    popd && \
     # Build MTL
-    pushd "${MTL_DIR}"
+    pushd "${MTL_DIR}" && \
     ./build.sh && \
-    meson install -C build
-    install script/nicctl.sh /usr/bin
-    ldconfig
-    popd
+    meson install -C build && \
+    install script/nicctl.sh /usr/bin && \
+    ldconfig && \
+    popd && \
+    return 0 || return 1
 }
 
 # Build and install gRPC from source
 function lib_install_grpc()
 {
     rm -rf "${GRPC_DIR}"
-    mkdir -p "${GRPC_DIR}"
+    mkdir -p "${GRPC_DIR}" && \
     git clone --branch "${GPRC_VER}" \
         --depth 1 \
         --recurse-submodules \
         --shallow-submodules \
-        https://github.com/grpc/grpc "${GRPC_DIR}"
-
-    mkdir -p "${GRPC_DIR}/cmake/build"
-    pushd "${GRPC_DIR}/cmake/build"
-
+        https://github.com/grpc/grpc "${GRPC_DIR}" && \
+    mkdir -p "${GRPC_DIR}/cmake/build" && \
+    pushd "${GRPC_DIR}/cmake/build" && \
     cmake -DgRPC_BUILD_TESTS=OFF -DgRPC_INSTALL=ON ../.. && \
     make -j "${NPROC}" && \
     make -j "${NPROC}" install && \
     cmake -DgRPC_BUILD_TESTS=ON -DgRPC_INSTALL=ON ../.. && \
     make -j "${NPROC}" grpc_cli && \
-
-    cp grpc_cli "/usr/local/bin/"
-    popd
+    cp grpc_cli "/usr/local/bin/" && \
+    popd && \
+    return 0 || return 1
 }
 
 # Build and install JPEG XS
 function lib_install_jpeg_xs()
 {
-    git_download_strip_unpack "OpenVisualCloud/SVT-JPEG-XS" "${JPEGXS_VER}" "${JPEGXS_DIR}"
-
-    mkdir -p "${JPEGXS_DIR}/Build/linux" "${JPEGXS_DIR}/imtl-plugin"
-    pushd "${JPEGXS_DIR}/Build/linux"
-    ./build.sh release install
-    ldconfig
-    popd
+    git_download_strip_unpack "OpenVisualCloud/SVT-JPEG-XS" "${JPEGXS_VER}" "${JPEGXS_DIR}" && \
+    mkdir -p "${JPEGXS_DIR}/Build/linux" "${JPEGXS_DIR}/imtl-plugin" && \
+    pushd "${JPEGXS_DIR}/Build/linux" && \
+    ./build.sh release install && \
+    ldconfig && \
+    popd && \
+    return 0 || return 1
 }
 
 # Build and install JPEG XS imtl plugin
 function lib_install_mtl_jpeg_xs_plugin()
 {
-    pushd "${JPEGXS_DIR}/imtl-plugin"
+    pushd "${JPEGXS_DIR}/imtl-plugin" && \
     ./build.sh build-only && \
     meson install --no-rebuild -C build && \
     mkdir -p /usr/local/etc/ && \
-    cp -f "${JPEGXS_DIR}/imtl-plugin/kahawai.json" /usr/local/etc/imtl.json
-    popd
+    cp -f "${JPEGXS_DIR}/imtl-plugin/kahawai.json" /usr/local/etc/imtl.json && \
+    popd && \
+    return 0 || return 1
 }
 
 function full_build_and_install_workflow()
 {
-    set -x
-    lib_install_xdp_bpf_tools
-    lib_install_fabrics
-    lib_install_mtl_and_dpdk
-    lib_install_grpc
-    lib_install_jpeg_xs
-    lib_install_mtl_jpeg_xs_plugin
-    chmod -R a+r "${BUILD_DIR}"
-    set +x
+    lib_install_grpc && \
+    lib_install_xdp_bpf_tools && \
+    lib_install_fabrics && \
+    lib_install_mtl_and_dpdk && \
+    lib_install_jpeg_xs && \
+    lib_install_mtl_jpeg_xs_plugin && \
+    chmod -R a+r "${BUILD_DIR}" && \
+    return 0 || return 1
 }
 
 if [ "${EUID}" != "0" ]; then
@@ -233,19 +321,24 @@ sleep 1
 trap_error_print_debug
 sleep 1
 prompt Starting: OS packages installation, MTL and DPDK download.
-install_ubuntu_package_dependencies
+install_package_dependencies
 lib_download_mtl_and_dpdk
 prompt Finished: OS packages installation, MTL and DPDK download.
 prompt Starting: Intel drivers download and patch apply.
 get_and_patch_intel_drivers
 prompt Finished: Intel drivers download and patch apply.
-prompt Starting: Build, install and configuration of Intel drivers.
-build_install_and_config_intel_drivers
-prompt Finished: Build, install and configuration of Intel drivers.
 prompt Starting: Dependencies build, install and configation.
-full_build_and_install_workflow
+full_build_and_install_workflow ||
+error Dependencies build, install and configation failed. && \
+exit 1
 prompt Finished: Dependencies build, install and configation.
-prompt All tasks compleated successfully. Reboot required.
+prompt Starting: Build, install and configuration of Intel drivers.
+build_install_and_config_intel_drivers || \
+error Intel drivers were not installed correctly. && \
+error Please rerun the driver setup part manuallly Requires manual setup. && \
+exit 1
+prompt Finished: Build, install and configuration of Intel drivers.
+prompt All tasks compleated. Reboot required.
 warning ""
 warning OS reboot is required for all of the changes to take place.
 sleep 2


### PR DESCRIPTION
[MCM] Adjust setup-script to `dnf`/`yum`. Fix fail on errors:
ADD: Check package manager and adjust packages to `dnf`/`yum`
ADD: Support for Centos and `dnf`/`yum` based package manager.
FIXED: Trap and stack trace to fail on errors an report to user.
