### PR TITLE
FIX: Validation apps build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MP_TESTS_DIR ${MP_DIR}/tests)
 set(SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sdk)
 set(SDK_TESTS_DIR ${SDK_DIR}/tests)
 set(SDK_INCLUDE_DIR ${SDK_DIR}/include)
+set(TESTS_VAL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests/validation)
 
 # Setup output folder
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -39,6 +40,7 @@ if (BUILD_UNIT_TESTS)
     enable_testing()
     add_subdirectory(${MP_TESTS_DIR})
     add_subdirectory(${SDK_TESTS_DIR})
+    add_subdirectory(${TESTS_VAL_DIR})
 endif()
 
 target_include_directories(media_proxy_lib PUBLIC ${SDK_INCLUDE_DIR})

--- a/tests/validation/CMakeLists.txt
+++ b/tests/validation/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.16)
+project(McmDPSdk_Validation VERSION 0.1.0
+        DESCRIPTION "MCM DP SDK Library Validation Code"
+        LANGUAGES C
+        )
+
+set(CMAKE_C_STANDARD 11)
+
+add_executable(recver_val recver_val.c common.c)
+target_include_directories(recver_val PRIVATE ../include)
+target_link_libraries(recver_val PRIVATE mcm_dp)
+
+add_executable(sender_val sender_val.c common.c)
+target_include_directories(sender_val PRIVATE ../include)
+target_link_libraries(sender_val PRIVATE mcm_dp)
+
+install(TARGETS recver_val sender_val RUNTIME COMPONENT Runtime)


### PR DESCRIPTION
FIX: Validation apps build process
- added tests/validation/CMakeLists.txt
- created `add_executable` for `recver_val` and `sender_val`