### PR TITLE
Fixed: Added missing SETCAP capabilities

### DIFF
--- a/deployment/DaemonSet/media-proxy-rx.yaml
+++ b/deployment/DaemonSet/media-proxy-rx.yaml
@@ -22,12 +22,20 @@ spec:
           image: mcm/media-proxy:latest
           imagePullPolicy: Never
           command: [ "media_proxy" ]
-          args: [ "-d", "0000:31:11.5", "-i", "192.168.96.20" ]
+          args: [ "-d", "kernel:eth0", "-i", $(NODE_IP) ]
           env:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           resources:
             requests:
               cpu: 2
@@ -66,7 +74,7 @@ spec:
       volumes:
         - name: memif-dir  # Using hostPath volume
           hostPath:
-            path: /tmp/mcm/memif
+            path: /run/mcm
         - name: dev-vfio
           hostPath:
             path: /dev/vfio

--- a/deployment/DaemonSet/media-proxy-tx.yaml
+++ b/deployment/DaemonSet/media-proxy-tx.yaml
@@ -22,12 +22,20 @@ spec:
           image: mcm/media-proxy:latest
           imagePullPolicy: Never
           command: [ "media_proxy" ]
-          args: [ "-d", "0000:31:01.5", "-i", "192.168.96.10" ]
+          args: [ "-d", "kernel:eth0", "-i", $(NODE_IP) ]
           env:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           resources:
             requests:
               cpu: 2
@@ -66,7 +74,7 @@ spec:
       volumes:
         - name: memif-dir  # Using hostPath volume
           hostPath:
-            path: /tmp/mcm/memif
+            path: /run/mcm
         - name: dev-vfio
           hostPath:
             path: /dev/vfio

--- a/deployment/DaemonSet/media-proxy.yaml
+++ b/deployment/DaemonSet/media-proxy.yaml
@@ -16,10 +16,11 @@ spec:
     spec:
       nodeSelector:
         node-role.kubernetes.io/worker: "true"
+      hostNetwork: true
       containers:
         - name: media-proxy
           image: mcm/media-proxy:latest
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           env:
           - name: NODE_NAME
             valueFrom:
@@ -34,7 +35,7 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           command: [ "media_proxy" ]
-          args: [ "-d", "kernel:eth0", "-i", $(POD_IP) ]
+          args: [ "-d", "kernel:ens25", "-i", $(POD_IP) ]
           resources:
             limits:
               cpu: 2
@@ -67,14 +68,46 @@ spec:
               name: cache-volume
             - name: mtl-mgr  # Communicate with MTL manager
               mountPath: /var/run/imtl  # Mount path in the pod
+        - name: mtl-manager
+          image: mcm/media-proxy:latest
+          imagePullPolicy: IfNotPresent
+          command: [ "MtlManager" ]
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          volumeMounts:
+            - name: memif-dir  # Using hostPath volume
+              mountPath: /run/mcm  # Mount path in the pod
+            - name: dev-vfio
+              mountPath: /dev/vfio
+            - mountPath: /hugepages-2Mi
+              name: hugepage-2mi
+            - mountPath: /hugepages-1Gi
+              name: hugepage-1gi
+            - mountPath: /dev/shm
+              name: cache-volume
+            - name: mtl-mgr  # Communicate with MTL manager
+              mountPath: /var/run/imtl  # Mount path in the pod
       volumes:
         - name: memif-dir  # Using hostPath volume
           hostPath:
             path: /tmp/mcm/memif
         - name: dev-vfio
           hostPath:
-            # Do not mount the top-level /dev/ directory for security reasons.
-            # Instead mount a sub directory underneath the /dev/ directory, e.g. /dev/vfio/
             path: /dev/vfio
         - name: hugepage-2mi
           emptyDir:

--- a/deployment/Deployments/sample-app-rx.yaml
+++ b/deployment/Deployments/sample-app-rx.yaml
@@ -19,10 +19,10 @@ spec:
       containers:
         - name: sample-app-rx
           image: mcm/sample-app:latest
-          imagePullPolicy: Never
-          workingDir: /opt/mcm/sdk/out/samples
-          command: ["./recver_app"]
-          args: ["-w", "1920", "-h", "1080", "-f", "30", "-r", "192.168.96.10", "-p", "10000", "-t", "st20"]
+          imagePullPolicy: IfNotPresent
+          workingDir: /opt/mcm
+          command: ["/usr/local/bin/recver_app"]
+          args: ["-w", "1920", "-h", "1080", "-f", "30", "-r", "192.168.96.10", "-p", "10000", "-t", "st20", "-x", "yuv422p10le", "-o", "auto"]
           securityContext:
             runAsUser: 0
             runAsGroup: 0
@@ -45,7 +45,7 @@ spec:
       volumes:
         - name: memif-dir  # Using hostPath volume
           hostPath:
-            path: /tmp/mcm/memif
+            path: /run/mcm
         - name: mtl-mgr
           persistentVolumeClaim:
             claimName: mtl-pvc

--- a/deployment/Deployments/sample-app-tx.yaml
+++ b/deployment/Deployments/sample-app-tx.yaml
@@ -19,10 +19,10 @@ spec:
       containers:
         - name: sample-app-tx
           image: mcm/sample-app:latest
-          imagePullPolicy: Never
-          workingDir: /opt/mcm/sdk/out/samples
-          command: ["./sender_app"]
-          args: ["-w", "1920", "-h", "1080", "-f", "30", "-s", "192.168.96.20", "-p", "10000", "-t", "st20", "-n", "3000"]
+          imagePullPolicy: IfNotPresent
+          workingDir: /opt/mcm
+          command: ["/usr/local/bin/sender_app"]
+          args: ["-w", "1920", "-h", "1080", "-f", "30", "-s", "192.168.96.20", "-p", "10000", "-t", "st20", "-n", "3000", "-x", "yuv422p10le", "-o", "auto"]
           securityContext:
             runAsUser: 0
             runAsGroup: 0
@@ -45,7 +45,7 @@ spec:
       volumes:
         - name: memif-dir  # Using hostPath volume
           hostPath:
-            path: /tmp/mcm/memif
+            path: /run/mcm
         - name: mtl-mgr
           persistentVolumeClaim:
             claimName: mtl-pvc

--- a/deployment/pv.yaml
+++ b/deployment/pv.yaml
@@ -1,4 +1,4 @@
-# pv.yaml
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/deployment/setup.sh
+++ b/deployment/setup.sh
@@ -16,9 +16,10 @@ display_step_info() {
 # Default number of nodes
 num_nodes=3
 step_num=0
+minikube_ops=( )
 
 while getopts "n:h" opt; do
-    case ${opt} in
+    case "${opt}" in
         n)
             display_step_info "Setting number of nodes to $OPTARG"
             num_nodes=$OPTARG
@@ -27,11 +28,12 @@ while getopts "n:h" opt; do
             echo "Usage: $0 [-n NUM_NODES]" >&2
             exit 0
             ;;
+        *)  pass_to_minikube+=( "${opt}" ) ;;
     esac
 done
 
-display_step_info "Starting the Minikube cluster with $num_nodes nodes"
-minikube start --nodes $num_nodes --namespace mcm --mount-string="/var/run/imtl:/var/run/imtl" --mount
+display_step_info "Starting the Minikube cluster with ${num_nodes} nodes"
+minikube start --nodes "${num_nodes}" --namespace mcm --mount-string="/var/run/imtl:/var/run/imtl" "${minikube_ops[@]}" --mount #  --extra-config=kubelet.node-ip=192.168.0.3
 
 # Enable minikube addons
 display_step_info "Enabling metrics-server addon"
@@ -61,14 +63,14 @@ kubectl label nodes minikube-m03 mcm-type=rx
 
 # Create the custom namespace
 display_step_info "Creating the mcm namespace"
-kubectl create -f namespace.yaml
+kubectl create -f "${SCRIPT_DIR}/namespace.yaml"
 
 # Create PVC
 display_step_info "Creating the PVC"
-kubectl apply -f pv.yaml
-kubectl apply -f pvc.yaml
+kubectl apply -f "${SCRIPT_DIR}/pv.yaml"
+kubectl apply -f "${SCRIPT_DIR}/pvc.yaml"
 
 display_step_info "Deploy Media Proxy DaemonSet"
 # kubectl apply -f DaemonSet/media-proxy.yaml
-kubectl apply -f DaemonSet/media-proxy-rx.yaml
-kubectl apply -f DaemonSet/media-proxy-tx.yaml
+kubectl apply -f "${SCRIPT_DIR}/DaemonSet/media-proxy-rx.yaml"
+kubectl apply -f "${SCRIPT_DIR}/DaemonSet/media-proxy-tx.yaml"

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -177,7 +177,7 @@ RUN ldconfig && \
     groupadd -g 2110 vfio && \
     groupadd -g 993 imtl && \
     getent group ${MCM_GROUP} > /dev/null || groupadd -r ${MCM_GROUP} -g "${MCM_GID}" && \
-    getent passwd ${MCM_USER} > /dev/null || useradd -r -g ${MCM_GROUP} -u "${MCM_UID}" -s /sbin/nologin ${MCM_USER} -d /opt/mcm && \
+    getent passwd ${MCM_USER} > /dev/null || useradd -r -g ${MCM_GROUP} -l -u "${MCM_UID}" -s /sbin/nologin ${MCM_USER} -d /opt/mcm && \
     usermod -aG sudo,vfio,imtl ${MCM_USER} && \
     chown -R ${MCM_USER}:${MCM_GROUP} /opt/mcm /opt/grpc && \
     chown -R root:${MCM_GROUP} /usr/lib64 /usr/local /run /var/run && \

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -145,35 +145,47 @@ LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
 ARG MCM_DIR="/opt/mcm"
 ARG GRPC_DIR="/opt/grpc"
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
+
+ENV MCM_USER=mcm \
+    MCM_GROUP=mcm \
+    MCM_UID=994 \
+    MCM_GID=994
 
 ENV KAHAWAI_CFG_PATH="/usr/local/etc/jpegxs.json"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu"
 
+WORKDIR /opt/mcm/
 SHELL ["/bin/bash", "-exc"]
 RUN apt-get update --fix-missing && \
     apt-get full-upgrade -y && \
     apt-get install -y --no-install-recommends \
        ca-certificates libbsd0 libnuma1 libjson-c5 libpcap0.8 libsdl2-2.0-0 libsdl2-ttf-2.0-0 \
        libssl3 zlib1g libelf1 libcap-ng0 libatomic1 librdmacm1 systemtap sudo \
-       librte-net-mlx4-22 librte-net-mlx5-22 libfdt1 ethtool && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    groupadd -g 2110 vfio && \
-    groupadd -g 1001 imtl && \
-    useradd -m -s /bin/bash -G vfio,imtl -u 1002 mcm && \
-    usermod -aG sudo mcm
-
-COPY --chown=mcm --from=builder /install /
-
-RUN ldconfig && \
-    apt-get purge -y '.*sound.*' '.*systemtap.*' '.*libdrm.*' '.*vorbis.*' '.*wayland.*' '.*x11.*' '.*python.*' '.*readline.*' '.*avahi.*' '^libx[a-w,y-z].*' make media-types libopus0 \
+       librte-net-mlx4-22 librte-net-mlx5-22 libfdt1 ethtool libcap2-bin && \
+    apt-get purge -y '*sound*' '*systemtap*' '*libdrm*' '*vorbis*' '*wayland*' '*x11*' '*python*' '*readline*' '*avahi*' '^libx[a-w,y-z].*' make media-types libopus0 \
         libexpat1 libflac8 libfreetype6 libsndfile1 libgbm1 libglib2.0-0 libgraphite2-3 libharfbuzz0b libogg0 libpulse0 libmpdec3 libnspr4 libpng16-16 \
-        xkb-data distro-info-data libdw1 libbrotli1 libdecor-0-0 libxxf86vm1 libapparmor1 libasyncns0 libnss3 libsqlite3-0 lsb-release
-USER mcm
-WORKDIR /opt/mcm/
+        xkb-data distro-info-data libdw1 libbrotli1 libdecor-0-0 libxxf86vm1 libapparmor1 libasyncns0 libnss3 libsqlite3-0 lsb-release && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+COPY --chown=${MCM_USER}:${MCM_GROUP} --from=builder /install /
+RUN ldconfig && \
+    mkdir /opt/grpc && \
+    groupadd -g 2110 vfio && \
+    groupadd -g 993 imtl && \
+    getent group ${MCM_GROUP} > /dev/null || groupadd -r ${MCM_GROUP} -g "${MCM_GID}" && \
+    getent passwd ${MCM_USER} > /dev/null || useradd -r -g ${MCM_GROUP} -u "${MCM_UID}" -s /sbin/nologin ${MCM_USER} -d /opt/mcm && \
+    usermod -aG sudo,vfio,imtl ${MCM_USER} && \
+    chown -R ${MCM_USER}:${MCM_GROUP} /opt/mcm /opt/grpc && \
+    chown -R root:${MCM_GROUP} /usr/lib64 /usr/local /run /var/run && \
+    chmod -R 2775 /usr/lib64 /usr/local /run /var/run /opt/mcm  && \
+    passwd -d ${MCM_USER} && \
+    setcap "cap_ipc_lock,cap_bpf,cap_net_raw,cap_net_admin,cap_net_bind_service=+eip" /usr/local/bin/media_proxy
+
+USER mcm
 EXPOSE 8001/tcp 8002/tcp
 
 CMD ["--help"]

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -183,7 +183,9 @@ RUN ldconfig && \
     chown -R root:${MCM_GROUP} /usr/lib64 /usr/local /run /var/run && \
     chmod -R 2775 /usr/lib64 /usr/local /run /var/run /opt/mcm  && \
     passwd -d ${MCM_USER} && \
-    setcap "cap_ipc_lock,cap_bpf,cap_net_raw,cap_net_admin,cap_net_bind_service=+eip" /usr/local/bin/media_proxy
+    ln -s /usr/lib64/libbpf.so.1 /usr/lib/x86_64-linux-gnu/libbpf.so.1 && \
+    setcap "cap_sys_nice,cap_bpf,cap_dac_override,cap_ipc_lock,cap_setgid,cap_sys_rawio,cap_net_raw,cap_sys_admin,cap_net_admin+eip" /usr/local/bin/media_proxy
+    # add docker flags --cap-add sys_nice --cap-add bpf --cap-add dac_override --cap-add ipc_lock --cap-add setgid --cap-add sys_rawio --cap-add net_raw --cap-add sys_admin --cap-add net_admin
 
 USER mcm
 EXPOSE 8001/tcp 8002/tcp

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -164,8 +164,8 @@ RUN apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
        ca-certificates libbsd0 libnuma1 libjson-c5 libpcap0.8 libsdl2-2.0-0 libsdl2-ttf-2.0-0 \
        libssl3 zlib1g libelf1 libcap-ng0 libatomic1 librdmacm1 systemtap sudo \
-       librte-net-mlx4-22 librte-net-mlx5-22 libfdt1 ethtool libcap2-bin && \
-    apt-get purge -y '*sound*' '*systemtap*' '*libdrm*' '*vorbis*' '*wayland*' '*x11*' '*python*' '*readline*' '*avahi*' '^libx[a-w,y-z].*' make media-types libopus0 \
+       librte-net-mlx4-22 librte-net-mlx5-22 libfdt1 ethtool libcap2-bin iproute2 && \
+       apt-get purge -y '*sound*' '*systemtap*' '*libdrm*' '*vorbis*' '*wayland*' '*x11*' '*python*' '*readline*' '*avahi*' '^libx[a-w,y-z].*' make media-types libopus0 \
         libexpat1 libflac8 libfreetype6 libsndfile1 libgbm1 libglib2.0-0 libgraphite2-3 libharfbuzz0b libogg0 libpulse0 libmpdec3 libnspr4 libpng16-16 \
         xkb-data distro-info-data libdw1 libbrotli1 libdecor-0-0 libxxf86vm1 libapparmor1 libasyncns0 libnss3 libsqlite3-0 lsb-release && \
     apt-get clean && \


### PR DESCRIPTION
Fixed: Added missing SETCAP capabilities
Fixed: Added valid mcm user configuration
Added caps: cap_sys_nice,cap_bpf,cap_dac_override,cap_ipc_lock,cap_setgid,cap_sys_rawio,cap_net_raw,cap_sys_admin,cap_net_admin+eip

Example Docker run parameters:
```bash
docker run -it --net=host \
    --cap-add sys_nice \
    --cap-add bpf \
    --cap-add dac_override \
    --cap-add ipc_lock \
    --cap-add setgid \
    --cap-add sys_rawio \
    --cap-add net_raw \
    --cap-add sys_admin \
    --cap-add net_admin \
    --device /dev/vfio \
    -v /mnt/hugepages1G:/mnt/hugepages1G \
    -v /mnt/hugepages2M:/mnt/hugepages2M \
    -v /run/mcm:/run/mcm \
    -v /sys/fs/bpf:/sys/fs/bpf \
    -v /dev/shm:/dev/shm \
    mcm/media-proxy:latest --dev=0000:98:01.2 --ip=192.168.96.2 -t 8003
```