### PR TITLE
Add RDMA support to ffmpeg plugin

### DIFF
--- a/ffmpeg-plugin/README.md
+++ b/ffmpeg-plugin/README.md
@@ -33,14 +33,14 @@ Install dependencies and build MCM as described in the top level README.md, para
 
 The next arguments are supported to configure a connection to MCM
 
-| Argument        | Type    | Description                                              | Default          |
-| --------------- | :-----: | -------------------------------------------------------- | :--------------: |
-| `ip_addr`       | String  | Remote IP address                                        | `"192.168.96.1"` |
-| `port`          | String  | Remote port (Sender), or Local port (Receiver)           | `"9001"`         |
-| `protocol_type` | String  | MCM Protocol type (`"auto"`, `"memif"`, etc.)            | `"auto"`         |
-| `payload_type`  | String  | ST2110 payload type (`"st20"`, `"st22"`, `"st30"`, etc.) | `"st20"`         |
-| `socket_name`   | String  | Memif socket name                                        | -                |
-| `interface_id`  | Integer | Memif interface id                                       | `0`              |
+| Argument        | Type    | Description                                               | Default          |
+| --------------- | :-----: | --------------------------------------------------------- | :--------------: |
+| `ip_addr`       | String  | Remote IP address                                         | `"192.168.96.1"` |
+| `port`          | String  | Remote port (Sender), or Local port (Receiver)            | `"9001"`         |
+| `protocol_type` | String  | MCM Protocol type (`"auto"`, `"memif"`, etc.)             | `"auto"`         |
+| `payload_type`  | String  | Payload type (`"st20"`, `"st22"`, `"st30", "rdma"`, etc.) | `"st20"`         |
+| `socket_name`   | String  | Memif socket name                                         | -                |
+| `interface_id`  | Integer | Memif interface id                                        | `0`              |
 
 ## Video configuration
 
@@ -98,6 +98,13 @@ TBD
       -ip_addr 192.168.96.2 \
       -port 9001 -
    ```
+
+   When working with raw video files that lack metadata, you must explicitly provide FFmpeg with the necessary video frame details. This includes specifying the format `-f rawvideo`, pixel format `-pix_fmt`, and resolution `-s WxH`. For example:
+
+    ```bash
+    ffmpeg -f rawvideo -pix_fmt yuv422p10le -s 1920x1080 -i <video-file-path> ...
+   ```
+
 
 ### VLC player setup
 

--- a/ffmpeg-plugin/mcm_common.c
+++ b/ffmpeg-plugin/mcm_common.c
@@ -92,6 +92,20 @@ int mcm_parse_conn_param(AVFormatContext* avctx, MeshConnection *conn,
         err = mesh_apply_connection_config_memif(conn, &cfg);
         if (err)
             return err;
+    } else if (!strcmp(payload_type, "rdma")) {
+        MeshConfig_RDMA cfg;
+
+        if (kind == MESH_CONN_KIND_SENDER) {
+            cfg.remote_port = atoi(port);
+            strlcpy(cfg.remote_ip_addr, ip_addr, sizeof(cfg.remote_ip_addr));
+        } else {
+            cfg.local_port = atoi(port);
+            strlcpy(cfg.local_ip_addr, ip_addr, sizeof(cfg.local_ip_addr));
+        }
+
+        err = mesh_apply_connection_config_rdma(conn, &cfg);
+        if (err)
+           return err;
     } else {
         MeshConfig_ST2110 cfg;
 

--- a/sdk/src/mcm_dp.c
+++ b/sdk/src/mcm_dp.c
@@ -233,10 +233,13 @@ mcm_conn_context* mcm_create_connection(mcm_conn_param* param)
     switch (param->protocol) {
     case PROTO_AUTO:
         /**
-         * This is a temporary workaround to calculate the RDMA transfer size
+         * TODO: This is a temporary workaround to calculate the RDMA transfer size
          * from video payload parameters provided by the user. It will be
          * removed after the Control Plane implementation supporting Multipoint
          * Groups is implemented in Media Proxy.
+         * 
+         * In the new implementation the transfer size of audio payload should be calculated too,
+         * PAYLOAD_TYPE_RDMA_VIDEO should be renamed to PAYLOAD_TYPE_RDMA, as it will support both.
          */
         if (param->payload_type == PAYLOAD_TYPE_RDMA_VIDEO) {
             size_t sz = (size_t)param->payload_args.video_args.width *


### PR DESCRIPTION
This enables ffmpeg plugging to send video via RDMA. Audio files should work as well, but currently the transfer_size is not calculated correctly for audio.