### PR TITLE
ST2110 bridge fixes

### DIFF
--- a/media-proxy/include/mesh/st2110.h
+++ b/media-proxy/include/mesh/st2110.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #ifndef ST2110_H
 #define ST2110_H
 

--- a/media-proxy/include/mesh/st2110rx.h
+++ b/media-proxy/include/mesh/st2110rx.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #ifndef ST2110RX_H
 #define ST2110RX_H
 

--- a/media-proxy/include/mesh/st2110rx.h
+++ b/media-proxy/include/mesh/st2110rx.h
@@ -26,8 +26,11 @@ class ST2110Rx : public ST2110<FRAME, HANDLE, OPS> {
     std::jthread frame_thread_handle;
 
     int configure_common(context::Context& ctx, const std::string& dev_port,
-                         const MeshConfig_ST2110& cfg_st2110) override{
-        ST2110<FRAME, HANDLE, OPS>::configure_common(ctx, dev_port, cfg_st2110);
+                         const MeshConfig_ST2110& cfg_st2110) override {
+        int ret = ST2110<FRAME, HANDLE, OPS>::configure_common(ctx, dev_port, cfg_st2110);
+        if (ret) {
+            return ret;
+        }
 
         inet_pton(AF_INET, cfg_st2110.remote_ip_addr, this->ops.port.ip_addr[MTL_PORT_P]);
         inet_pton(AF_INET, cfg_st2110.local_ip_addr, this->ops.port.mcast_sip_addr[MTL_PORT_P]);

--- a/media-proxy/include/mesh/st2110tx.h
+++ b/media-proxy/include/mesh/st2110tx.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #ifndef ST2110TX_H
 #define ST2110TX_H
 

--- a/media-proxy/include/mesh/st2110tx.h
+++ b/media-proxy/include/mesh/st2110tx.h
@@ -25,7 +25,10 @@ class ST2110Tx : public ST2110<FRAME, HANDLE, OPS> {
   protected:
     int configure_common(context::Context& ctx, const std::string& dev_port,
                          const MeshConfig_ST2110& cfg_st2110) override {
-        ST2110<FRAME, HANDLE, OPS>::configure_common(ctx, dev_port, cfg_st2110);
+        int ret = ST2110<FRAME, HANDLE, OPS>::configure_common(ctx, dev_port, cfg_st2110);
+        if (ret) {
+            return ret;
+        }
 
         inet_pton(AF_INET, cfg_st2110.remote_ip_addr, this->ops.port.dip_addr[MTL_PORT_P]);
         this->ops.port.udp_port[MTL_PORT_P] = cfg_st2110.remote_port;

--- a/media-proxy/src/mesh/st2110.cc
+++ b/media-proxy/src/mesh/st2110.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include "st2110.h"
 
 namespace mesh::connection {

--- a/media-proxy/src/mesh/st2110_20rx.cc
+++ b/media-proxy/src/mesh/st2110_20rx.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include "st2110rx.h"
 
 namespace mesh::connection {

--- a/media-proxy/src/mesh/st2110_20tx.cc
+++ b/media-proxy/src/mesh/st2110_20tx.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include "st2110tx.h"
 
 namespace mesh::connection {

--- a/media-proxy/src/mesh/st2110_22rx.cc
+++ b/media-proxy/src/mesh/st2110_22rx.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include "st2110rx.h"
 
 namespace mesh::connection {

--- a/media-proxy/src/mesh/st2110_22tx.cc
+++ b/media-proxy/src/mesh/st2110_22tx.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include "st2110tx.h"
 
 namespace mesh::connection {

--- a/media-proxy/src/mesh/st2110_30rx.cc
+++ b/media-proxy/src/mesh/st2110_30rx.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include "st2110rx.h"
 
 namespace mesh::connection {

--- a/media-proxy/src/mesh/st2110_30tx.cc
+++ b/media-proxy/src/mesh/st2110_30tx.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include "st2110tx.h"
 
 namespace mesh::connection {


### PR DESCRIPTION
1. Add missing license in multiple ST2110 files
2. Add missing check in configure()