### PR TITLE
Add RDMA Connection Implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,4 +14,5 @@ IndentCaseLabels: false
 IncludeBlocks: Preserve
 SortIncludes: false
 ReferenceAlignment: Left
+AccessModifierOffset: -4
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,23 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 add_subdirectory(${SDK_DIR})
 add_subdirectory(${MP_DIR})
 
+
+# Fetch google test dependencies
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/35d0c365609296fa4730d62057c487e3cfa030ff.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+target_include_directories(media_proxy_lib PUBLIC ${SDK_INCLUDE_DIR})
 option(BUILD_UNIT_TESTS "Build and enable unit tests" ON)
 if (BUILD_UNIT_TESTS)
     enable_testing()
     add_subdirectory(${MP_TESTS_DIR})
     add_subdirectory(${SDK_TESTS_DIR})
     add_subdirectory(${TESTS_VAL_DIR})
+    target_link_libraries(media_proxy_lib PUBLIC mcm_dp gtest gmock gtest_main)
+else()
+    target_link_libraries(media_proxy_lib PUBLIC mcm_dp)
 endif()
-
-target_include_directories(media_proxy_lib PUBLIC ${SDK_INCLUDE_DIR})
-target_link_libraries(media_proxy_lib PUBLIC mcm_dp)

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ as_root ln -s /usr/lib64/libbpf.so.1 /usr/lib/x86_64-linux-gnu/libbpf.so.1 2>/de
 as_root ldconfig
 
 # Run unit tests
-export LD_LIBRARY_PATH="${PREFIX_DIR}/usr/local/lib:/usr/local/lib"
+export LD_LIBRARY_PATH="${PREFIX_DIR}/usr/local/lib:/usr/local/lib64"
 ctest --output-on-failure --test-dir "${MCM_BUILD_DIR}" -V
 
 ln -sf "${MCM_BUILD_DIR}" "${SCRIPT_DIR}/build"

--- a/build.sh
+++ b/build.sh
@@ -35,9 +35,9 @@ as_root ln -s /usr/lib64/libbpf.so.1 /usr/lib/x86_64-linux-gnu/libbpf.so.1 2>/de
 as_root ldconfig
 
 # Run unit tests
-export LD_LIBRARY_PATH="${PREFIX_DIR}/usr/local/lib:/usr/local/lib64"
-"${MCM_BUILD_DIR}/bin/sdk_unit_tests"
-"${MCM_BUILD_DIR}/bin/media_proxy_unit_tests"
+export LD_LIBRARY_PATH="${PREFIX_DIR}/usr/local/lib:/usr/local/lib"
+ctest --output-on-failure --test-dir "${MCM_BUILD_DIR}" -V
+
 ln -sf "${MCM_BUILD_DIR}" "${SCRIPT_DIR}/build"
 
 log_info "Build Succeeded"

--- a/media-proxy/include/libfabric_ep.h
+++ b/media-proxy/include/libfabric_ep.h
@@ -34,6 +34,8 @@ typedef struct ep_ctx_t {
     cq_ctx_t cq_ctx;
 
     libfabric_ctx *rdma_ctx;
+
+    volatile bool stop_flag;
 } ep_ctx_t;
 
 typedef struct {

--- a/media-proxy/include/mesh/conn.h
+++ b/media-proxy/include/mesh/conn.h
@@ -71,7 +71,6 @@ enum class Result {
     error_initialization_failed,
     error_memory_registration_failed,
     error_thread_creation_failed,
-    error_operation_cancelled,
     error_no_buffer,
     error_timeout,
     error_context_cancelled,

--- a/media-proxy/include/mesh/conn.h
+++ b/media-proxy/include/mesh/conn.h
@@ -72,8 +72,6 @@ enum class Result {
     error_memory_registration_failed,
     error_thread_creation_failed,
     error_operation_cancelled,
-    error_buffer_overflow,
-    error_buffer_underflow,
     error_no_buffer,
     error_timeout,
     error_context_cancelled,

--- a/media-proxy/include/mesh/conn.h
+++ b/media-proxy/include/mesh/conn.h
@@ -67,13 +67,13 @@ enum class Result {
     error_bad_argument,
     error_out_of_memory,
     error_general_failure,
+    error_context_cancelled,
     error_already_initialized,
     error_initialization_failed,
     error_memory_registration_failed,
     error_thread_creation_failed,
     error_no_buffer,
     error_timeout,
-    error_context_cancelled,
     
     // TODO: more error codes to be added...
 };

--- a/media-proxy/include/mesh/conn.h
+++ b/media-proxy/include/mesh/conn.h
@@ -67,8 +67,17 @@ enum class Result {
     error_bad_argument,
     error_out_of_memory,
     error_general_failure,
+    error_already_initialized,
+    error_initialization_failed,
+    error_memory_registration_failed,
+    error_thread_creation_failed,
+    error_operation_cancelled,
+    error_buffer_overflow,
+    error_buffer_underflow,
+    error_no_buffer,
+    error_timeout,
     error_context_cancelled,
-   
+    
     // TODO: more error codes to be added...
 };
 

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -42,7 +42,8 @@ public:
     Rdma();
     virtual ~Rdma();
     static void
-    deinit_rdma_if_needed(libfabric_ctx *mDevHandle); // Deinitialize RDMA if no active connections
+    // Deinitialize RDMA if no active connections
+    deinit_rdma_if_needed(libfabric_ctx *m_dev_handle);
 
 // Used only for Unit tests, provides access to protected members
 #ifdef UNIT_TESTS_ENABLED
@@ -78,7 +79,7 @@ protected:
     void handle_error(context::Context& ctx, const char *step);
 
     // RDMA-specific members
-    libfabric_ctx *mDevHandle;                  // RDMA device handle
+    libfabric_ctx *m_dev_handle;                // RDMA device handle
     ep_ctx_t *ep_ctx;                           // RDMA endpoint context
     ep_cfg_t ep_cfg;                            // RDMA endpoint configuration
     size_t trx_sz;                              // Data transfer size

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -1,0 +1,128 @@
+#ifndef CONN_RDMA_H
+#define CONN_RDMA_H
+
+#include "logger.h"
+#include "mesh/conn.h"
+#include "concurrency.h"
+#include "libfabric_ep.h"
+#include "libfabric_mr.h"
+#include "libfabric_cq.h"
+#include "libfabric_dev.h"
+#include "mcm_dp.h"
+#include <mutex>
+#include <cstring>
+#include <cstddef>
+#include <atomic>
+#include <queue>
+
+#ifndef RDMA_DEFAULT_TIMEOUT
+#define RDMA_DEFAULT_TIMEOUT 1
+#endif
+#ifndef MAX_BUFFER_SIZE
+#define MAX_BUFFER_SIZE 1 << 30
+#endif
+#ifndef CQ_BATCH_SIZE
+#define CQ_BATCH_SIZE 64
+#endif
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 4096
+#endif
+
+namespace mesh {
+
+namespace connection {
+
+/**
+ * Rdma
+ *
+ * Base class for RDMA connections, derived from the `Connection` class.
+ * Provides common RDMA-related functionality and acts as a foundation
+ * for specialized RDMA Tx and Rx classes.
+ */
+class Rdma : public Connection {
+  public:
+    Rdma();
+    virtual ~Rdma();
+
+  //Used only for Unit tests, provides access to protected members
+  #ifdef UNIT_TESTS_ENABLED
+      size_t get_buffer_queue_size() const { return buffer_queue.size(); }
+      bool is_buffer_queue_empty() const { return buffer_queue.empty(); }
+      Kind get_kind() const { return _kind; }
+      void* get_buffer_block() const { return buffer_block; }
+  #endif
+
+    // Queue synchronization
+    void init_buf_available();
+    void notify_buf_available();
+    void wait_buf_available();
+
+  protected:
+    // Configure the RDMA session
+    virtual Result configure(context::Context& ctx, const mcm_conn_param& request,
+                             const std::string& dev_port, libfabric_ctx *& dev_handle, Kind kind,
+                             direction dir);
+
+    // Overrides from Connection
+    virtual Result on_establish(context::Context& ctx) override;
+    virtual void on_delete(context::Context& ctx) override;
+    virtual Result on_shutdown(context::Context& ctx) override;
+
+    // RDMA-specific methods
+
+    // Configure RDMA endpoint
+    Result configure_endpoint(context::Context& ctx);
+
+    // Cleanup RDMA resources
+    Result cleanup_resources(context::Context& ctx);
+
+    // Error handler for logging and recovery
+    void handle_error(context::Context& ctx, const char *step);
+
+    // RDMA-specific members
+    libfabric_ctx* mDevHandle; // RDMA device handle
+    ep_ctx_t* ep_ctx;          // RDMA endpoint context
+    ep_cfg_t ep_cfg;           // RDMA endpoint configuration
+    size_t trx_sz;             // Data transfer size
+    bool init;                 // Indicates if RDMA is initialized
+    void* buffer_block;        // Pointer to the allocated buffer block
+    int queue_size;            // Number of buffers in the queue
+
+    // Queue for managing buffers
+    std::queue<void*> buffer_queue; // Queue holding available buffers
+    std::mutex queue_mutex;         // Mutex for buffer queue synchronization
+    std::condition_variable_any queue_cv; // Condition variable for buffer availability
+
+    // // RDMA thread logic
+    // virtual void process_buffers_thread(context::Context& ctx) = 0;
+    // virtual void rdma_cq_thread(context::Context& ctx) = 0;
+    virtual Result start_threads(context::Context& ctx) { return Result::success; }
+
+    Result init_queue_with_elements(size_t capacity, size_t trx_sz);
+    Result add_to_queue(void *element);
+    Result consume_from_queue(context::Context& ctx, void **element);
+    void cleanup_queue();
+
+    std::jthread handle_process_buffers_thread; // Thread for processing buffers
+    std::jthread handle_rdma_cq_thread;         // Thread for completion queue operations
+    context::Context process_buffers_thread_ctx; // Context for buffer processing thread
+    context::Context rdma_cq_thread_ctx;        // Context for completion queue thread
+
+    std::mutex cq_mutex;              // Mutex for completion queue synchronization
+    std::condition_variable_any cq_cv; // Condition variable for completion queue events
+    bool event_ready = false;         // Indicates if an event is ready in the CQ
+
+    void notify_cq_event();
+    void shutdown_rdma(context::Context& ctx);
+
+    //Helper functions
+    std::string kind_to_string(Kind kind);
+
+    std::atomic<bool> buf_available; // Indicates buffer availability in the queue
+};
+
+} // namespace connection
+
+} // namespace mesh
+
+#endif // CONN_RDMA_H

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -58,7 +58,7 @@ class Rdma : public Connection {
   protected:
     // Configure the RDMA session
     virtual Result configure(context::Context& ctx, const mcm_conn_param& request,
-                             const std::string& dev_port, libfabric_ctx *& dev_handle);
+                             libfabric_ctx *& dev_handle);
 
     // Overrides from Connection
     virtual Result on_establish(context::Context& ctx) override;

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -41,6 +41,7 @@ class Rdma : public Connection {
   public:
     Rdma();
     virtual ~Rdma();
+    static void deinit_rdma_if_needed(libfabric_ctx *mDevHandle); // Deinitialize RDMA if no active connections
 
   //Used only for Unit tests, provides access to protected members
   #ifdef UNIT_TESTS_ENABLED
@@ -76,14 +77,15 @@ class Rdma : public Connection {
     void handle_error(context::Context& ctx, const char *step);
 
     // RDMA-specific members
-    libfabric_ctx* mDevHandle; // RDMA device handle
-    ep_ctx_t* ep_ctx;          // RDMA endpoint context
-    ep_cfg_t ep_cfg;           // RDMA endpoint configuration
-    size_t trx_sz;             // Data transfer size
-    bool init;                 // Indicates if RDMA is initialized
-    void* buffer_block;        // Pointer to the allocated buffer block
-    int queue_size;            // Number of buffers in the queue
-    direction dir;             // Data transfer direction
+    libfabric_ctx *mDevHandle;                  // RDMA device handle
+    ep_ctx_t *ep_ctx;                           // RDMA endpoint context
+    ep_cfg_t ep_cfg;                            // RDMA endpoint configuration
+    size_t trx_sz;                              // Data transfer size
+    bool init;                                  // Indicates if RDMA is initialized
+    void *buffer_block;                         // Pointer to the allocated buffer block
+    int queue_size;                             // Number of buffers in the queue
+    direction dir;                              // Data transfer direction
+    static std::atomic<int> active_connections; // Number of active RDMA connections
 
     // Queue for managing buffers
     std::queue<void*> buffer_queue; // Queue holding available buffers

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -41,9 +41,8 @@ class Rdma : public Connection {
 public:
     Rdma();
     virtual ~Rdma();
-    static void
     // Deinitialize RDMA if no active connections
-    deinit_rdma_if_needed(libfabric_ctx *m_dev_handle);
+    static void deinit_rdma_if_needed(libfabric_ctx *m_dev_handle);
 
 // Used only for Unit tests, provides access to protected members
 #ifdef UNIT_TESTS_ENABLED

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -38,24 +38,25 @@ namespace mesh::connection {
  * for specialized RDMA Tx and Rx classes.
  */
 class Rdma : public Connection {
-  public:
+public:
     Rdma();
     virtual ~Rdma();
-    static void deinit_rdma_if_needed(libfabric_ctx *mDevHandle); // Deinitialize RDMA if no active connections
+    static void
+    deinit_rdma_if_needed(libfabric_ctx *mDevHandle); // Deinitialize RDMA if no active connections
 
-  //Used only for Unit tests, provides access to protected members
-  #ifdef UNIT_TESTS_ENABLED
-      size_t get_buffer_queue_size() const { return buffer_queue.size(); }
-      bool is_buffer_queue_empty() const { return buffer_queue.empty(); }
-      void* get_buffer_block() const { return buffer_block; }
-  #endif
+// Used only for Unit tests, provides access to protected members
+#ifdef UNIT_TESTS_ENABLED
+    size_t get_buffer_queue_size() const { return buffer_queue.size(); }
+    bool is_buffer_queue_empty() const { return buffer_queue.empty(); }
+    void *get_buffer_block() const { return buffer_block; }
+#endif
 
     // Queue synchronization
     void init_buf_available();
     void notify_buf_available();
     void wait_buf_available();
 
-  protected:
+protected:
     // Configure the RDMA session
     virtual Result configure(context::Context& ctx, const mcm_conn_param& request,
                              libfabric_ctx *& dev_handle);
@@ -88,8 +89,8 @@ class Rdma : public Connection {
     static std::atomic<int> active_connections; // Number of active RDMA connections
 
     // Queue for managing buffers
-    std::queue<void*> buffer_queue; // Queue holding available buffers
-    std::mutex queue_mutex;         // Mutex for buffer queue synchronization
+    std::queue<void *> buffer_queue;      // Queue holding available buffers
+    std::mutex queue_mutex;               // Mutex for buffer queue synchronization
     std::condition_variable_any queue_cv; // Condition variable for buffer availability
 
     // // RDMA thread logic
@@ -100,17 +101,17 @@ class Rdma : public Connection {
     Result consume_from_queue(context::Context& ctx, void **element);
     void cleanup_queue();
 
-    std::jthread handle_process_buffers_thread; // Thread for processing buffers
-    std::jthread handle_rdma_cq_thread;         // Thread for completion queue operations
+    std::jthread handle_process_buffers_thread;  // Thread for processing buffers
+    std::jthread handle_rdma_cq_thread;          // Thread for completion queue operations
     context::Context process_buffers_thread_ctx; // Context for buffer processing thread
-    context::Context rdma_cq_thread_ctx;        // Context for completion queue thread
+    context::Context rdma_cq_thread_ctx;         // Context for completion queue thread
 
-    std::mutex cq_mutex;              // Mutex for completion queue synchronization
+    std::mutex cq_mutex;               // Mutex for completion queue synchronization
     std::condition_variable_any cq_cv; // Condition variable for completion queue events
-    bool event_ready = false;         // Indicates if an event is ready in the CQ
+    bool event_ready = false;          // Indicates if an event is ready in the CQ
 
     void notify_cq_event();
-  
+
     std::atomic<bool> buf_available; // Indicates buffer availability in the queue
 };
 

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -28,9 +28,7 @@
 #define PAGE_SIZE 4096
 #endif
 
-namespace mesh {
-
-namespace connection {
+namespace mesh::connection {
 
 /**
  * Rdma
@@ -48,7 +46,6 @@ class Rdma : public Connection {
   #ifdef UNIT_TESTS_ENABLED
       size_t get_buffer_queue_size() const { return buffer_queue.size(); }
       bool is_buffer_queue_empty() const { return buffer_queue.empty(); }
-      Kind get_kind() const { return _kind; }
       void* get_buffer_block() const { return buffer_block; }
   #endif
 
@@ -60,8 +57,7 @@ class Rdma : public Connection {
   protected:
     // Configure the RDMA session
     virtual Result configure(context::Context& ctx, const mcm_conn_param& request,
-                             const std::string& dev_port, libfabric_ctx *& dev_handle, Kind kind,
-                             direction dir);
+                             const std::string& dev_port, libfabric_ctx *& dev_handle);
 
     // Overrides from Connection
     virtual Result on_establish(context::Context& ctx) override;
@@ -87,6 +83,7 @@ class Rdma : public Connection {
     bool init;                 // Indicates if RDMA is initialized
     void* buffer_block;        // Pointer to the allocated buffer block
     int queue_size;            // Number of buffers in the queue
+    direction dir;             // Data transfer direction
 
     // Queue for managing buffers
     std::queue<void*> buffer_queue; // Queue holding available buffers
@@ -94,9 +91,7 @@ class Rdma : public Connection {
     std::condition_variable_any queue_cv; // Condition variable for buffer availability
 
     // // RDMA thread logic
-    // virtual void process_buffers_thread(context::Context& ctx) = 0;
-    // virtual void rdma_cq_thread(context::Context& ctx) = 0;
-    virtual Result start_threads(context::Context& ctx) { return Result::success; }
+    virtual Result start_threads(context::Context& ctx) = 0;
 
     Result init_queue_with_elements(size_t capacity, size_t trx_sz);
     Result add_to_queue(void *element);
@@ -113,16 +108,10 @@ class Rdma : public Connection {
     bool event_ready = false;         // Indicates if an event is ready in the CQ
 
     void notify_cq_event();
-    void shutdown_rdma(context::Context& ctx);
-
-    //Helper functions
-    std::string kind_to_string(Kind kind);
-
+  
     std::atomic<bool> buf_available; // Indicates buffer availability in the queue
 };
 
-} // namespace connection
-
-} // namespace mesh
+} // namespace mesh::connection
 
 #endif // CONN_RDMA_H

--- a/media-proxy/include/mesh/conn_rdma_rx.h
+++ b/media-proxy/include/mesh/conn_rdma_rx.h
@@ -6,17 +6,15 @@
 #include <mutex>
 #include <condition_variable>
 
-namespace mesh::connection
-{
+namespace mesh::connection {
 
 /**
  * RdmaRx
  *
  * Derived class for RDMA Receive operations.
  */
-class RdmaRx : public Rdma
-{
-  public:
+class RdmaRx : public Rdma {
+public:
     RdmaRx();
     ~RdmaRx();
 
@@ -24,7 +22,7 @@ class RdmaRx : public Rdma
     Result configure(context::Context& ctx, const mcm_conn_param& request,
                      libfabric_ctx *& dev_handle);
 
-  protected:
+protected:
     virtual Result start_threads(context::Context& ctx);
 
     // Receive data using RDMA

--- a/media-proxy/include/mesh/conn_rdma_rx.h
+++ b/media-proxy/include/mesh/conn_rdma_rx.h
@@ -22,7 +22,7 @@ class RdmaRx : public Rdma
 
     // Configure the RDMA Receive session
     Result configure(context::Context& ctx, const mcm_conn_param& request,
-                     const std::string& dev_port, libfabric_ctx *& dev_handle);
+                     libfabric_ctx *& dev_handle);
 
   protected:
     virtual Result start_threads(context::Context& ctx);

--- a/media-proxy/include/mesh/conn_rdma_rx.h
+++ b/media-proxy/include/mesh/conn_rdma_rx.h
@@ -1,0 +1,42 @@
+#ifndef RDMA_RX_H
+#define RDMA_RX_H
+
+#include "conn_rdma.h"
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+namespace mesh
+{
+
+namespace connection
+{
+
+/**
+ * RdmaRx
+ *
+ * Derived class for RDMA Receive operations.
+ */
+class RdmaRx : public Rdma
+{
+  public:
+    RdmaRx();
+    ~RdmaRx();
+
+    // Configure the RDMA Receive session
+    Result configure(context::Context& ctx, const mcm_conn_param& request,
+                     const std::string& dev_port, libfabric_ctx *& dev_handle);
+
+  protected:
+    virtual Result start_threads(context::Context& ctx);
+
+    // Receive data using RDMA
+    void process_buffers_thread(context::Context& ctx);
+    void rdma_cq_thread(context::Context& ctx);
+};
+
+} // namespace connection
+
+} // namespace mesh
+
+#endif // RDMA_RX_H

--- a/media-proxy/include/mesh/conn_rdma_rx.h
+++ b/media-proxy/include/mesh/conn_rdma_rx.h
@@ -6,10 +6,7 @@
 #include <mutex>
 #include <condition_variable>
 
-namespace mesh
-{
-
-namespace connection
+namespace mesh::connection
 {
 
 /**
@@ -35,8 +32,6 @@ class RdmaRx : public Rdma
     void rdma_cq_thread(context::Context& ctx);
 };
 
-} // namespace connection
-
-} // namespace mesh
+} // namespace mesh::connection
 
 #endif // RDMA_RX_H

--- a/media-proxy/include/mesh/conn_rdma_tx.h
+++ b/media-proxy/include/mesh/conn_rdma_tx.h
@@ -14,7 +14,7 @@ namespace mesh::connection {
  * Derived class for RDMA Transmit operations.
  */
 class RdmaTx : public Rdma {
-  public:
+public:
     RdmaTx();
     ~RdmaTx();
 
@@ -25,7 +25,7 @@ class RdmaTx : public Rdma {
     // Transmit data using RDMA when received from connection class
     Result on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_t& sent);
 
-  protected:
+protected:
     virtual Result start_threads(context::Context& ctx);
     void rdma_cq_thread(context::Context& ctx);
 };

--- a/media-proxy/include/mesh/conn_rdma_tx.h
+++ b/media-proxy/include/mesh/conn_rdma_tx.h
@@ -1,0 +1,41 @@
+#ifndef RDMA_TX_H
+#define RDMA_TX_H
+
+#include "conn_rdma.h"
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+namespace mesh {
+
+namespace connection {
+
+/**
+ * RdmaTx
+ *
+ * Derived class for RDMA Transmit operations.
+ */
+class RdmaTx : public Rdma {
+  public:
+    RdmaTx();
+    ~RdmaTx();
+
+    // Configure the RDMA Transmit session
+    Result configure(context::Context& ctx, const mcm_conn_param& request,
+                     const std::string& dev_port, libfabric_ctx *& dev_handle);
+
+    // Transmit data using RDMA when received from connection class
+    Result on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_t& sent);
+
+  protected:
+    virtual Result start_threads(context::Context& ctx);
+    void rdma_cq_thread(context::Context& ctx);
+
+    size_t total_sent = 0;
+};
+
+} // namespace connection
+
+} // namespace mesh
+
+#endif // RDMA_TX_H

--- a/media-proxy/include/mesh/conn_rdma_tx.h
+++ b/media-proxy/include/mesh/conn_rdma_tx.h
@@ -6,9 +6,7 @@
 #include <mutex>
 #include <condition_variable>
 
-namespace mesh {
-
-namespace connection {
+namespace mesh::connection {
 
 /**
  * RdmaTx
@@ -30,12 +28,8 @@ class RdmaTx : public Rdma {
   protected:
     virtual Result start_threads(context::Context& ctx);
     void rdma_cq_thread(context::Context& ctx);
-
-    size_t total_sent = 0;
 };
 
-} // namespace connection
-
-} // namespace mesh
+} // namespace mesh::connection
 
 #endif // RDMA_TX_H

--- a/media-proxy/include/mesh/conn_rdma_tx.h
+++ b/media-proxy/include/mesh/conn_rdma_tx.h
@@ -20,7 +20,7 @@ class RdmaTx : public Rdma {
 
     // Configure the RDMA Transmit session
     Result configure(context::Context& ctx, const mcm_conn_param& request,
-                     const std::string& dev_port, libfabric_ctx *& dev_handle);
+                     libfabric_ctx *& dev_handle);
 
     // Transmit data using RDMA when received from connection class
     Result on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_t& sent);

--- a/media-proxy/src/libfabric_dev.c
+++ b/media-proxy/src/libfabric_dev.c
@@ -118,6 +118,7 @@ int rdma_init(libfabric_ctx **ctx)
     rdma_freehints(hints);
     if (ret) {
         libfabric_dev_ops.rdma_deinit(ctx);
+        ERROR("Failed to initialize RDMA device");
         return ret;
     }
 

--- a/media-proxy/src/libfabric_ep.c
+++ b/media-proxy/src/libfabric_ep.c
@@ -42,6 +42,7 @@
 #include <unistd.h>
 #include <sched.h>
 #include <sys/types.h>
+#include <netinet/in.h> // For struct sockaddr_in
 
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
@@ -138,14 +139,22 @@ int ep_reg_mr(ep_ctx_t *ep_ctx, void *data_buf, size_t data_buf_size)
     return ret;
 }
 
-int ep_send_buf(ep_ctx_t *ep_ctx, void *buf, size_t buf_size)
-{
+int ep_send_buf(ep_ctx_t* ep_ctx, void* buf, size_t buf_size) {
+    if (!ep_ctx || !buf || buf_size == 0) {
+        ERROR("Invalid parameters provided to ep_send_buf: ep_ctx=%p, buf=%p, buf_size=%zu",
+              ep_ctx, buf, buf_size);
+        return -EINVAL;
+    }
+
     int ret;
 
     do {
-        ret = fi_send(ep_ctx->ep, buf, buf_size, ep_ctx->data_desc, ep_ctx->dest_av_entry, NULL);
-        if (ret == -EAGAIN)
-            (void)fi_cq_read(ep_ctx->cq_ctx.cq, NULL, 0);
+        // Pass the buffer address as the context to fi_send
+        ret = fi_send(ep_ctx->ep, buf, buf_size, ep_ctx->data_desc, ep_ctx->dest_av_entry, buf);
+        if (ret == -EAGAIN) {
+            struct fi_cq_entry cq_entry;
+            (void)fi_cq_read(ep_ctx->cq_ctx.cq, &cq_entry, 1); // Drain CQ
+        }
     } while (ret == -EAGAIN);
 
     return ret;
@@ -199,6 +208,11 @@ int ep_init(ep_ctx_t **ep_ctx, ep_cfg_t *cfg)
     (*ep_ctx)->rdma_ctx = cfg->rdma_ctx;
 
     hints = fi_dupinfo((*ep_ctx)->rdma_ctx->info);
+    if (!hints) {
+        RDMA_PRINTERR("fi_dupinfo failed\n", -ENOMEM);
+        libfabric_ep_ops.ep_destroy(ep_ctx);
+        return -ENOMEM;
+    }
 
     hints->src_addr = NULL;
     hints->src_addrlen = 0;

--- a/media-proxy/src/mesh/conn.cc
+++ b/media-proxy/src/mesh/conn.cc
@@ -316,7 +316,6 @@ const char * result2str(Result res)
     case Result::error_initialization_failed:      return "initialization failed";
     case Result::error_memory_registration_failed: return "memory registration failed";
     case Result::error_thread_creation_failed:     return "thread creation failed";
-    case Result::error_operation_cancelled:        return "operation cancelled";
     case Result::error_no_buffer:        return "no buffer";
     case Result::error_timeout:          return "timeout";
     default:                             return str_unknown;

--- a/media-proxy/src/mesh/conn.cc
+++ b/media-proxy/src/mesh/conn.cc
@@ -311,6 +311,14 @@ const char * result2str(Result res)
     case Result::error_bad_argument:     return "bad argument";
     case Result::error_out_of_memory:    return "out of memory";
     case Result::error_general_failure:  return "general failure";
+    case Result::error_context_cancelled:          return "context cancelled";
+    case Result::error_already_initialized:        return "already initialized";
+    case Result::error_initialization_failed:      return "initialization failed";
+    case Result::error_memory_registration_failed: return "memory registration failed";
+    case Result::error_thread_creation_failed:     return "thread creation failed";
+    case Result::error_operation_cancelled:        return "operation cancelled";
+    case Result::error_no_buffer:        return "no buffer";
+    case Result::error_timeout:          return "timeout";
     default:                             return str_unknown;
     }
 }

--- a/media-proxy/src/mesh/conn_rdma.cc
+++ b/media-proxy/src/mesh/conn_rdma.cc
@@ -165,7 +165,6 @@ void Rdma::cleanup_queue()
  * 
  * @param ctx The operation context.
  * @param request The connection parameters including addresses and RDMA arguments.
- * @param dev_port The device port identifier.
  * @param dev_handle Reference to the RDMA device handle.
  * @param kind The type of connection (receiver or transmitter).
  * @param dir The data transfer direction (RX or TX).

--- a/media-proxy/src/mesh/conn_rdma.cc
+++ b/media-proxy/src/mesh/conn_rdma.cc
@@ -1,0 +1,388 @@
+#include <queue>
+#include "conn_rdma.h"
+
+namespace mesh {
+
+namespace connection {
+
+Rdma::Rdma() : ep_ctx(nullptr), init(false), trx_sz(0), mDevHandle(nullptr)
+{
+    std::memset(&ep_cfg, 0, sizeof(ep_cfg));
+}
+
+Rdma::~Rdma() { shutdown_rdma(context::Background()); }
+
+std::string Rdma::kind_to_string(Kind kind)
+{
+    switch (kind) {
+    case Kind::undefined:
+        return "undefined";
+    case Kind::transmitter:
+        return "transmitter";
+    case Kind::receiver:
+        return "receiver";
+    default:
+        return "unknown";
+    }
+}
+
+void Rdma::notify_cq_event()
+{
+    std::lock_guard<std::mutex> lock(cq_mutex);
+    event_ready = true;
+    cq_cv.notify_one();
+}
+
+void Rdma::init_buf_available() { buf_available = false; }
+
+void Rdma::notify_buf_available()
+{
+    buf_available.store(true, std::memory_order_release);
+    buf_available.notify_one();
+}
+
+void Rdma::wait_buf_available()
+{
+    buf_available.wait(false, std::memory_order_acquire);
+    buf_available = false;
+}
+
+// Add to queue
+Result Rdma::add_to_queue(void *element)
+{
+    if (!element) {
+        return Result::error_bad_argument;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        buffer_queue.push(element);
+    }
+    notify_buf_available(); // Notify availability
+
+    return Result::success;
+}
+
+// Consume from queue
+Result Rdma::consume_from_queue(context::Context& ctx, void **element)
+{
+    std::unique_lock<std::mutex> lock(queue_mutex);
+
+    if (ctx.cancelled()) {
+        *element = nullptr; // Ensure element remains nullptr
+        return Result::error_operation_cancelled;
+    }
+
+    if (buffer_queue.empty()) {
+        return Result::error_no_buffer;
+    }
+
+    *element = buffer_queue.front();
+    buffer_queue.pop();
+
+    return Result::success;
+}
+
+/**
+ * @brief Initializes the RDMA buffer queue with a specified number of pre-allocated elements.
+ * 
+ * Allocates a single contiguous memory block, aligns buffer sizes to the page size, and divides 
+ * the block into individual buffers. Pushes these buffers into the queue for future use.
+ * Ensures proper cleanup on failure or reinitialization attempts.
+ * 
+ * @param capacity The number of buffers to allocate within continuous virtual memory.
+ * @param trx_sz The size of each buffer (aligned to the page size).
+ * @return Result::success on successful initialization, or an error result if arguments are invalid 
+ *         or memory allocation fails.
+ */
+Result Rdma::init_queue_with_elements(size_t capacity, size_t trx_sz)
+{
+    if (trx_sz == 0 || trx_sz > MAX_BUFFER_SIZE) {
+        log::error("Invalid transfer size provided for buffer allocation")("trx_sz", trx_sz);
+        return Result::error_bad_argument;
+    }
+
+    std::lock_guard<std::mutex> lock(queue_mutex);
+
+    // Check if already initialized
+    if (!buffer_queue.empty()) {
+        log::error("Buffer queue already initialized");
+        return Result::error_already_initialized;
+    }
+
+    // Calculate total memory size needed and align to page size
+    size_t aligned_trx_sz = ((trx_sz + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
+    size_t total_size = capacity * aligned_trx_sz;
+
+    // Allocate a single contiguous memory block
+    void *memory_block = std::aligned_alloc(PAGE_SIZE, total_size);
+    if (!memory_block) {
+        log::error("Failed to allocate a single memory block")("total_size", total_size);
+        return Result::error_out_of_memory;
+    }
+
+    // Zero-initialize the entire memory block
+    std::memset(memory_block, 0, total_size);
+
+    // Divide the memory block into individual buffers
+    char *base_ptr = static_cast<char *>(memory_block);
+    for (size_t i = 0; i < capacity; ++i) {
+        void *buf = base_ptr + i * aligned_trx_sz;
+        buffer_queue.push(buf);
+    }
+
+    // Store the base memory block for cleanup
+    buffer_block = memory_block;
+
+    return Result::success;
+}
+
+// Cleanup the buffer queue
+void Rdma::cleanup_queue()
+{
+    if (buffer_block) {
+        // Free the entire memory block
+        std::free(buffer_block);
+        buffer_block = nullptr;
+    }
+    while (!buffer_queue.empty()) {
+        buffer_queue.pop();
+    }
+}
+
+/**
+ * @brief Configures the RDMA connection with the provided parameters.
+ * 
+ * Sets up the RDMA transfer size, connection kind, endpoint configuration,
+ * and queue size based on the input request. Ensures that the kind-direction
+ * pairing is valid (e.g., receiver with RX direction). Updates the connection
+ * state to "configured" upon success.
+ * 
+ * @param ctx The operation context.
+ * @param request The connection parameters including addresses and RDMA arguments.
+ * @param dev_port The device port identifier.
+ * @param dev_handle Reference to the RDMA device handle.
+ * @param kind The type of connection (receiver or transmitter).
+ * @param dir The data transfer direction (RX or TX).
+ * @return Result::success on successful configuration, or an error result if arguments are invalid.
+ */
+Result Rdma::configure(context::Context& ctx, const mcm_conn_param& request,
+                       const std::string& dev_port, libfabric_ctx *& dev_handle, Kind kind,
+                       direction dir)
+{
+
+    if ((kind == Kind::receiver && dir != direction::RX) ||
+        (kind == Kind::transmitter && dir != direction::TX)) {
+        return Result::error_bad_argument;
+    }
+
+    trx_sz = request.payload_args.rdma_args.transfer_size;
+    _kind = kind;
+
+    std::memset(&ep_cfg, 0, sizeof(ep_cfg));
+    std::memcpy(&ep_cfg.remote_addr, &request.remote_addr, sizeof(request.remote_addr));
+    std::memcpy(&ep_cfg.local_addr, &request.local_addr, sizeof(request.local_addr));
+    ep_cfg.dir = dir;
+
+    mDevHandle = dev_handle;
+
+    queue_size = request.payload_args.rdma_args.queue_size;
+
+    set_state(ctx, State::configured);
+    return Result::success;
+}
+
+/**
+ * @brief Establishes an RDMA connection by initializing the device, endpoint, buffer queue,
+ * and starting necessary threads for processing RDMA operations.
+ *
+ * Ensures proper cleanup and state updates on failure. Returns success if all steps
+ * (device initialization, endpoint setup, buffer queue creation, and endpoint configuration)
+ * complete successfully.
+ *
+ * @param ctx The operation context.
+ * @return Result::success on success, or an appropriate error result on failure.
+ */
+Result Rdma::on_establish(context::Context& ctx)
+{
+    if (init) {
+        log::error("RDMA device is already initialized")("state", "initialized");
+        set_state(ctx, State::active);
+        return Result::error_already_initialized;
+    }
+
+    int ret;
+    Result res;
+
+    if (!mDevHandle) {
+        ret = libfabric_dev_ops.rdma_init(&mDevHandle);
+        if (ret) {
+            log::error("Failed to initialize RDMA device")("ret", ret);
+            set_state(ctx, State::closed);
+            return Result::error_initialization_failed;
+        }
+    }
+
+    ep_cfg.rdma_ctx = mDevHandle;
+
+    ret = libfabric_ep_ops.ep_init(&ep_ctx, &ep_cfg);
+    if (ret) {
+        log::error("Failed to initialize RDMA endpoint context")("error", fi_strerror(-ret));
+        set_state(ctx, State::closed);
+        return Result::error_initialization_failed;
+    }
+
+    res = init_queue_with_elements(queue_size, trx_sz);
+    if (res != Result::success) {
+        log::error("Failed to initialize buffer queue")("trx_sz", trx_sz);
+        if (ep_ctx) {
+            libfabric_ep_ops.ep_destroy(&ep_ctx);
+        }
+        set_state(ctx, State::closed);
+        return res;
+    }
+
+    // Configure RDMA endpoint
+    res = configure_endpoint(ctx);
+    if (res != Result::success) {
+        log::error("RDMA configuring failed")("state", "closed");
+        if (ep_ctx) {
+            libfabric_ep_ops.ep_destroy(&ep_ctx);
+        }
+        set_state(ctx, State::closed);
+        return res;
+    }
+
+    init = true;
+    res = start_threads(ctx);
+
+    set_state(ctx, State::active);
+    return Result::success;
+}
+
+Result Rdma::on_shutdown(context::Context& ctx)
+{
+    // Note: this is a blocking call
+    shutdown_rdma(ctx);
+
+    return Result::success;
+}
+
+/**
+ * @brief Handles the deletion of the RDMA connection.
+ *
+ * This function ensures that the RDMA connection is properly shut down
+ * and resources are cleaned up before the object is deleted.
+ *
+ * @param ctx The context used for the delete operation.
+ */
+void Rdma::on_delete(context::Context& ctx)
+{
+    // Note: this is a blocking call
+    on_shutdown(ctx);
+}
+
+/**
+ * @brief Configures the RDMA endpoint by registering the memory block with the RDMA endpoint.
+ *
+ * This function ensures that the endpoint context is initialized and the memory block for the buffer queue
+ * is allocated. It then registers it with the RDMA endpoint.
+ *
+ * @param ctx The context for the operation.
+ * @return Result::success if the endpoint is successfully configured, otherwise an appropriate error code.
+ */
+Result Rdma::configure_endpoint(context::Context& ctx)
+{
+    if (!ep_ctx) {
+        log::error("Endpoint context is not initialized");
+        return Result::error_wrong_state;
+    }
+
+    std::lock_guard<std::mutex> lock(queue_mutex);
+
+    if (!buffer_block) {
+        log::error("Memory block for buffer queue is not allocated");
+        return Result::error_out_of_memory;
+    }
+
+    // Calculate the total size of the memory block
+    size_t total_size = buffer_queue.size() * ((trx_sz + PAGE_SIZE - 1) / PAGE_SIZE * PAGE_SIZE);
+
+    // Register the entire memory block with the RDMA endpoint
+    int ret = libfabric_ep_ops.ep_reg_mr(ep_ctx, buffer_block, total_size);
+    if (ret) {
+        log::error("Memory registration failed for the buffer block")("error", fi_strerror(-ret));
+        return Result::error_memory_registration_failed;
+    }
+
+    return Result::success;
+}
+
+/**
+ * @brief Cleans up RDMA resources and resets the state.
+ *
+ * This function destroys the RDMA endpoint context if it exists, cleans up the buffer queue,
+ * and marks the RDMA as uninitialized. It ensures that all allocated resources are properly
+ * released and the state is reset to allow for reinitialization if needed.
+ *
+ * @param ctx The context used for the cleanup operation.
+ * @return Result indicating the success or failure of the cleanup operation.
+ */
+Result Rdma::cleanup_resources(context::Context& ctx)
+{
+    if (ep_ctx) {
+        int err = libfabric_ep_ops.ep_destroy(&ep_ctx);
+        if (err) {
+            log::error("Failed to destroy RDMA endpoint")("error", fi_strerror(-err));
+        }
+    }
+
+    // Clean up the buffer queue
+    cleanup_queue();
+
+    // Mark RDMA as uninitialized
+    init = false;
+
+    return Result::success;
+}
+
+/**
+ * @brief Shuts down the RDMA connection and cleans up resources.
+ *
+ * This function cancels the RDMA completion queue thread and the buffer processing thread,
+ * ensuring that they are properly joined. It also notifies buffer availability to unblock
+ * any waiting operations. If the RDMA connection was initialized, it cleans up the RDMA
+ * resources and sets the state to closed.
+ *
+ * @param ctx The context used for the shutdown operation.
+ */
+void Rdma::shutdown_rdma(context::Context& ctx)
+{
+    // Cancel `rdma_cq_thread` context
+    rdma_cq_thread_ctx.cancel();
+    // Cancel `process_buffers_thread` context
+    process_buffers_thread_ctx.cancel();
+    // Ensure buffer-related threads are unblocked
+    notify_buf_available();
+
+    // Check if `rdma_cq_thread` has stopped
+    if (handle_rdma_cq_thread.joinable()) {
+        handle_rdma_cq_thread.join();
+    }
+
+    // Check if `process_buffers_thread` has stopped
+    if (handle_process_buffers_thread.joinable()) {
+        handle_process_buffers_thread.join();
+    }
+
+    // Clean up RDMA resources if initialized
+    if (init) {
+        cleanup_resources(ctx);
+    }
+
+    set_state(ctx, State::closed);
+}
+
+} // namespace connection
+
+} // namespace mesh

--- a/media-proxy/src/mesh/conn_rdma.cc
+++ b/media-proxy/src/mesh/conn_rdma.cc
@@ -212,6 +212,11 @@ Result Rdma::on_establish(context::Context& ctx)
         set_state(ctx, State::closed);
         return Result::error_initialization_failed;
     }
+    if(queue_size == 0) {
+        log::error("Queue size is not set")("queue_size", queue_size);
+        set_state(ctx, State::closed);
+        return Result::error_bad_argument;
+    }
 
     res = init_queue_with_elements(queue_size, trx_sz);
     if (res != Result::success) {
@@ -236,7 +241,6 @@ Result Rdma::on_establish(context::Context& ctx)
 
     init = true;
     res = start_threads(ctx);
-
     set_state(ctx, State::active);
     return Result::success;
 }

--- a/media-proxy/src/mesh/conn_rdma.cc
+++ b/media-proxy/src/mesh/conn_rdma.cc
@@ -171,7 +171,7 @@ void Rdma::cleanup_queue()
  * @return Result::success on successful configuration, or an error result if arguments are invalid.
  */
 Result Rdma::configure(context::Context& ctx, const mcm_conn_param& request,
-                       const std::string& dev_port, libfabric_ctx *& dev_handle)
+                       libfabric_ctx *& dev_handle)
 {
 
     trx_sz = request.payload_args.rdma_args.transfer_size;

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -143,6 +143,7 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
             break;
         }
     }
+    ep_ctx->stop_flag = true; // Set the stop flag
 }
 
 } // namespace mesh::connection

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -30,7 +30,7 @@ Result RdmaRx::start_threads(context::Context& ctx)
         handle_process_buffers_thread = std::jthread(
             [this]() { this->process_buffers_thread(this->process_buffers_thread_ctx); });
     } catch (const std::system_error& e) {
-        log::fatal("Failed to start thread")("error", e.what());
+        log::error("Failed to start thread")("error", e.what());
         return Result::error_thread_creation_failed;
     }
 
@@ -38,7 +38,7 @@ Result RdmaRx::start_threads(context::Context& ctx)
         handle_rdma_cq_thread =
             std::jthread([this]() { this->rdma_cq_thread(this->rdma_cq_thread_ctx); });
     } catch (const std::system_error& e) {
-        log::fatal("Failed to start thread")("error", e.what());
+        log::error("Failed to start thread")("error", e.what());
         return Result::error_thread_creation_failed;
     }
 

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -68,11 +68,11 @@ void RdmaRx::process_buffers_thread(context::Context& ctx)
                 if (err) {
                     log::error("Failed to pass empty buffer to RDMA to receive into")
                               ("buffer_address", buf)("error", fi_strerror(-err))
-                              (" ", kind2str(_kind));
+                              ("Kind", kind2str(_kind));
                     res = add_to_queue(buf);
                     if (res != Result::success) {
                         log::error("Failed to add buffer to queue")("error", result2str(res))
-                                  (" ", kind2str(_kind));
+                                  ("Kind", kind2str(_kind));
                         break;
                     }
                 }
@@ -117,7 +117,7 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
                 void *buf = cq_entries[i].op_context;
                 if (buf == nullptr) {
                     log::error("Null buffer context, skipping...")
-                              ("batch_index",i)(" ", kind2str(_kind));
+                              ("batch_index",i)("Kind", kind2str(_kind));
                     continue;
                 }
 
@@ -125,7 +125,7 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
                 Result res = transmit(ctx, buf, trx_sz);
                 if (res != Result::success) {
                     log::error("Failed to transmit buffer")("buffer_address", buf)("size", trx_sz)
-                              (" ", kind2str(_kind));
+                              ("Kind", kind2str(_kind));
                     continue;
                 }
 
@@ -136,7 +136,7 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
                     notify_buf_available();
                 } else {
                     log::error("Failed to add buffer back to the queue")("buffer_address", buf)
-                              (" ", kind2str(_kind));
+                              ("Kind", kind2str(_kind));
                 }
             }
         } else if (ret == -EAGAIN) {

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -66,8 +66,9 @@ void RdmaRx::process_buffers_thread(context::Context& ctx)
             if (res == Result::success && buf != nullptr) {
                 int err = libfabric_ep_ops.ep_recv_buf(ep_ctx, buf, trx_sz, buf);
                 if (err) {
-                    log::error("Failed to pass empty buffer to RDMA to receive into")("buffer_address", buf)
-                              ("error", fi_strerror(-err))(" ", kind2str(_kind));
+                    log::error("Failed to pass empty buffer to RDMA to receive into")
+                              ("buffer_address", buf)("error", fi_strerror(-err))
+                              (" ", kind2str(_kind));
                     res = add_to_queue(buf);
                     if (res != Result::success) {
                         log::error("Failed to add buffer to queue")("error", result2str(res))

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -66,10 +66,14 @@ void RdmaRx::process_buffers_thread(context::Context& ctx)
             if (res == Result::success && buf != nullptr) {
                 int err = libfabric_ep_ops.ep_recv_buf(ep_ctx, buf, trx_sz, buf);
                 if (err) {
-                    log::error("Failed to pass empty buffer to RDMA to receive into")
-                              ("buffer_address", buf)("error", fi_strerror(-err))
-                              (" ",kind2str(_kind));
-                    add_to_queue(buf);
+                    log::error("Failed to pass empty buffer to RDMA to receive into")("buffer_address", buf)
+                              ("error", fi_strerror(-err))(" ", kind2str(_kind));
+                    res = add_to_queue(buf);
+                    if (res != Result::success) {
+                        log::error("Failed to add buffer to queue")("error", result2str(res))
+                                  (" ", kind2str(_kind));
+                        break;
+                    }
                 }
             } else {
                 break; // Exit the loop to avoid spinning on errors

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -1,0 +1,149 @@
+#include "conn_rdma_rx.h"
+#include <stdexcept>
+#include <queue>
+
+namespace mesh {
+
+namespace connection {
+
+RdmaRx::RdmaRx() : Rdma() { init_buf_available(); }
+
+RdmaRx::~RdmaRx()
+{
+    // Any specific cleanup for Rx can go here
+}
+
+Result RdmaRx::configure(context::Context& ctx, const mcm_conn_param& request,
+                         const std::string& dev_port, libfabric_ctx *& dev_handle)
+{
+    return Rdma::configure(ctx, request, dev_port, dev_handle, Kind::receiver, direction::RX);
+}
+
+Result RdmaRx::start_threads(context::Context& ctx)
+{
+
+    process_buffers_thread_ctx = context::WithCancel(ctx);
+    rdma_cq_thread_ctx = context::WithCancel(ctx);
+
+    try {
+        handle_process_buffers_thread = std::jthread(
+            [this]() { this->process_buffers_thread(this->process_buffers_thread_ctx); });
+    } catch (const std::system_error& e) {
+        log::fatal("Failed to start thread")("error", e.what());
+        return Result::error_thread_creation_failed;
+    }
+
+    try {
+        handle_rdma_cq_thread =
+            std::jthread([this]() { this->rdma_cq_thread(this->rdma_cq_thread_ctx); });
+    } catch (const std::system_error& e) {
+        log::fatal("Failed to start thread")("error", e.what());
+        return Result::error_thread_creation_failed;
+    }
+
+    return Result::success;
+}
+
+/**
+ * @brief Handles the buffer processing logic for RDMA in a dedicated thread.
+ * 
+ * Continuously consumes available buffers from the queue and prepares them for RDMA reception
+ * by passing them to the RDMA endpoint. If no buffers are available, the thread waits for 
+ * notification of buffer availability. Ensures graceful handling of errors and context cancellation.
+ * 
+ * @param ctx The context for managing thread cancellation and operations.
+ */
+void RdmaRx::process_buffers_thread(context::Context& ctx)
+{
+
+    while (!ctx.cancelled()) {
+        void *buf = nullptr;
+
+        // Process all available buffers in the queue
+        while (!ctx.cancelled()) {
+            Result res = consume_from_queue(ctx, &buf);
+            if (res == Result::success && buf != nullptr) {
+                int err = libfabric_ep_ops.ep_recv_buf(ep_ctx, buf, trx_sz, buf);
+                if (err) {
+                    log::error("Failed to pass empty buffer to RDMA to receive into")
+                              ("buffer_address", buf)("error", fi_strerror(-err))
+                              (" ",kind_to_string(_kind));
+                    add_to_queue(buf);
+                }
+            } else {
+                break; // Exit the loop to avoid spinning on errors
+            }
+        }
+        // Wait for the buffer to become available
+        wait_buf_available();
+    }
+}
+
+/**
+ * @brief Handles the RDMA completion queue (CQ) events in a dedicated thread.
+ * 
+ * This function continuously monitors the CQ for completion events, processes
+ * completed buffers, and returns them to the buffer queue for reuse. It ensures
+ * efficient event handling by reading events in batches and sleeping briefly
+ * when no events are available to avoid busy waiting.
+ * 
+ * Key Steps:
+ * 1. Reads a batch of CQ entries.
+ * 2. For each entry:
+ *    - Processes the received buffer and sends it.
+ *    - Adds the buffer back to the queue upon successful processing.
+ *    - Logs errors for any issues during processing or queue operations.
+ * 3. Handles `EAGAIN` errors by yielding CPU time to avoid busy looping.
+ * 4. Logs and exits on other CQ read errors.
+ * 
+ * @param ctx The context for managing thread cancellation and operations.
+ */
+void RdmaRx::rdma_cq_thread(context::Context& ctx)
+{
+    constexpr int CQ_RETRY_DELAY_US = 100; // Retry delay for EAGAIN
+    struct fi_cq_entry cq_entries[CQ_BATCH_SIZE]; // Array to hold batch of CQ entries
+
+    while (!ctx.cancelled()) {
+        // Read a batch of completion events
+        int ret = fi_cq_read(ep_ctx->cq_ctx.cq, cq_entries, CQ_BATCH_SIZE);
+        if (ret > 0) {
+            for (int i = 0; i < ret; ++i) {
+                void *buf = cq_entries[i].op_context;
+                if (buf == nullptr) {
+                    log::error("Null buffer context, skipping...")
+                              ("batch_index",i)(" ", kind_to_string(_kind));
+                    continue;
+                }
+
+                // Process the buffer (e.g., transmit or handle)
+                Result res = transmit(ctx, buf, trx_sz);
+                if (res != Result::success) {
+                    log::error("Failed to transmit buffer")("buffer_address", buf)("size", trx_sz)
+                              (" ", kind_to_string(_kind));
+                    continue;
+                }
+
+                // Add the buffer back to the queue
+                res = add_to_queue(buf);
+                if (res == Result::success) {
+                    // Notify that a buffer is available
+                    notify_buf_available();
+                } else {
+                    log::error("Failed to add buffer back to the queue")("buffer_address", buf)
+                              (" ", kind_to_string(_kind));
+                }
+            }
+        } else if (ret == -EAGAIN) {
+            // No events to process, yield CPU briefly to avoid busy looping
+            std::this_thread::sleep_for(std::chrono::microseconds(CQ_RETRY_DELAY_US));
+        } else {
+            // Handle CQ read error
+            log::error("CQ read failed")("error", fi_strerror(-ret));
+            break;
+        }
+    }
+}
+
+} // namespace connection
+
+} // namespace mesh

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -2,11 +2,12 @@
 #include <stdexcept>
 #include <queue>
 
-namespace mesh {
+namespace mesh::connection {
 
-namespace connection {
-
-RdmaRx::RdmaRx() : Rdma() { init_buf_available(); }
+RdmaRx::RdmaRx() : Rdma() {
+    _kind = Kind::receiver; // Set the Kind in the constructor
+    dir = direction::RX;    // Set the direction in the constructor
+}
 
 RdmaRx::~RdmaRx()
 {
@@ -16,7 +17,7 @@ RdmaRx::~RdmaRx()
 Result RdmaRx::configure(context::Context& ctx, const mcm_conn_param& request,
                          const std::string& dev_port, libfabric_ctx *& dev_handle)
 {
-    return Rdma::configure(ctx, request, dev_port, dev_handle, Kind::receiver, direction::RX);
+    return Rdma::configure(ctx, request, dev_port, dev_handle);
 }
 
 Result RdmaRx::start_threads(context::Context& ctx)
@@ -67,7 +68,7 @@ void RdmaRx::process_buffers_thread(context::Context& ctx)
                 if (err) {
                     log::error("Failed to pass empty buffer to RDMA to receive into")
                               ("buffer_address", buf)("error", fi_strerror(-err))
-                              (" ",kind_to_string(_kind));
+                              (" ",kind2str(_kind));
                     add_to_queue(buf);
                 }
             } else {
@@ -111,7 +112,7 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
                 void *buf = cq_entries[i].op_context;
                 if (buf == nullptr) {
                     log::error("Null buffer context, skipping...")
-                              ("batch_index",i)(" ", kind_to_string(_kind));
+                              ("batch_index",i)(" ", kind2str(_kind));
                     continue;
                 }
 
@@ -119,7 +120,7 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
                 Result res = transmit(ctx, buf, trx_sz);
                 if (res != Result::success) {
                     log::error("Failed to transmit buffer")("buffer_address", buf)("size", trx_sz)
-                              (" ", kind_to_string(_kind));
+                              (" ", kind2str(_kind));
                     continue;
                 }
 
@@ -130,7 +131,7 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
                     notify_buf_available();
                 } else {
                     log::error("Failed to add buffer back to the queue")("buffer_address", buf)
-                              (" ", kind_to_string(_kind));
+                              (" ", kind2str(_kind));
                 }
             }
         } else if (ret == -EAGAIN) {
@@ -144,6 +145,4 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx)
     }
 }
 
-} // namespace connection
-
-} // namespace mesh
+} // namespace mesh::connection

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -15,9 +15,9 @@ RdmaRx::~RdmaRx()
 }
 
 Result RdmaRx::configure(context::Context& ctx, const mcm_conn_param& request,
-                         const std::string& dev_port, libfabric_ctx *& dev_handle)
+                         libfabric_ctx *& dev_handle)
 {
-    return Rdma::configure(ctx, request, dev_port, dev_handle);
+    return Rdma::configure(ctx, request, dev_handle);
 }
 
 Result RdmaRx::start_threads(context::Context& ctx)

--- a/media-proxy/src/mesh/conn_rdma_tx.cc
+++ b/media-proxy/src/mesh/conn_rdma_tx.cc
@@ -28,7 +28,7 @@ Result RdmaTx::start_threads(context::Context& ctx)
         handle_rdma_cq_thread =
             std::jthread([this]() { this->rdma_cq_thread(this->rdma_cq_thread_ctx); });
     } catch (const std::system_error& e) {
-        log::fatal("Failed to start threads")("error", e.what())(" ", kind2str(_kind));
+        log::error("Failed to start threads")("error", e.what())(" ", kind2str(_kind));
         return Result::error_thread_creation_failed;
     }
     return Result::success;

--- a/media-proxy/src/mesh/conn_rdma_tx.cc
+++ b/media-proxy/src/mesh/conn_rdma_tx.cc
@@ -168,7 +168,11 @@ Result RdmaTx::on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_
                   (" ", kind2str(_kind));
 
         // Add the buffer back to the queue in case of failure
-        add_to_queue(reg_buf);
+        Result res = add_to_queue(reg_buf);
+        if (res != Result::success) {
+            log::error("Failed to add buffer to queue")("error", result2str(res))
+                      (" ",kind2str(_kind));
+        }
 
         sent = 0;
         return Result::error_general_failure;

--- a/media-proxy/src/mesh/conn_rdma_tx.cc
+++ b/media-proxy/src/mesh/conn_rdma_tx.cc
@@ -15,9 +15,9 @@ RdmaTx::~RdmaTx()
 }
 
 Result RdmaTx::configure(context::Context& ctx, const mcm_conn_param& request,
-                         const std::string& dev_port, libfabric_ctx *& dev_handle)
+                         libfabric_ctx *& dev_handle)
 {
-    return Rdma::configure(ctx, request, dev_port, dev_handle);
+    return Rdma::configure(ctx, request, dev_handle);
 }
 
 Result RdmaTx::start_threads(context::Context& ctx)

--- a/media-proxy/src/mesh/conn_rdma_tx.cc
+++ b/media-proxy/src/mesh/conn_rdma_tx.cc
@@ -1,0 +1,186 @@
+#include "conn_rdma_tx.h"
+#include <stdexcept>
+#include <queue>
+
+namespace mesh {
+
+namespace connection {
+
+RdmaTx::RdmaTx() : Rdma() { init_buf_available(); }
+
+RdmaTx::~RdmaTx()
+{
+    // Any specific cleanup for Tx can go here
+}
+
+Result RdmaTx::configure(context::Context& ctx, const mcm_conn_param& request,
+                         const std::string& dev_port, libfabric_ctx *& dev_handle)
+{
+    return Rdma::configure(ctx, request, dev_port, dev_handle, Kind::transmitter, direction::TX);
+}
+
+Result RdmaTx::start_threads(context::Context& ctx)
+{
+    rdma_cq_thread_ctx = context::WithCancel(ctx);
+
+    try {
+        handle_rdma_cq_thread =
+            std::jthread([this]() { this->rdma_cq_thread(this->rdma_cq_thread_ctx); });
+    } catch (const std::system_error& e) {
+        log::fatal("Failed to start threads")("error", e.what())(" ", kind_to_string(_kind));
+        return Result::error_thread_creation_failed;
+    }
+    return Result::success;
+}
+
+/**
+ * @brief Monitors the RDMA completion queue (CQ) for send completions and manages buffer recycling.
+ * 
+ * This function runs in a dedicated thread to handle send completion events from the RDMA CQ.
+ * It waits for buffer availability notifications, processes CQ events, and replenishes buffers
+ * to the queue for reuse. Implements a retry mechanism with a timeout to handle transient CQ read issues.
+ * 
+ * @param ctx The context for managing thread cancellation and stop requests.
+ */
+
+void RdmaTx::rdma_cq_thread(context::Context& ctx)
+{
+    constexpr uint32_t RETRY_INTERVAL_US = 100; // Retry interval of 100 us
+    constexpr uint32_t TIMEOUT_US = 1000000;       // Total timeout of 1s
+
+    while (!ctx.cancelled()) {
+        // Wait for the buffer to become available after successful send
+        wait_buf_available();
+
+        if (ctx.stop_token().stop_requested()) {
+            break;
+        }
+
+        struct fi_cq_entry cq_entries[CQ_BATCH_SIZE];
+
+        uint32_t elapsed_time = 0;
+        while (elapsed_time < TIMEOUT_US) {
+            int ret = fi_cq_read(ep_ctx->cq_ctx.cq, cq_entries, CQ_BATCH_SIZE);
+
+            if (ret > 0) {
+                for (int i = 0; i < ret; i++) {
+                    void *buf = cq_entries[i].op_context;
+                    if (buf == nullptr) {
+                        log::error("Null buffer context, skipping...")(" ", kind_to_string(_kind));
+                        continue;
+                    }
+
+                    // Replenish buffer
+                    Result res = add_to_queue(buf);
+                    if (res != Result::success) {
+                        log::error("Failed to add buffer back to queue")("buffer_address", buf)
+                                  (" ", kind_to_string(_kind));
+                    }
+                }
+                break; // Exit retry loop as CQ events were successfully processed
+            } else if (ret == -EAGAIN) {
+                // No events, introduce short wait to avoid busy looping
+                std::this_thread::sleep_for(std::chrono::microseconds(RETRY_INTERVAL_US));
+                elapsed_time += RETRY_INTERVAL_US;
+            } else {
+                // Handle errors
+                log::error("CQ read failed")("error", fi_strerror(-ret))
+                          (" ",kind_to_string(_kind));
+                break; // Exit retry loop on error
+            }
+
+            if (ctx.stop_token().stop_requested()) {
+                return;
+            }
+        }
+
+        // Log if timeout occurred without receiving any events after buffer should be already
+        // available
+        if (elapsed_time >= TIMEOUT_US) {
+            log::debug("CQ read timed out after retries")(" ", kind_to_string(_kind));
+        }
+    }
+}
+
+/**
+ * @brief Handles sending data through RDMA by consuming a buffer, copying data, and transmitting it.
+ * 
+ * This function attempts to consume a pre-allocated buffer from the queue within a specified timeout,
+ * copies the provided data into the buffer, and sends it through the RDMA endpoint. It ensures proper
+ * error handling, retries for buffer availability, and buffer management in case of transmission failure.
+ * 
+ * @param ctx The context for managing the operation.
+ * @param ptr Pointer to the data to be transmitted.
+ * @param sz The size of the data to be transmitted.
+ * @param sent Output parameter indicating the actual number of bytes sent.
+ * @return Result::success on successful transmission, or an appropriate error result on failure.
+ */
+Result RdmaTx::on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_t& sent)
+{
+    void *reg_buf = nullptr;
+    constexpr uint32_t TIMEOUT_US = 500000;     // 0.5-second timeout
+    constexpr uint32_t RETRY_INTERVAL_US = 100; // Retry interval of 100 us
+    uint32_t elapsed_time = 0;
+
+    // Attempt to consume a buffer from the queue with a timeout
+    while (elapsed_time < TIMEOUT_US) {
+        Result res = consume_from_queue(ctx, &reg_buf);
+        if (res == Result::success) {
+            if (reg_buf != nullptr) {
+                break; // Successfully got a buffer
+            } else {
+                log::debug("Buffer is null, retrying...")(" ", kind_to_string(_kind));
+            }
+        } else if (res != Result::error_no_buffer) {
+            // Log non-retryable errors and exit
+            log::error("Failed to consume buffer from queue")("result", static_cast<int>(res))
+                      (" ", kind_to_string(_kind));
+            sent = 0;
+            return res;
+        }
+
+        // Wait before retrying
+        std::this_thread::sleep_for(std::chrono::microseconds(RETRY_INTERVAL_US));
+        elapsed_time += RETRY_INTERVAL_US;
+    }
+
+    // Check if we failed to get a buffer within the timeout
+    if (reg_buf == nullptr) {
+        log::error("Failed to consume buffer within timeout")("timeout_ms", TIMEOUT_US)
+                  (" ", kind_to_string(_kind));
+        log::error("Total MB sent:")(" ", total_sent / 1048576.0);
+        sent = 0;
+        return Result::error_timeout;
+    }
+
+    uint32_t tmp_sent = std::min(static_cast<uint32_t>(trx_sz), sz);
+    if (tmp_sent != trx_sz) {
+        log::debug("Sent size differs from transfer size")("requested_size", tmp_sent)
+                  ("trx_sz", trx_sz)(" ", kind_to_string(_kind));
+    }
+
+    std::memcpy(reg_buf, ptr, tmp_sent);
+
+    // Transmit the buffer through RDMA
+    int err = libfabric_ep_ops.ep_send_buf(ep_ctx, reg_buf, tmp_sent);
+    notify_buf_available();
+    sent = tmp_sent;
+    total_sent += tmp_sent;
+
+    if (err) {
+        log::error("Failed to send buffer through RDMA")("error", fi_strerror(-err))
+                  (" ", kind_to_string(_kind));
+
+        // Add the buffer back to the queue in case of failure
+        add_to_queue(reg_buf);
+
+        sent = 0;
+        return Result::error_general_failure;
+    }
+
+    return Result::success;
+}
+
+} // namespace connection
+
+} // namespace mesh

--- a/media-proxy/src/session-rdma-rx.cc
+++ b/media-proxy/src/session-rdma-rx.cc
@@ -92,6 +92,7 @@ RxRdmaSession::RxRdmaSession(libfabric_ctx *dev_handle, const mcm_conn_param &re
     ep_cfg.rdma_ctx = dev_handle;
     memcpy(&ep_cfg.remote_addr, &request.remote_addr, sizeof(request.remote_addr));
     memcpy(&ep_cfg.local_addr, &request.local_addr, sizeof(request.local_addr));
+    ep_cfg.dir = direction::RX;
 }
 
 int RxRdmaSession::init()

--- a/media-proxy/src/session-rdma-rx.cc
+++ b/media-proxy/src/session-rdma-rx.cc
@@ -92,7 +92,6 @@ RxRdmaSession::RxRdmaSession(libfabric_ctx *dev_handle, const mcm_conn_param &re
     ep_cfg.rdma_ctx = dev_handle;
     memcpy(&ep_cfg.remote_addr, &request.remote_addr, sizeof(request.remote_addr));
     memcpy(&ep_cfg.local_addr, &request.local_addr, sizeof(request.local_addr));
-    ep_cfg.dir = direction::RX;
 }
 
 int RxRdmaSession::init()

--- a/media-proxy/src/session-rdma-tx.cc
+++ b/media-proxy/src/session-rdma-tx.cc
@@ -49,6 +49,7 @@ TxRdmaSession::TxRdmaSession(libfabric_ctx *dev_handle, const mcm_conn_param &re
     ep_cfg.rdma_ctx = dev_handle;
     memcpy(&ep_cfg.remote_addr, &request.remote_addr, sizeof(request.remote_addr));
     memcpy(&ep_cfg.local_addr, &request.local_addr, sizeof(request.local_addr));
+    ep_cfg.dir = direction::TX;
 }
 
 int TxRdmaSession::init()

--- a/media-proxy/src/session-rdma-tx.cc
+++ b/media-proxy/src/session-rdma-tx.cc
@@ -49,7 +49,6 @@ TxRdmaSession::TxRdmaSession(libfabric_ctx *dev_handle, const mcm_conn_param &re
     ep_cfg.rdma_ctx = dev_handle;
     memcpy(&ep_cfg.remote_addr, &request.remote_addr, sizeof(request.remote_addr));
     memcpy(&ep_cfg.local_addr, &request.local_addr, sizeof(request.local_addr));
-    ep_cfg.dir = direction::TX;
 }
 
 int TxRdmaSession::init()

--- a/media-proxy/tests/CMakeLists.txt
+++ b/media-proxy/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ file(GLOB MEDIA_PROXY_TEST_SOURCES
 )
 
 # Find source files for RDMA-specific tests
-file(GLOB RDMA__RX_TX_TEST_SOURCES
+file(GLOB RDMA_RX_TX_TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_rx_tests.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_tx_tests.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_test_mocks.cc"
@@ -68,14 +68,12 @@ target_include_directories(media_proxy_unit_tests PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-# Add an executable for RDMA-specific tests
-add_executable(conn_rdma_rx_tx_unit_tests ${RDMA__RX_TX_TEST_SOURCES})
+# Add an executable for RDMA-Rx-Tx-specific tests
+add_executable(conn_rdma_rx_tx_unit_tests ${RDMA_RX_TX_TEST_SOURCES})
 target_link_libraries(conn_rdma_rx_tx_unit_tests PRIVATE gmock gmock_main gtest gtest_main ${MP_LIB})
 target_include_directories(conn_rdma_rx_tx_unit_tests PUBLIC
     ${CMAKE_SOURCE_DIR}/media-proxy/include
-    # Include generated *.pb.h files
     ${CMAKE_BINARY_DIR}/media-proxy/generated
-    ${FFF_DOWNLOAD_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/media-proxy/tests/CMakeLists.txt
+++ b/media-proxy/tests/CMakeLists.txt
@@ -1,52 +1,77 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
 cmake_minimum_required(VERSION 3.16)
 project(McmMeifTests VERSION 0.1.0 LANGUAGES CXX C)
-
 set(CMAKE_C_STANDARD 11)
-
 # Download fff.h
 set(FFF_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps/")
-
 # Only download if not already present
 if(NOT EXISTS "${FFF_DOWNLOAD_DIR}/fff.h")
     message(STATUS "Downloading fff.h...")
-
     file(DOWNLOAD
         "https://raw.githubusercontent.com/meekrosoft/fff/master/fff.h"
         "${FFF_DOWNLOAD_DIR}/fff.h"
         SHOW_PROGRESS
         STATUS DOWNLOAD_STATUS
     )
-
     list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
     if(NOT STATUS_CODE EQUAL 0)
         message(FATAL_ERROR "Failed to download fff.h")
     endif()
 endif()
-
 add_executable(memif_test_rx memif_test_rx.c)
 target_include_directories(memif_test_rx PRIVATE ../include)
 target_link_libraries(memif_test_rx PRIVATE mcm_dp)
-
 add_executable(memif_test_tx memif_test_tx.c)
 target_include_directories(memif_test_tx PRIVATE ../include)
 target_link_libraries(memif_test_tx PRIVATE mcm_dp)
 
-# Find source files for tests
-file(GLOB TEST_SOURCES "*.cc")
+# Find source files for general tests
+file(GLOB MEDIA_PROXY_TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/libfabric_cq_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libfabric_dev_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libfabric_ep_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libfabric_mocks.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libfabric_mr_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/proxy_context_tests.cc"
+)
+
+# Find source files for RDMA-specific tests
+file(GLOB RDMA__RX_TX_TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_rx_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_tx_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_test_mocks.cc"
+)
+
+# Find source files for physical-RDMA-specific tests
+file(GLOB PHYS_RDMA_TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_real_ep_test.cc"
+)
+
+# Find source files for physical-RDMA-specific tests
+file(GLOB RDMA_BASE_TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_test_mocks.cc"
+)
 
 set(MP_LIB media_proxy_lib)
 
-# Add an executable for tests
-add_executable(media_proxy_unit_tests ${TEST_SOURCES})
+# Add an executable for general tests
+add_executable(media_proxy_unit_tests ${MEDIA_PROXY_TEST_SOURCES})
 target_compile_definitions(media_proxy_unit_tests PRIVATE UNIT_TESTS_ENABLED)
-
-# Link the executable with gtest and gtest_main
 target_link_libraries(media_proxy_unit_tests PRIVATE gtest gtest_main ${MP_LIB})
 target_include_directories(media_proxy_unit_tests PUBLIC
+    ${CMAKE_SOURCE_DIR}/media-proxy/include
+    ${CMAKE_BINARY_DIR}/media-proxy/generated
+    ${FFF_DOWNLOAD_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Add an executable for RDMA-specific tests
+add_executable(conn_rdma_rx_tx_unit_tests ${RDMA__RX_TX_TEST_SOURCES})
+target_link_libraries(conn_rdma_rx_tx_unit_tests PRIVATE gmock gmock_main gtest gtest_main ${MP_LIB})
+target_include_directories(conn_rdma_rx_tx_unit_tests PUBLIC
     ${CMAKE_SOURCE_DIR}/media-proxy/include
     # Include generated *.pb.h files
     ${CMAKE_BINARY_DIR}/media-proxy/generated
@@ -54,5 +79,42 @@ target_include_directories(media_proxy_unit_tests PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# Add an executable for RDMA-base-specific tests
+add_executable(conn_rdma_base_unit_tests ${RDMA_BASE_TEST_SOURCES})
+target_compile_definitions(conn_rdma_base_unit_tests PRIVATE UNIT_TESTS_ENABLED)
+target_link_libraries(conn_rdma_base_unit_tests PRIVATE gmock gmock_main gtest gtest_main ${MP_LIB})
+target_include_directories(conn_rdma_base_unit_tests PUBLIC
+    ${CMAKE_SOURCE_DIR}/media-proxy/include
+    ${CMAKE_BINARY_DIR}/media-proxy/generated
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Add an executable for physical-RDMA-specific tests
+add_executable(conn_rdma_real_ep_test ${PHYS_RDMA_TEST_SOURCES})
+target_link_libraries(conn_rdma_real_ep_test PRIVATE gtest gtest_main ${MP_LIB})
+target_include_directories(conn_rdma_real_ep_test PUBLIC
+    ${CMAKE_SOURCE_DIR}/media-proxy/include
+    ${CMAKE_BINARY_DIR}/media-proxy/generated
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 # Add tests to CTest
+add_test(NAME conn_rdma_rx_tx_unit_tests COMMAND conn_rdma_rx_tx_unit_tests)
 add_test(NAME media_proxy_unit_tests COMMAND media_proxy_unit_tests)
+add_test(NAME conn_rdma_base_unit_tests COMMAND conn_rdma_base_unit_tests)
+
+# ONLY USE THIS TEST (SET ON OPTION) IF YOU HAVE CONFIGURED REAL RDMA ENDPOINTS
+# IN FUNCTION SetupRdmaConnections
+option(RUN_REAL_RDMA_PERFORMANCE_TESTS "Build and enable unit tests" OFF)
+if (RUN_REAL_RDMA_PERFORMANCE_TESTS)
+    add_test(NAME conn_rdma_real_ep_test COMMAND conn_rdma_real_ep_test)
+    set_tests_properties(conn_rdma_real_ep_test PROPERTIES DESCRIPTION "
+        Validates the functionality, performance, and correctness of RDMA Tx and Rx operations with 
+            real endpoint configurations:
+        1. Tests concurrent data transmission and reception between an emulated transmitter
+            and a test receiver.
+        2. Measures latency and bandwidth for varying payload sizes and queue depths.
+        3. Reports average latency and transfer rate in GB/s for different configurations,
+            ensuring RDMA endpoint reliability and efficiency.
+    ")
+endif()

--- a/media-proxy/tests/conn_rdma_real_ep_test.cc
+++ b/media-proxy/tests/conn_rdma_real_ep_test.cc
@@ -139,8 +139,8 @@ class RdmaRealEndpointsTest : public ::testing::Test {
     // Set up RDMA Rx
     mcm_conn_param rx_request = {};
     rx_request.type = is_rx;
-    rx_request.local_addr = {.ip = "192.168.1.20", .port = "8002"};
-    rx_request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    rx_request.local_addr = {.ip = "192.168.10.21", .port = "8002"};
+    rx_request.remote_addr = {.ip = "192.168.10.20", .port = "8003"};
     rx_request.payload_args.rdma_args.transfer_size = payload_size;
     rx_request.payload_args.rdma_args.queue_size = queue_size;
 
@@ -151,8 +151,8 @@ class RdmaRealEndpointsTest : public ::testing::Test {
     // Set up RDMA Tx
     mcm_conn_param tx_request = {};
     tx_request.type = is_tx;
-    tx_request.local_addr = {.ip = "192.168.1.20", .port = "8002"};
-    tx_request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    tx_request.local_addr = {.ip = "192.168.10.20", .port = "8003"};
+    tx_request.remote_addr = {.ip = "192.168.10.21", .port = "8002"};
     tx_request.payload_args.rdma_args.transfer_size = payload_size;
     tx_request.payload_args.rdma_args.queue_size = queue_size;
 

--- a/media-proxy/tests/conn_rdma_real_ep_test.cc
+++ b/media-proxy/tests/conn_rdma_real_ep_test.cc
@@ -144,7 +144,7 @@ class RdmaRealEndpointsTest : public ::testing::Test {
     rx_request.payload_args.rdma_args.transfer_size = payload_size;
     rx_request.payload_args.rdma_args.queue_size = queue_size;
 
-    ASSERT_EQ(conn_rx->configure(ctx, rx_request, "0000:31:00.1", rx_dev_handle),
+    ASSERT_EQ(conn_rx->configure(ctx, rx_request, rx_dev_handle),
               connection::Result::success);
     ASSERT_EQ(conn_rx->establish(ctx), connection::Result::success);
 
@@ -156,7 +156,7 @@ class RdmaRealEndpointsTest : public ::testing::Test {
     tx_request.payload_args.rdma_args.transfer_size = payload_size;
     tx_request.payload_args.rdma_args.queue_size = queue_size;
 
-    ASSERT_EQ(conn_tx->configure(ctx, tx_request, "0000:31:00.1", tx_dev_handle),
+    ASSERT_EQ(conn_tx->configure(ctx, tx_request, tx_dev_handle),
               connection::Result::success);
     ASSERT_EQ(conn_tx->establish(ctx), connection::Result::success);
 

--- a/media-proxy/tests/conn_rdma_real_ep_test.cc
+++ b/media-proxy/tests/conn_rdma_real_ep_test.cc
@@ -1,0 +1,305 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include "mesh/conn_rdma_rx.h"
+#include "mesh/conn_rdma_tx.h"
+#include "logger.h"
+#include <cstring>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+#include "mesh/concurrency.h"
+#include <iomanip>
+
+using namespace mesh::log;
+
+namespace mesh {
+namespace connection {
+
+Level log_level = Level::fatal;
+
+class EmulatedReceiver : public connection::Connection {
+  public:
+    EmulatedReceiver(context::Context& ctx)
+    {
+        _kind = connection::Kind::receiver;
+        set_state(ctx, connection::State::configured);
+    }
+
+    connection::Result on_establish(context::Context& ctx) override
+    {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context& ctx) override
+    {
+        return connection::Result::success;
+    }
+
+    connection::Result on_receive(context::Context& ctx, void *ptr, uint32_t sz,
+                                  uint32_t& sent) override
+    {
+        ////log::info("Data received")("size", sz)("data", static_cast<char *>(ptr));
+        return connection::Result::success;
+    }
+
+    connection::Result configure(context::Context& ctx)
+    {
+        set_state(ctx, connection::State::configured);
+        return connection::Result::success;
+    }
+};
+
+// Custom Receiver Class for Test
+class TestReceiver : public EmulatedReceiver {
+  public:
+    std::string received_data;
+    std::atomic<bool> data_received;
+    std::mutex mtx;
+    std::condition_variable cv;
+
+    TestReceiver(context::Context& ctx) : EmulatedReceiver(ctx), data_received(false) {}
+
+    connection::Result on_receive(context::Context& ctx, void *ptr, uint32_t sz,
+                                  uint32_t& sent) override
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        received_data = std::string(static_cast<char *>(ptr), sz);
+        data_received = true;
+        cv.notify_all();
+        //////log::info("Data received via TestReceiver")("size", sz)("data", received_data);
+        return connection::Result::success;
+    }
+
+    void wait_for_data()
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait(lock, [this] { return data_received.load(); });
+    }
+};
+
+class EmulatedTransmitter : public connection::Connection {
+  public:
+    EmulatedTransmitter(context::Context& ctx)
+    {
+        _kind = connection::Kind::transmitter;
+        set_state(ctx, connection::State::configured);
+    }
+
+    connection::Result on_establish(context::Context& ctx) override
+    {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context& ctx) override
+    {
+        return connection::Result::success;
+    }
+
+    connection::Result configure(context::Context& ctx)
+    {
+        set_state(ctx, connection::State::configured);
+        return connection::Result::success;
+    }
+
+    connection::Result transmit_plaintext(context::Context& ctx, const void *ptr, size_t sz)
+    {
+        // Cast const void* to void* safely for transmit
+        return transmit(ctx, const_cast<void *>(ptr), sz);
+    }
+};
+
+
+
+class RdmaRealEndpointsTest : public ::testing::Test {
+  protected:
+    context::Context ctx;
+    RdmaRx *conn_rx;
+    RdmaTx *conn_tx;
+    TestReceiver *test_rx;
+    EmulatedTransmitter *emulated_tx;
+    libfabric_ctx *rx_dev_handle;
+    libfabric_ctx *tx_dev_handle;
+
+    std::atomic<bool> keep_running;
+
+    void SetupRdmaConnections(size_t payload_size, int queue_size) {
+    
+    ctx = context::WithCancel(context::Background());
+    // Initialize connections
+    conn_rx = new RdmaRx();
+    conn_tx = new RdmaTx();
+    test_rx = new TestReceiver(ctx);
+    emulated_tx = new EmulatedTransmitter(ctx);
+
+    libfabric_ctx *rx_dev_handle = NULL;
+    libfabric_ctx *tx_dev_handle = NULL;
+
+    // Set up RDMA Rx
+    mcm_conn_param rx_request = {};
+    rx_request.type = is_rx;
+    rx_request.local_addr = {.ip = "192.168.1.20", .port = "8002"};
+    rx_request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    rx_request.payload_args.rdma_args.transfer_size = payload_size;
+    rx_request.payload_args.rdma_args.queue_size = queue_size;
+
+    ASSERT_EQ(conn_rx->configure(ctx, rx_request, "0000:31:00.1", rx_dev_handle),
+              connection::Result::success);
+    ASSERT_EQ(conn_rx->establish(ctx), connection::Result::success);
+
+    // Set up RDMA Tx
+    mcm_conn_param tx_request = {};
+    tx_request.type = is_tx;
+    tx_request.local_addr = {.ip = "192.168.1.20", .port = "8002"};
+    tx_request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    tx_request.payload_args.rdma_args.transfer_size = payload_size;
+    tx_request.payload_args.rdma_args.queue_size = queue_size;
+
+    ASSERT_EQ(conn_tx->configure(ctx, tx_request, "0000:31:00.1", tx_dev_handle),
+              connection::Result::success);
+    ASSERT_EQ(conn_tx->establish(ctx), connection::Result::success);
+
+    // Configure Test Receiver
+    ASSERT_EQ(test_rx->configure(ctx), connection::Result::success);
+    ASSERT_EQ(test_rx->establish(ctx), connection::Result::success);
+
+    // Configure Emulated Transmitter
+    ASSERT_EQ(emulated_tx->configure(ctx), connection::Result::success);
+    ASSERT_EQ(emulated_tx->establish(ctx), connection::Result::success);
+
+    // Link connections
+    conn_rx->set_link(ctx, test_rx);
+    emulated_tx->set_link(ctx, conn_tx);
+
+    keep_running = true;
+}
+
+void CleanupRdmaConnections() {
+    keep_running = false;
+    ASSERT_EQ(conn_rx->shutdown(ctx), connection::Result::success);
+    ASSERT_EQ(conn_tx->shutdown(ctx), connection::Result::success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+    delete conn_rx;
+    delete conn_tx;
+    delete test_rx;
+    delete emulated_tx;
+}
+
+    void SetUp() override
+    {
+
+    }
+
+    void TearDown() override
+    {
+
+    }
+};
+
+TEST_F(RdmaRealEndpointsTest, ConcurrentTransmissionAndReception)
+{
+    SetupRdmaConnections(18,16);
+    
+    const char *test_data = "Hello RDMA World!";
+    size_t data_size = strlen(test_data) + 1;
+
+    // Transmitter thread
+    std::thread transmitter_thread([&]() {
+        for (int i = 0; i < 5 && keep_running; ++i) {
+            ////log::info("Transmitting data")("iteration", i + 1);
+            EXPECT_EQ(emulated_tx->transmit_plaintext(ctx, test_data, data_size),
+                      connection::Result::success);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        keep_running = false;
+    });
+
+    // Wait for data to be received
+    test_rx->wait_for_data();
+
+    ASSERT_EQ(test_rx->received_data, std::string(test_data) + '\0')
+        << "Data received does not match transmitted data.";
+
+    transmitter_thread.join();
+
+    // Cleanup RDMA connections
+    CleanupRdmaConnections();
+}
+
+TEST_F(RdmaRealEndpointsTest, LatencyAndBandwidthForVaryingPayloadSizesAndQueueSizes) {
+    const size_t payload_sizes[] = {1 << 20, 8 << 20, 3840 * 2160 * 4}; // 1 MB, 8 MB, ~32 MB
+    const int queue_sizes[] = {1, 8, 32}; // Queue sizes to test
+    const size_t total_data_size = 16L * 1024 * 1024 * 1024; // 16 GB
+    const size_t num_iterations = 1000;
+    const char filler = 'A'; // Filler character for payload
+
+    // Store results for latency and bandwidth
+    std::vector<std::tuple<double, size_t, double, double>> results; // Payload Size (MB), Queue Size, Latency (ms), Bandwidth (GB/s)
+
+    for (size_t queue_size : queue_sizes) {
+        for (size_t payload_size : payload_sizes) {
+            // Setup RDMA connections with current payload size and queue size
+            SetupRdmaConnections(payload_size, queue_size);
+
+            std::vector<char> test_data(payload_size, filler);
+
+            // Measure latency for a single transmission
+            double total_latency_ms = 0.0;
+
+            for (size_t i = 0; i < num_iterations; ++i) {
+                auto start = std::chrono::high_resolution_clock::now();
+
+                ASSERT_EQ(emulated_tx->transmit_plaintext(ctx, test_data.data(), payload_size), connection::Result::success);
+                test_rx->wait_for_data(); // Wait for receiver to acknowledge the data
+
+                auto end = std::chrono::high_resolution_clock::now();
+                std::chrono::duration<double, std::milli> elapsed = end - start;
+
+                total_latency_ms += elapsed.count();
+            }
+
+            // Calculate average latency per operation
+            double avg_latency_ms = total_latency_ms / num_iterations;
+
+            // Measure bandwidth
+            size_t num_bandwidth_iterations = total_data_size / payload_size;
+            auto start = std::chrono::high_resolution_clock::now();
+
+            for (size_t i = 0; i < num_bandwidth_iterations; ++i) {
+                ASSERT_EQ(emulated_tx->transmit_plaintext(ctx, test_data.data(), payload_size), connection::Result::success);
+                test_rx->wait_for_data(); // Wait for receiver to acknowledge the data
+            }
+
+            auto end = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> elapsed = end - start;
+
+            // Calculate transfer rate
+            double transfer_rate_gbps = (static_cast<double>(payload_size) * num_bandwidth_iterations) / (elapsed.count() * 1024 * 1024 * 1024);
+
+            // Store results (convert payload size to MB)
+            results.emplace_back(static_cast<double>(payload_size) / (1024 * 1024), queue_size, avg_latency_ms, transfer_rate_gbps);
+
+            // Cleanup RDMA connections
+            CleanupRdmaConnections();
+        }
+    }
+
+    // Display results in a tabular format
+    std::cout << "\n+-------------------+-------------+--------------------+----------------------+" << std::endl;
+    std::cout << "| Payload Size (MB) | Queue Size  |    Latency (ms)    | Transfer Rate (GB/s) |" << std::endl;
+    std::cout << "+-------------------+-------------+--------------------+----------------------+" << std::endl;
+    for (const auto& result : results) {
+        std::cout << "| " << std::setw(17) << std::fixed << std::setprecision(2) << std::get<0>(result)
+                  << " | " << std::setw(11) << std::get<1>(result)
+                  << " | " << std::setw(18) << std::fixed << std::setprecision(3) << std::get<2>(result)
+                  << " | " << std::setw(20) << std::fixed << std::setprecision(3) << std::get<3>(result)
+                  << " |" << std::endl;
+    }
+    std::cout << "+-------------------+-------------+--------------------+----------------------+" << std::endl;
+}
+
+
+} //connection
+
+} //mesh

--- a/media-proxy/tests/conn_rdma_rx_tests.cc
+++ b/media-proxy/tests/conn_rdma_rx_tests.cc
@@ -1,0 +1,316 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "mesh/conn_rdma_rx.h"
+#include "mesh/conn_rdma_tx.h"
+#include "conn_rdma_test_mocks.h"
+#include "libfabric_ep.h"
+#include "libfabric_dev.h"
+#include <cstring>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <iomanip>
+#include <sstream>
+
+#define DUMMY_DATA1 "DUMMY_DATA1"
+#define DUMMY_DATA2 "DUMMY_DATA2"
+
+using namespace mesh;
+using namespace mesh::log;
+
+// Helper to configure RdmaRx
+void ConfigureRdmaRx(connection::RdmaRx* conn_rx, context::Context& ctx, size_t transfer_size)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = transfer_size;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx* dev_handle = nullptr;
+
+    auto res = conn_rx->configure(ctx, request, dev_port, dev_handle);
+    ASSERT_EQ(res, connection::Result::success) << "Failed to configure RdmaTx";
+    ASSERT_EQ(conn_rx->state(), connection::State::configured) << "RdmaTx not in configured state";
+}
+
+class EmulatedTransmitter : public connection::Connection {
+  public:
+    uint32_t last_sent_size = 0;
+    std::vector<char> last_sent_data;
+
+    EmulatedTransmitter(context::Context &ctx)
+    {
+        _kind = connection::Kind::transmitter;
+        set_state(ctx, connection::State::configured);
+    }
+
+    connection::Result on_establish(context::Context &ctx) override
+    {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context &ctx) override
+    {
+        set_state(ctx, connection::State::closed);
+        return connection::Result::success;
+    }
+
+    connection::Result transmit_wrapper(context::Context &ctx, void *ptr, uint32_t sz)
+    {
+        // Store transmitted data for verification
+        last_sent_size = sz;
+        last_sent_data.assign(static_cast<char *>(ptr), static_cast<char *>(ptr) + sz);
+
+        // Trigger RDMA Tx transmission through the transmit method
+        return transmit(ctx, ptr, sz);
+    }
+};
+
+// Emulated receiver class
+class EmulatedReceiver : public connection::Connection {
+  public:
+    uint32_t received_packets = 0;
+    std::string last_received_data;
+
+    EmulatedReceiver(context::Context& ctx)
+    {
+        _kind = connection::Kind::receiver;
+        set_state(ctx, connection::State::configured);
+    }
+
+    connection::Result on_establish(context::Context& ctx) override
+    {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context& ctx) override
+    {
+        set_state(ctx, connection::State::closed);
+        return connection::Result::success;
+    }
+
+    connection::Result on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_t& sent)
+    {
+        last_received_data.assign(static_cast<uint8_t *>(ptr), static_cast<uint8_t *>(ptr) + sz);
+        received_packets++;
+        return connection::Result::success;
+    }
+};
+
+// Test Fixture
+class RdmaRxTest : public ::testing::Test {
+  protected:
+    void SetUp() override
+    {
+        mock_ep_ops = new MockLibfabricEpOps();   // Initialize mock object for EpOps
+        mock_dev_ops = new MockLibfabricDevOps(); // Initialize mock object for DevOps
+        SetUpMockEpOps();                         // Set up mocked functions for EpOps
+        SetUpMockDevOps();                        // Set up mocked functions for DevOps
+        ctx = context::WithCancel(context::Background());
+        conn_rx = new connection::RdmaRx();
+    }
+
+    void TearDown() override
+    {
+        delete conn_rx;
+        delete mock_ep_ops;
+        delete mock_dev_ops;
+        mock_ep_ops = nullptr;
+        mock_dev_ops = nullptr;
+    }
+
+    context::Context ctx;
+    connection::RdmaRx *conn_rx;
+};
+
+TEST_F(RdmaRxTest, EstablishSuccess)
+{
+    libfabric_ctx mock_dev_handle; // Mocked device handle
+
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(&mock_dev_handle),
+                                   ::testing::Return(0))); // Mock successful RDMA initialization
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep *>(0xdeadbeef); // Mock endpoint
+            return 0;                                               // Success
+        });
+
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Return(0)); // Mock successful buffer registration
+
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0;
+    });
+
+    // Configure and establish the connection
+    ConfigureRdmaRx(conn_rx, ctx, 1024);
+
+    // Act: Call on_establish
+    auto result = conn_rx->establish(ctx);
+
+    // Assert
+    EXPECT_EQ(result, connection::Result::success);
+    EXPECT_EQ(conn_rx->state(), connection::State::active);
+}
+
+TEST_F(RdmaRxTest, EstablishFailureEpInit)
+{
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::Return(0)); // Mock successful RDMA initialization
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(-1)); // Mock failure in ep_init
+
+    // Configure Rdma
+    ConfigureRdmaRx(conn_rx, ctx, 1024);
+
+    // Act: Call on_establish
+    auto result = conn_rx->establish(ctx);
+
+    // Assert
+    EXPECT_EQ(result, connection::Result::error_initialization_failed);
+    EXPECT_EQ(conn_rx->state(), connection::State::closed);
+}
+
+TEST_F(RdmaRxTest, EstablishFailureBufferAllocation)
+{
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::Return(0)); // Mock successful RDMA initialization
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep *>(0xdeadbeef); // Mock endpoint
+            return 0;
+        });
+
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(-1)); // Mock failure in buffer registration
+
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0;
+    });
+
+    // Configure Rdma
+    ConfigureRdmaRx(conn_rx, ctx, 1024);
+
+    // Act: Call on_establish
+    auto result = conn_rx->establish(ctx);
+
+    // Assert
+    EXPECT_EQ(result, connection::Result::error_memory_registration_failed);
+    EXPECT_EQ(conn_rx->state(), connection::State::closed);
+}
+
+TEST_F(RdmaRxTest, EstablishAlreadyInitialized)
+{
+    libfabric_ctx mock_dev_handle; // Mocked device handle
+
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(&mock_dev_handle),
+                                   ::testing::Return(0))); // Mock successful RDMA initialization
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep *>(0xdeadbeef); // Mock endpoint
+            return 0;
+        });
+
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Return(0)); // Mock successful buffer registration
+
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0;
+    });
+
+    // Configure and establish the connection
+    ConfigureRdmaRx(conn_rx, ctx, 1024);
+
+    // Establish the first time
+    auto first_result = conn_rx->establish(ctx);
+    EXPECT_EQ(first_result, connection::Result::success);
+    EXPECT_EQ(conn_rx->state(), connection::State::active);
+
+    // Act: Call on_establish again
+    auto second_result = conn_rx->establish(ctx);
+
+    // Assert
+    EXPECT_EQ(second_result, connection::Result::error_wrong_state);
+    EXPECT_EQ(conn_rx->state(), connection::State::active);
+}
+
+TEST_F(RdmaRxTest, ValidateStateTransitions)
+{
+    // Mock RDMA device initialization
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::Return(0)); // Mock successful RDMA initialization
+
+    // Mock endpoint initialization
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep *>(0xdeadbeef); // Mock endpoint
+            return 0;                                               // Success
+        });
+
+    // Mock buffer registration
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Return(0)); // Success
+
+    // Mock endpoint destruction
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0;
+    });
+
+    // Prepare arguments for configure
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024 * 1024; // 1 MB transfer size
+
+    std::string dev_port = "0000:31:00.0"; // Mocked device port
+    libfabric_ctx *dev_handle = nullptr;   // Mocked device handle
+
+    // Initial state should be not_configured
+    ASSERT_EQ(conn_rx->state(), connection::State::not_configured);
+
+    // Transition: not_configured -> configured
+    auto res = conn_rx->configure(ctx, request, dev_port, dev_handle);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_rx->state(), connection::State::configured);
+
+    // Transition: configured -> active
+    res = conn_rx->establish(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_rx->state(), connection::State::active);
+
+    // Transition: active -> suspended
+    res = conn_rx->suspend(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_rx->state(), connection::State::suspended);
+
+    // Transition: suspended -> active
+    res = conn_rx->resume(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_rx->state(), connection::State::active);
+
+    // Transition: active -> closed
+    res = conn_rx->shutdown(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_rx->state(), connection::State::closed);
+}

--- a/media-proxy/tests/conn_rdma_rx_tests.cc
+++ b/media-proxy/tests/conn_rdma_rx_tests.cc
@@ -156,6 +156,8 @@ TEST_F(RdmaRxTest, EstablishSuccess)
         return 0;
     });
 
+    EXPECT_CALL(*mock_dev_ops, rdma_deinit(::testing::_)).Times(1).WillOnce(::testing::Return(0));
+
     EXPECT_CALL(*mock_conn_rx, start_threads(::testing::_))
         .WillOnce(::testing::Return(connection::Result::success));
 

--- a/media-proxy/tests/conn_rdma_rx_tests.cc
+++ b/media-proxy/tests/conn_rdma_rx_tests.cc
@@ -27,10 +27,9 @@ void ConfigureRdmaRx(MockRdmaRx* conn_rx, context::Context& ctx, size_t transfer
     request.payload_args.rdma_args.transfer_size = transfer_size;
     request.payload_args.rdma_args.queue_size = 32;
 
-    std::string dev_port = "0000:31:00.0";
     libfabric_ctx* dev_handle = nullptr;
 
-    auto res = conn_rx->configure(ctx, request, dev_port, dev_handle);
+    auto res = conn_rx->configure(ctx, request, dev_handle);
     ASSERT_EQ(res, connection::Result::success) << "Failed to configure RdmaTx";
     ASSERT_EQ(conn_rx->state(), connection::State::configured) << "RdmaTx not in configured state";
 }

--- a/media-proxy/tests/conn_rdma_test_mocks.cc
+++ b/media-proxy/tests/conn_rdma_test_mocks.cc
@@ -1,0 +1,71 @@
+#include "conn_rdma_test_mocks.h"
+
+MockLibfabricEpOps *mock_ep_ops = nullptr;
+MockLibfabricDevOps *mock_dev_ops = nullptr;
+
+// Utility function to convert data to a hex string
+std::string to_hex(const void* data, size_t size) {
+    std::ostringstream oss;
+    const unsigned char* bytes = static_cast<const unsigned char*>(data);
+    for (size_t i = 0; i < size; ++i) {
+        oss << std::hex << std::setfill('0') << std::setw(2)
+            << static_cast<int>(bytes[i]);
+    }
+    return oss.str();
+}
+
+// Mock setup functions
+void SetUpMockEpOps() {
+    libfabric_ep_ops.ep_init = [](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+        return mock_ep_ops->ep_init(ep_ctx, cfg);
+    };
+    libfabric_ep_ops.ep_reg_mr = [](ep_ctx_t *ep_ctx, void *buf, size_t size) -> int {
+        return mock_ep_ops->ep_reg_mr(ep_ctx, buf, size);
+    };
+    libfabric_ep_ops.ep_destroy = [](ep_ctx_t **ep_ctx) -> int {
+        return mock_ep_ops->ep_destroy(ep_ctx);
+    };
+    libfabric_ep_ops.ep_cq_read = [](ep_ctx_t *ep_ctx, void **buf_ctx, int timeout) -> int {
+        return mock_ep_ops->ep_cq_read(ep_ctx, buf_ctx, timeout);
+    };
+    libfabric_ep_ops.ep_send_buf = [](ep_ctx_t *ep_ctx, void *buf, size_t size) -> int {
+        return mock_ep_ops->ep_send_buf(ep_ctx, buf, size);
+    };
+    libfabric_ep_ops.ep_recv_buf = [](ep_ctx_t *ep_ctx, void *buf, size_t size, void *buf_ctx) -> int {
+        return mock_ep_ops->ep_recv_buf(ep_ctx, buf, size, buf_ctx);
+    };
+}
+
+void SetUpMockDevOps() {
+    libfabric_dev_ops.rdma_init = [](libfabric_ctx **rdma_ctx) -> int {
+        return mock_dev_ops->rdma_init(rdma_ctx);
+    };
+}
+
+// Define mock function pointers
+int MockEpInit(ep_ctx_t **ep_ctx, ep_cfg_t *cfg) { return mock_ep_ops->ep_init(ep_ctx, cfg); }
+
+int MockEpRegMr(ep_ctx_t *ep_ctx, void *data_buf, size_t data_buf_size)
+{
+    return mock_ep_ops->ep_reg_mr(ep_ctx, data_buf, data_buf_size);
+}
+
+int MockEpDestroy(ep_ctx_t **ep_ctx) { return mock_ep_ops->ep_destroy(ep_ctx); }
+
+int MockEpCqRead(ep_ctx_t *ep_ctx, void **buf_ctx, int timeout)
+{
+    return mock_ep_ops->ep_cq_read(ep_ctx, buf_ctx, timeout);
+}
+
+int MockEpSendBuf(ep_ctx_t *ep_ctx, void *buffer, size_t size)
+{
+    return mock_ep_ops->ep_send_buf(ep_ctx, buffer, size);
+}
+
+int MockEpRecvBuf(ep_ctx_t *ep_ctx, void *buffer, size_t size, void *buf_ctx)
+{
+    return mock_ep_ops->ep_recv_buf(ep_ctx, buffer, size, buf_ctx);
+}
+
+int MockRdmaInit(libfabric_ctx **rdma_ctx) { return mock_dev_ops->rdma_init(rdma_ctx); }
+

--- a/media-proxy/tests/conn_rdma_test_mocks.cc
+++ b/media-proxy/tests/conn_rdma_test_mocks.cc
@@ -40,6 +40,9 @@ void SetUpMockDevOps() {
     libfabric_dev_ops.rdma_init = [](libfabric_ctx **rdma_ctx) -> int {
         return mock_dev_ops->rdma_init(rdma_ctx);
     };
+    libfabric_dev_ops.rdma_deinit = [](libfabric_ctx **ctx) -> int { // Add this lambda
+        return mock_dev_ops->rdma_deinit(ctx);
+    };
 }
 
 // Define mock function pointers

--- a/media-proxy/tests/conn_rdma_test_mocks.h
+++ b/media-proxy/tests/conn_rdma_test_mocks.h
@@ -1,0 +1,46 @@
+#ifndef CONN_RDMA_TEST_MOCKS_H
+#define CONN_RDMA_TEST_MOCKS_H
+
+#include <gmock/gmock.h>
+#include <iomanip>
+#include "libfabric_ep.h"
+#include "libfabric_dev.h"
+
+
+// Define the mock classes
+class MockLibfabricEpOps {
+  public:
+    MOCK_METHOD(int, ep_init,     (ep_ctx_t **, ep_cfg_t *));
+    MOCK_METHOD(int, ep_reg_mr,   (ep_ctx_t *, void *, size_t));
+    MOCK_METHOD(int, ep_destroy,  (ep_ctx_t **));
+    MOCK_METHOD(int, ep_cq_read,  (ep_ctx_t *, void **, int));
+    MOCK_METHOD(int, ep_send_buf, (ep_ctx_t *, void *, size_t));
+    MOCK_METHOD(int, ep_recv_buf, (ep_ctx_t *, void *, size_t, void *));
+};
+
+class MockLibfabricDevOps {
+  public:
+    MOCK_METHOD(int, rdma_init, (libfabric_ctx **));
+};
+
+//Helper functions
+std::string to_hex(const void* data, size_t size);
+
+// Declare global mock objects
+extern MockLibfabricEpOps *mock_ep_ops;
+extern MockLibfabricDevOps *mock_dev_ops;
+
+// Declare mock function pointers
+int MockEpInit(ep_ctx_t **ep_ctx, ep_cfg_t *cfg);
+int MockEpRegMr(ep_ctx_t *ep_ctx, void *data_buf, size_t data_buf_size);
+int MockEpDestroy(ep_ctx_t **ep_ctx);
+int MockEpCqRead(ep_ctx_t *ep_ctx, void **buf_ctx, int timeout);
+int MockEpSendBuf(ep_ctx_t *ep_ctx, void *buffer, size_t size);
+int MockEpRecvBuf(ep_ctx_t *ep_ctx, void *buffer, size_t size, void *buf_ctx);
+int MockRdmaInit(libfabric_ctx **rdma_ctx);
+
+// Declare mock setup functions
+void SetUpMockEpOps();
+void SetUpMockDevOps();
+
+#endif // CONN_RDMA_TEST_MOCKS_H

--- a/media-proxy/tests/conn_rdma_test_mocks.h
+++ b/media-proxy/tests/conn_rdma_test_mocks.h
@@ -22,6 +22,7 @@ class MockLibfabricEpOps {
 class MockLibfabricDevOps {
   public:
     MOCK_METHOD(int, rdma_init, (libfabric_ctx **));
+    MOCK_METHOD(int, rdma_deinit, (libfabric_ctx **));
 };
 
 class MockRdmaRx : public mesh::connection::RdmaRx {

--- a/media-proxy/tests/conn_rdma_test_mocks.h
+++ b/media-proxy/tests/conn_rdma_test_mocks.h
@@ -5,7 +5,8 @@
 #include <iomanip>
 #include "libfabric_ep.h"
 #include "libfabric_dev.h"
-
+#include "mesh/conn_rdma_rx.h"
+#include "mesh/conn_rdma_tx.h"
 
 // Define the mock classes
 class MockLibfabricEpOps {
@@ -21,6 +22,16 @@ class MockLibfabricEpOps {
 class MockLibfabricDevOps {
   public:
     MOCK_METHOD(int, rdma_init, (libfabric_ctx **));
+};
+
+class MockRdmaRx : public mesh::connection::RdmaRx {
+  public:
+    MOCK_METHOD(mesh::connection::Result, start_threads, (mesh::context::Context& ctx), (override));
+};
+
+class MockRdmaTx : public mesh::connection::RdmaTx {
+  public:
+    MOCK_METHOD(mesh::connection::Result, start_threads, (mesh::context::Context& ctx), (override));
 };
 
 //Helper functions

--- a/media-proxy/tests/conn_rdma_tests.cc
+++ b/media-proxy/tests/conn_rdma_tests.cc
@@ -22,7 +22,7 @@ class TestRdma : public Rdma {
     using Rdma::ep_ctx;
     using Rdma::init;
     using Rdma::init_queue_with_elements;
-    using Rdma::mDevHandle;
+    using Rdma::m_dev_handle;
     using Rdma::on_delete;
     using Rdma::on_establish;
     using Rdma::on_shutdown;

--- a/media-proxy/tests/conn_rdma_tests.cc
+++ b/media-proxy/tests/conn_rdma_tests.cc
@@ -63,11 +63,10 @@ class RdmaTest : public ::testing::Test {
         request.payload_args.rdma_args.transfer_size = transfer_size;
         request.payload_args.rdma_args.queue_size = 32;
 
-        std::string dev_port = "0000:31:00.0";
         libfabric_ctx *dev_handle = nullptr;
 
         rdma->set_kind(kind);
-        auto res = rdma->configure(ctx, request, dev_port, dev_handle);
+        auto res = rdma->configure(ctx, request, dev_handle);
         ASSERT_EQ(res, Result::success);
         ASSERT_EQ(rdma->state(), State::configured);
         ASSERT_EQ(rdma->kind(), kind);

--- a/media-proxy/tests/conn_rdma_tests.cc
+++ b/media-proxy/tests/conn_rdma_tests.cc
@@ -426,6 +426,8 @@ TEST_F(RdmaTest, RepeatedShutdown) {
         return 0; // Success
     });
 
+    EXPECT_CALL(*mock_dev_ops, rdma_deinit(::testing::_)).Times(1).WillOnce(::testing::Return(0));
+
     // Use ConfigureRdma helper to configure the RDMA instance
     ConfigureRdma(rdma, ctx, 1024, Kind::transmitter);
 

--- a/media-proxy/tests/conn_rdma_tests.cc
+++ b/media-proxy/tests/conn_rdma_tests.cc
@@ -1,0 +1,623 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "libfabric_ep.h"
+#include "libfabric_dev.h"
+#include "mesh/conn_rdma.h"
+#include "conn_rdma_test_mocks.h"
+
+using namespace testing;
+using namespace mesh;
+using namespace connection;
+using namespace mesh::log;
+
+class TestRdma : public Rdma {
+  public:
+    using Rdma::add_to_queue;
+    using Rdma::cleanup_queue;
+    using Rdma::cleanup_resources;
+    using Rdma::configure;
+    using Rdma::configure_endpoint;
+    using Rdma::consume_from_queue;
+    using Rdma::ep_cfg;
+    using Rdma::ep_ctx;
+    using Rdma::init;
+    using Rdma::init_queue_with_elements;
+    using Rdma::mDevHandle;
+    using Rdma::on_delete;
+    using Rdma::on_establish;
+    using Rdma::on_shutdown;
+    using Rdma::shutdown_rdma;
+    using Rdma::trx_sz;
+};
+
+// Test fixture
+class RdmaTest : public ::testing::Test {
+  protected:
+    TestRdma *rdma;
+    context::Context ctx;
+
+    void SetUp() override
+    {
+        mock_ep_ops = new MockLibfabricEpOps();
+        mock_dev_ops = new MockLibfabricDevOps();
+        SetUpMockEpOps();
+        SetUpMockDevOps();
+        ctx = context::WithCancel(context::Background());
+        rdma = new TestRdma();
+    }
+
+    void TearDown() override
+    {
+        delete rdma;
+        delete mock_ep_ops;
+        delete mock_dev_ops;
+        mock_ep_ops = nullptr;
+        mock_dev_ops = nullptr;
+    }
+
+    void ConfigureRdma(size_t transfer_size)
+    {
+        mcm_conn_param request = {};
+        request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+        request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+        request.payload_args.rdma_args.transfer_size = transfer_size;
+
+        std::string dev_port = "0000:31:00.0";
+        libfabric_ctx *dev_handle = nullptr;
+
+        EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+            .WillOnce(
+                ::testing::DoAll(::testing::SetArgPointee<0>(dev_handle),
+                                 ::testing::Return(0))); // Mock successful RDMA initialization
+
+        auto res =
+            rdma->configure(ctx, request, dev_port, dev_handle, Kind::transmitter, direction::TX);
+        ASSERT_EQ(res, Result::success);
+        ASSERT_EQ(rdma->state(), State::configured);
+    }
+};
+
+TEST_F(RdmaTest, ConfigureSuccess)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx *dev_handle = nullptr;
+
+    // Call configure with a null dev_handle to trigger rdma_init in on_establish
+    auto res = rdma->configure(ctx, request, dev_port, dev_handle, Kind::receiver, direction::RX);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(rdma->state(), State::configured);
+}
+
+TEST_F(RdmaTest, EstablishSuccess)
+{
+
+    ConfigureRdma(1024);
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(_, _)).WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+        *ep_ctx = new ep_ctx_t();
+        return 0;
+    });
+
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(_, _, _)).WillRepeatedly(Return(0));
+
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        return 0;
+    });
+
+    auto result = rdma->on_establish(ctx);
+    EXPECT_EQ(result, Result::success);
+    EXPECT_EQ(rdma->state(), State::active);
+}
+
+TEST_F(RdmaTest, EstablishFailureEpInit)
+{
+    ConfigureRdma(1024);
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(_, _)).WillOnce(Return(-1));
+
+    auto result = rdma->establish(ctx);
+    EXPECT_EQ(result, Result::error_initialization_failed);
+    EXPECT_EQ(rdma->state(), State::closed);
+}
+
+TEST_F(RdmaTest, CleanupResources)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx *dev_handle = nullptr;
+
+    // Mock rdma_init
+    EXPECT_CALL(*mock_dev_ops, rdma_init(_)).WillOnce([](libfabric_ctx **ctx) -> int {
+        *ctx = new libfabric_ctx();
+        return 0; // Success
+    });
+
+    // Mock ep_init
+    EXPECT_CALL(*mock_ep_ops, ep_init(_, _)).WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+        *ep_ctx = new ep_ctx_t();
+        return 0; // Success
+    });
+
+    // Mock ep_reg_mr
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(_, _, _)).WillRepeatedly(Return(0));
+
+    // Mock ep_destroy
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0; // Success
+    });
+
+    // Configure and establish
+    rdma->configure(ctx, request, dev_port, dev_handle, Kind::transmitter, direction::TX);
+    rdma->establish(ctx);
+
+    // Trigger cleanup
+    rdma->shutdown_rdma(ctx);
+
+    // Verify state is closed
+    EXPECT_EQ(rdma->state(), State::closed);
+}
+
+TEST_F(RdmaTest, ValidateStateTransitions)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx *dev_handle = nullptr;
+
+    // Initial state should be `not_configured`
+    ASSERT_EQ(rdma->state(), State::not_configured);
+
+    // Mock rdma_init
+    EXPECT_CALL(*mock_dev_ops, rdma_init(_)).WillOnce([](libfabric_ctx **ctx) -> int {
+        *ctx = new libfabric_ctx();
+        return 0; // Success
+    });
+
+    // Mock ep_init
+    EXPECT_CALL(*mock_ep_ops, ep_init(_, _)).WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+        *ep_ctx = new ep_ctx_t();
+        return 0; // Success
+    });
+    // Mock ep_reg_mr
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(_, _, _)).WillRepeatedly(Return(0));
+
+    // Mock ep_destroy
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0; // Success
+    });
+
+    // Transition: `not_configured` -> `configured`
+    auto res =
+        rdma->configure(ctx, request, dev_port, dev_handle, Kind::transmitter, direction::TX);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(rdma->state(), State::configured);
+
+    // Transition: `configured` -> `active`
+    res = rdma->establish(ctx);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(rdma->state(), State::active);
+
+    // Transition: `active` -> `suspended`
+    res = rdma->suspend(ctx);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(rdma->state(), State::suspended);
+
+    // Transition: `suspended` -> `active`
+    res = rdma->resume(ctx);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(rdma->state(), State::active);
+
+    // Transition: `active` -> `closed`
+    rdma->shutdown_rdma(ctx);
+    ASSERT_EQ(rdma->state(), State::closed);
+}
+
+TEST_F(RdmaTest, ValidateKindAndDirectionRX)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx *dev_handle = nullptr;
+
+    // Case 1: Receiver configuration
+    auto res = rdma->configure(ctx, request, dev_port, dev_handle, Kind::receiver, direction::RX);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(rdma->state(), State::configured);
+    EXPECT_EQ(rdma->get_kind(), Kind::receiver);
+    EXPECT_EQ(rdma->ep_cfg.dir, direction::RX);
+}
+
+TEST_F(RdmaTest, ValidateKindAndDirectionTX)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx *dev_handle = nullptr;
+
+    // Case 2: Transmitter configuration
+    auto res =
+        rdma->configure(ctx, request, dev_port, dev_handle, Kind::transmitter, direction::TX);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(rdma->state(), State::configured);
+    EXPECT_EQ(rdma->get_kind(), Kind::transmitter);
+    EXPECT_EQ(rdma->ep_cfg.dir, direction::TX);
+}
+
+TEST_F(RdmaTest, InvalidDirectionForKind)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx *dev_handle = nullptr;
+
+    // Invalid case: Receiver with Send direction
+    auto res = rdma->configure(ctx, request, dev_port, dev_handle, Kind::receiver, direction::TX);
+    EXPECT_NE(res, Result::success);
+
+    // Invalid case: Transmitter with Receive direction
+    res = rdma->configure(ctx, request, dev_port, dev_handle, Kind::transmitter, direction::RX);
+    EXPECT_NE(res, Result::success);
+}
+
+TEST_F(RdmaTest, InitQueueWithElementsSuccess) {
+    // Parameters for initialization
+    const size_t capacity = 5;
+    const size_t trx_sz = 1024;
+    const size_t aligned_trx_sz = ((trx_sz + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
+
+    // Step 1: Initialize the RDMA queue
+    auto result = rdma->init_queue_with_elements(capacity, trx_sz);
+    ASSERT_EQ(result, Result::success);                 // Verify successful initialization
+    ASSERT_EQ(rdma->get_buffer_queue_size(), capacity); // Check initial queue size
+
+    // Step 2: Validate buffer allocation and queue operations
+    for (size_t i = 0; i < capacity; ++i) {
+        void *buf = nullptr;
+
+        // Consume a buffer from the queue
+        auto res = rdma->consume_from_queue(ctx, &buf);
+        ASSERT_EQ(res, Result::success); // Ensure successful consumption
+        ASSERT_NE(buf, nullptr);         // Check that the buffer is valid
+
+        // Check if the buffer is within the allocated memory block
+        ASSERT_GE(buf, rdma->get_buffer_block());
+        ASSERT_LT(buf, static_cast<char *>(rdma->get_buffer_block()) + capacity * aligned_trx_sz);
+
+        // Validate that the buffer is page-aligned
+        ASSERT_EQ(reinterpret_cast<uintptr_t>(buf) % PAGE_SIZE, 0);
+
+        // Check if the buffer is zero-initialized
+        char *data = static_cast<char *>(buf);
+        for (size_t j = 0; j < trx_sz; ++j) {
+            ASSERT_EQ(data[j], 0); // Verify zero-initialization
+        }
+
+        // Add the buffer back to the queue
+        res = rdma->add_to_queue(buf);
+        ASSERT_EQ(res, Result::success); // Ensure successful addition
+    }
+
+    // Step 3: Verify the queue size is restored
+    ASSERT_EQ(rdma->get_buffer_queue_size(), capacity); // Check restored queue size
+
+    // Step 4: Cleanup resources
+    rdma->cleanup_queue();
+}
+
+TEST_F(RdmaTest, InitQueueWithElementsFailureMemoryAllocationWithSize0)
+{
+    size_t capacity = 10;
+    size_t trx_sz = 0; // Invalid size to simulate failure
+
+    auto result = rdma->init_queue_with_elements(capacity, trx_sz);
+    ASSERT_EQ(result, Result::error_bad_argument);
+    ASSERT_TRUE(rdma->is_buffer_queue_empty());
+}
+
+TEST_F(RdmaTest, InitQueueWithElementsFailureMemoryAllocationWithSize1GB)
+{
+    size_t capacity = 10;
+    size_t trx_sz = 1 << 31; // Invalid size to simulate failure
+
+    auto result = rdma->init_queue_with_elements(capacity, trx_sz);
+    ASSERT_EQ(result, Result::error_bad_argument);
+    ASSERT_TRUE(rdma->is_buffer_queue_empty());
+}
+
+TEST_F(RdmaTest, AddToQueueSuccess)
+{
+    int dummy_data = 42;
+
+    auto result = rdma->add_to_queue(&dummy_data);
+    ASSERT_EQ(result, Result::success);
+    ASSERT_EQ(rdma->get_buffer_queue_size(), 1);
+
+    // Validate the added element
+    void *element = nullptr;
+    auto res = rdma->consume_from_queue(ctx, &element);
+    ASSERT_EQ(res, Result::success);
+    ASSERT_EQ(element, &dummy_data);
+}
+
+TEST_F(RdmaTest, AddToQueueFailureNullptr)
+{
+    auto result = rdma->add_to_queue(nullptr);
+    ASSERT_EQ(result, Result::error_bad_argument);
+    ASSERT_TRUE(rdma->is_buffer_queue_empty());
+}
+
+TEST_F(RdmaTest, ConsumeFromQueueSuccess)
+{
+    int dummy_data1 = 42;
+    int dummy_data2 = 84;
+
+    rdma->add_to_queue(&dummy_data1);
+    rdma->add_to_queue(&dummy_data2);
+
+    // Consume first element
+    void *element = nullptr;
+    auto result = rdma->consume_from_queue(ctx, &element);
+    ASSERT_EQ(result, Result::success);
+    ASSERT_EQ(element, &dummy_data1);
+
+    // Consume second element
+    result = rdma->consume_from_queue(ctx, &element);
+    ASSERT_EQ(result, Result::success);
+    ASSERT_EQ(element, &dummy_data2);
+
+    // Queue should be empty now
+    ASSERT_TRUE(rdma->is_buffer_queue_empty());
+}
+
+TEST_F(RdmaTest, ConsumeFromQueueFailureEmptyQueue)
+{
+    void *element = nullptr;
+    auto result = rdma->consume_from_queue(ctx, &element);
+    ASSERT_EQ(result, Result::error_no_buffer);
+    ASSERT_EQ(element, nullptr);
+}
+
+TEST_F(RdmaTest, ConsumeFromQueueFailureContextCancelled)
+{
+    int dummy_data = 42;
+    rdma->add_to_queue(&dummy_data);
+
+    // Cancel the context
+    ctx.cancel();
+
+    void *element = nullptr;
+    auto result = rdma->consume_from_queue(ctx, &element);
+    ASSERT_EQ(result, Result::error_operation_cancelled);
+    ASSERT_EQ(element, nullptr);
+
+    // The queue should remain unchanged
+    ASSERT_EQ(rdma->get_buffer_queue_size(), 1);
+}
+
+TEST_F(RdmaTest, CleanupQueue)
+{
+    size_t capacity = 5;
+    size_t trx_sz = 1024;
+
+    // Initialize the queue with elements
+    rdma->init_queue_with_elements(capacity, trx_sz);
+
+    // Ensure the queue is not empty
+    ASSERT_EQ(rdma->get_buffer_queue_size(), capacity);
+
+    // Cleanup the queue
+    rdma->cleanup_queue();
+
+    // Validate that the queue is now empty
+    ASSERT_TRUE(rdma->is_buffer_queue_empty());
+}
+
+TEST_F(RdmaTest, QueuePerformanceTest)
+{
+    const size_t iterations = 1000000;
+    const size_t trx_sz = 1024;
+
+    // Initialize queue
+    auto result = rdma->init_queue_with_elements(iterations, trx_sz);
+    ASSERT_EQ(result, Result::success);
+
+    size_t aligned_trx_sz = ((trx_sz + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
+
+    // Measure time taken for queue operations
+    auto start = std::chrono::high_resolution_clock::now();
+
+    // Consume from queue
+    for (size_t i = 0; i < iterations; ++i) {
+        void *buf = nullptr;
+        auto res = rdma->consume_from_queue(ctx, &buf);
+        ASSERT_EQ(res, Result::success);
+        ASSERT_NE(buf, nullptr);
+
+        // Check if the buffer is within the allocated range
+        ASSERT_GE(buf, rdma->get_buffer_block()); // Buffer >= base address
+        ASSERT_LT(buf, static_cast<char *>(rdma->get_buffer_block()) +
+                           iterations * aligned_trx_sz); // Buffer < end address
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
+    std::cout << "Processed " << iterations << " queue operations in " << elapsed.count()
+              << " seconds.\n";
+
+    // Ensure queue is empty
+    ASSERT_TRUE(rdma->is_buffer_queue_empty());
+
+    // Cleanup
+    rdma->cleanup_queue();
+}
+
+TEST_F(RdmaTest, RepeatedShutdown)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx *dev_handle = nullptr;
+
+    // Mock rdma_init
+    EXPECT_CALL(*mock_dev_ops, rdma_init(_)).WillOnce([](libfabric_ctx **ctx) -> int {
+        *ctx = new libfabric_ctx();
+        return 0; // Success
+    });
+
+    // Mock ep_init
+    EXPECT_CALL(*mock_ep_ops, ep_init(_, _)).WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+        *ep_ctx = new ep_ctx_t();
+        return 0; // Success
+    });
+
+    // Mock ep_reg_mr
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(_, _, _)).WillRepeatedly(Return(0));
+
+    // Mock ep_destroy
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0; // Success
+    });
+
+    // Configure and establish
+    rdma->configure(ctx, request, dev_port, dev_handle, Kind::transmitter, direction::TX);
+    rdma->establish(ctx);
+
+    for (int i = 0; i++; i < 10) {
+        // Repeated shutdown should not crash
+        rdma->shutdown_rdma(ctx);
+        ASSERT_EQ(rdma->state(), State::closed);
+    }
+}
+
+TEST_F(RdmaTest, StressTest) {
+    const size_t num_threads = 128;
+    const size_t operations_per_thread = 10000;
+
+    std::vector<std::thread> threads;
+
+    // Initialize queue with a large number of elements
+    const size_t capacity = num_threads * operations_per_thread;
+    auto result = rdma->init_queue_with_elements(capacity, sizeof(int));
+    ASSERT_EQ(result, Result::success); // Ensure initialization was successful
+
+    // Atomic counters for tracking
+    std::atomic<size_t> consumed_buffers{0};
+    std::atomic<size_t> freed_buffers{0};
+
+    // Launch threads to perform concurrent queue operations
+    for (size_t i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() {
+            for (size_t j = 0; j < operations_per_thread; ++j) {
+                void *buf = nullptr;
+
+                if (j % 2 == 0) {
+                    // Consume from the queue and re-add the buffer
+                    if (rdma->consume_from_queue(ctx, &buf) == Result::success) {
+                        consumed_buffers.fetch_add(1, std::memory_order_relaxed);
+                        rdma->add_to_queue(buf);
+                    }
+                } else {
+                    // Consume from the queue and simulate processing/freeing
+                    if (rdma->consume_from_queue(ctx, &buf) == Result::success) {
+                        std::memset(buf, 0, sizeof(int));
+                        freed_buffers.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            }
+        });
+    }
+
+    // Wait for all threads to finish
+    for (auto &thread : threads) {
+        thread.join();
+    }
+
+    // Cleanup remaining buffers
+    rdma->cleanup_queue();
+
+    // Verify results
+    ASSERT_EQ(consumed_buffers.load() + freed_buffers.load(), capacity); // Ensure all buffers were processed
+    ASSERT_TRUE(rdma->is_buffer_queue_empty()); // Ensure queue is empty
+}
+
+
+TEST_F(RdmaTest, ConcurrentAccessWithDelays) {
+    const size_t num_threads = 128;
+    const size_t operations_per_thread = 1000;
+
+    std::vector<std::thread> threads;
+
+    // Initialize queue with elements
+    const size_t capacity = num_threads * operations_per_thread;
+    auto result = rdma->init_queue_with_elements(capacity, sizeof(int));
+    ASSERT_EQ(result, Result::success);
+
+    // Start concurrent operations
+    for (size_t i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() {
+            for (size_t j = 0; j < operations_per_thread; ++j) {
+                void *buf = nullptr; // Thread-local buffer
+
+                if (j % 2 == 0) {
+                    // Consume a buffer and return it to the queue
+                    if (rdma->consume_from_queue(ctx, &buf) == Result::success) {
+                        std::memset(buf, 0, sizeof(int)); // Simulate processing
+                        rdma->add_to_queue(buf);
+                    }
+                } else {
+                    // Consume a buffer and simulate processing without returning it
+                    if (rdma->consume_from_queue(ctx, &buf) == Result::success) {
+                        std::memset(buf, 0, sizeof(int)); // Simulate processing
+                    }
+                }
+
+                // Simulate delays
+                std::this_thread::sleep_for(std::chrono::microseconds(j % 2 == 0 ? 10 : 5));
+            }
+        });
+    }
+
+    // Wait for all threads to finish
+    for (auto &thread : threads) {
+        thread.join();
+    }
+
+    // Verify the queue is not empty, as half of the buffers were not returned
+    ASSERT_FALSE(rdma->is_buffer_queue_empty());
+
+    // Cleanup remaining buffers
+    rdma->cleanup_queue();
+    ASSERT_TRUE(rdma->is_buffer_queue_empty());
+}
+

--- a/media-proxy/tests/conn_rdma_tx_tests.cc
+++ b/media-proxy/tests/conn_rdma_tx_tests.cc
@@ -1,0 +1,322 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "mesh/conn_rdma_rx.h"
+#include "mesh/conn_rdma_tx.h"
+#include "libfabric_ep.h"
+#include "libfabric_dev.h"
+#include "conn_rdma_test_mocks.h"
+#include <cstring>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <iomanip>
+#include <sstream>
+
+#define DUMMY_DATA1 "DUMMY_DATA1"
+#define DUMMY_DATA2 "DUMMY_DATA2"
+
+using namespace mesh;
+
+using namespace mesh::log;
+
+// Helper to configure RdmaTx
+void ConfigureRdmaTx(connection::RdmaTx* conn_tx, context::Context& ctx, size_t transfer_size)
+{
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = transfer_size;
+
+    std::string dev_port = "0000:31:00.0";
+    libfabric_ctx* dev_handle = nullptr;
+
+    auto res = conn_tx->configure(ctx, request, dev_port, dev_handle);
+    ASSERT_EQ(res, connection::Result::success) << "Failed to configure RdmaTx";
+    ASSERT_EQ(conn_tx->state(), connection::State::configured) << "RdmaTx not in configured state";
+}
+
+class EmulatedTransmitter : public connection::Connection {
+  public:
+    uint32_t last_sent_size = 0;
+    std::vector<char> last_sent_data;
+
+    EmulatedTransmitter(context::Context &ctx)
+    {
+        _kind = connection::Kind::transmitter;
+        set_state(ctx, connection::State::configured);
+        last_sent_size = 0; // Initialize all members
+    }
+
+    connection::Result on_establish(context::Context &ctx) override
+    {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context &ctx) override
+    {
+        set_state(ctx, connection::State::closed);
+        return connection::Result::success;
+    }
+
+    connection::Result transmit_wrapper(context::Context &ctx, void *ptr, uint32_t sz)
+    {
+        // Store transmitted data for verification
+        last_sent_size = sz;
+        last_sent_data.assign(static_cast<char *>(ptr), static_cast<char *>(ptr) + sz);
+
+        // Trigger RDMA Tx transmission through the transmit method
+        return transmit(ctx, ptr, sz);
+    }
+};
+
+// Emulated receiver class
+class EmulatedReceiver : public connection::Connection {
+  public:
+    uint32_t received_packets = 0;
+    std::string last_received_data;
+
+    EmulatedReceiver(context::Context& ctx)
+    {
+        _kind = connection::Kind::receiver;
+        set_state(ctx, connection::State::configured);
+    }
+
+    connection::Result on_establish(context::Context& ctx) override
+    {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context& ctx) override
+    {
+        set_state(ctx, connection::State::closed);
+        return connection::Result::success;
+    }
+
+    connection::Result on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_t& sent)
+    {
+        last_received_data.assign(static_cast<uint8_t *>(ptr), static_cast<uint8_t *>(ptr) + sz);
+        received_packets++;
+        return connection::Result::success;
+    }
+};
+
+// Test Fixture
+class RdmaTxTest : public ::testing::Test {
+  protected:
+    void SetUp() override
+    {
+        mock_ep_ops = new MockLibfabricEpOps();   // Initialize mock object for EpOps
+        mock_dev_ops = new MockLibfabricDevOps(); // Initialize mock object for DevOps
+        SetUpMockEpOps();                         // Set up mocked functions for EpOps
+        SetUpMockDevOps();                        // Set up mocked functions for DevOps
+        ctx = context::WithCancel(context::Background());
+        conn_tx = new connection::RdmaTx();
+    }
+
+    void TearDown() override
+    {
+        delete conn_tx;
+        delete mock_ep_ops;
+        delete mock_dev_ops;
+        mock_ep_ops = nullptr;
+        mock_dev_ops = nullptr;
+    }
+
+    context::Context ctx;
+    connection::RdmaTx *conn_tx;
+};
+
+TEST_F(RdmaTxTest, EstablishSuccess)
+{
+    libfabric_ctx mock_dev_handle; // Mocked device handle
+
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(&mock_dev_handle),
+                                   ::testing::Return(0))); // Mock successful RDMA initialization
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep *>(0xdeadbeef); // Mock endpoint
+            return 0;                                               // Success
+        });
+
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Return(0)); // Mock successful buffer registration
+
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0;
+    });
+
+    // Configure and establish the connection
+    ConfigureRdmaTx(conn_tx, ctx, 1024);
+
+    // Act: Call establish
+    auto result = conn_tx->establish(ctx);
+
+    // Assert
+    EXPECT_EQ(result, connection::Result::success);
+    EXPECT_EQ(conn_tx->state(), connection::State::active);
+}
+
+TEST_F(RdmaTxTest, EstablishFailureEpInit)
+{
+   EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::Return(0)); // Mock successful RDMA initialization
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(-1)); // Mock failure in ep_init
+
+    // Configure and establish the connection
+    ConfigureRdmaTx(conn_tx, ctx, 1024);
+
+    // Act: Call establish
+    auto result = conn_tx->establish(ctx);
+
+    // Assert
+    EXPECT_EQ(result, connection::Result::error_initialization_failed);
+    EXPECT_EQ(conn_tx->state(), connection::State::closed);
+}
+
+TEST_F(RdmaTxTest, EstablishFailureBufferAllocation)
+{
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::Return(0)); // Mock successful RDMA initialization
+
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep *>(0xdeadbeef); // Mock endpoint
+            return 0;
+        });
+
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(-1)); // Mock failure in buffer registration
+
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0;
+    });
+
+    // Configure and establish the connection
+    ConfigureRdmaTx(conn_tx, ctx, 1024);
+
+    // Act: Call establish
+    auto result = conn_tx->establish(ctx);
+
+    // Assert
+    EXPECT_EQ(result, connection::Result::error_memory_registration_failed);
+    EXPECT_EQ(conn_tx->state(), connection::State::closed);
+}
+
+TEST_F(RdmaTxTest, EstablishAlreadyInitialized) {
+    libfabric_ctx mock_dev_handle;
+
+    // Mock RDMA initialization
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(&mock_dev_handle),
+            ::testing::Return(0)));
+
+    // Mock endpoint initialization
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t** ep_ctx, ep_cfg_t* cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep*>(0xdeadbeef);
+            return 0;
+        });
+
+    // Mock buffer registration
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Return(0));
+
+    // Mock endpoint destruction
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_))
+        .WillOnce([](ep_ctx_t** ep_ctx) -> int {
+            delete *ep_ctx;
+            *ep_ctx = nullptr;
+            return 0;
+        });
+
+    // Configure and establish the connection
+    ConfigureRdmaTx(conn_tx, ctx, 1024);
+
+    // First establish
+    auto first_result = conn_tx->establish(ctx);
+    EXPECT_EQ(first_result, connection::Result::success);
+    EXPECT_EQ(conn_tx->state(), connection::State::active);
+
+    // Second establish
+    auto second_result = conn_tx->establish(ctx);
+    EXPECT_EQ(second_result, connection::Result::error_wrong_state);
+    EXPECT_EQ(conn_tx->state(), connection::State::active);
+}
+
+
+TEST_F(RdmaTxTest, ValidateStateTransitions)
+{
+    // Mock RDMA device initialization
+    EXPECT_CALL(*mock_dev_ops, rdma_init(::testing::_))
+        .WillOnce(::testing::Return(0)); // Mock successful RDMA initialization
+
+    // Mock endpoint initialization
+    EXPECT_CALL(*mock_ep_ops, ep_init(::testing::_, ::testing::_))
+        .WillOnce([](ep_ctx_t **ep_ctx, ep_cfg_t *cfg) -> int {
+            *ep_ctx = new ep_ctx_t();
+            (*ep_ctx)->ep = reinterpret_cast<fid_ep *>(0xdeadbeef); // Mock endpoint
+            return 0;                                               // Success
+        });
+
+    // Mock buffer registration
+    EXPECT_CALL(*mock_ep_ops, ep_reg_mr(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Return(0)); // Success
+
+    // Mock endpoint destruction
+    EXPECT_CALL(*mock_ep_ops, ep_destroy(::testing::_)).WillOnce([](ep_ctx_t **ep_ctx) -> int {
+        delete *ep_ctx;
+        *ep_ctx = nullptr;
+        return 0;
+    });
+
+    // Prepare arguments for configure
+    mcm_conn_param request = {};
+    request.local_addr = {.ip = "192.168.1.10", .port = "8001"};
+    request.remote_addr = {.ip = "192.168.1.20", .port = "8002"};
+    request.payload_args.rdma_args.transfer_size = 1024 * 1024; // 1 MB transfer size
+
+    std::string dev_port = "0000:31:00.0"; // Mocked device port
+    libfabric_ctx *dev_handle = nullptr;   // Mocked device handle
+
+    // Initial state should be not_configured
+    ASSERT_EQ(conn_tx->state(), connection::State::not_configured);
+
+    // Transition: not_configured -> configured
+    auto res = conn_tx->configure(ctx, request, dev_port, dev_handle);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_tx->state(), connection::State::configured);
+
+    // Transition: configured -> active
+    res = conn_tx->establish(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_tx->state(), connection::State::active);
+
+    // Transition: active -> suspended
+    res = conn_tx->suspend(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_tx->state(), connection::State::suspended);
+
+    // Transition: suspended -> active
+    res = conn_tx->resume(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_tx->state(), connection::State::active);
+
+    // Transition: active -> closed
+    res = conn_tx->shutdown(ctx);
+    ASSERT_EQ(res, connection::Result::success);
+    ASSERT_EQ(conn_tx->state(), connection::State::closed);
+}

--- a/media-proxy/tests/conn_rdma_tx_tests.cc
+++ b/media-proxy/tests/conn_rdma_tx_tests.cc
@@ -156,6 +156,8 @@ TEST_F(RdmaTxTest, EstablishSuccess)
         return 0;
     });
 
+    EXPECT_CALL(*mock_dev_ops, rdma_deinit(::testing::_)).Times(1).WillOnce(::testing::Return(0));
+
     // Configure and establish the connection
     ConfigureRdmaTx(static_cast<MockRdmaTx*>(conn_tx), ctx, 1024);
 

--- a/media-proxy/tests/conn_rdma_tx_tests.cc
+++ b/media-proxy/tests/conn_rdma_tx_tests.cc
@@ -28,10 +28,9 @@ void ConfigureRdmaTx(MockRdmaTx* conn_tx, context::Context& ctx, size_t transfer
     request.payload_args.rdma_args.transfer_size = transfer_size;
     request.payload_args.rdma_args.queue_size = 32;
 
-    std::string dev_port = "0000:31:00.0";
     libfabric_ctx* dev_handle = nullptr;
 
-    auto res = conn_tx->configure(ctx, request, dev_port, dev_handle);
+    auto res = conn_tx->configure(ctx, request, dev_handle);
     ASSERT_EQ(res, connection::Result::success) << "Failed to configure RdmaTx";
     ASSERT_EQ(conn_tx->state(), connection::State::configured) << "RdmaTx not in configured state";
 }

--- a/media-proxy/tests/libfabric_ep_tests.cc
+++ b/media-proxy/tests/libfabric_ep_tests.cc
@@ -149,8 +149,10 @@ struct fi_ops_cq LibfabricEpTest::ops_cq;
 TEST_F(LibfabricEpTest, TestEpSendBufSuccess)
 {
     send_fake.return_val = 0;
+    size_t valid_buf_size = 1024;
+    void *valid_buf = std::malloc(valid_buf_size);
 
-    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, nullptr, 0);
+    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, valid_buf, valid_buf_size);
 
     ASSERT_EQ(ret, 0);
     ASSERT_EQ(send_fake.call_count, 1);
@@ -161,12 +163,16 @@ TEST_F(LibfabricEpTest, TestEpSendBufFail)
 {
     send_fake.return_val = -1;
 
-    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, nullptr, 0);
+    char dummy_buf[10] = {0};
+    size_t buf_size = sizeof(dummy_buf);
+
+    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, dummy_buf, buf_size);
 
     ASSERT_EQ(ret, -1);
     ASSERT_EQ(send_fake.call_count, 1);
     ASSERT_EQ(cq_read_fake.call_count, 0);
 }
+
 
 TEST_F(LibfabricEpTest, TestEpSendBufRetrySuccess)
 {
@@ -174,12 +180,16 @@ TEST_F(LibfabricEpTest, TestEpSendBufRetrySuccess)
     SET_RETURN_SEQ(send, send_fake_return_vals,
                    sizeof(send_fake_return_vals) / sizeof(send_fake_return_vals[0]));
 
-    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, nullptr, 0);
+    char dummy_buf[10] = {0};
+    size_t buf_size = sizeof(dummy_buf);
+
+    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, dummy_buf, buf_size);
 
     ASSERT_EQ(ret, 0);
     ASSERT_EQ(send_fake.call_count, 3);
     ASSERT_EQ(cq_read_fake.call_count, 2);
 }
+
 
 TEST_F(LibfabricEpTest, TestEpSendBufRetryFail)
 {
@@ -187,12 +197,16 @@ TEST_F(LibfabricEpTest, TestEpSendBufRetryFail)
     SET_RETURN_SEQ(send, send_fake_return_vals,
                    sizeof(send_fake_return_vals) / sizeof(send_fake_return_vals[0]));
 
-    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, nullptr, 0);
+    char dummy_buf[10] = {0};
+    size_t buf_size = sizeof(dummy_buf);
+
+    int ret = libfabric_ep_ops.ep_send_buf(&ep_ctx, dummy_buf, buf_size);
 
     ASSERT_EQ(ret, -1);
     ASSERT_EQ(send_fake.call_count, 3);
     ASSERT_EQ(cq_read_fake.call_count, 2);
 }
+
 
 TEST_F(LibfabricEpTest, TestEpRecvBufFail)
 {

--- a/sdk/include/mcm_dp.h
+++ b/sdk/include/mcm_dp.h
@@ -207,6 +207,7 @@ typedef struct {
 /* rdma format */
 typedef struct {
     size_t transfer_size;
+    int queue_size;
 } mcm_rdma_args;
 
 typedef struct {


### PR DESCRIPTION
- Introduced `conn_rdma` as a base class for RDMA connection handling.
- Added `conn_rdma_rx` and `conn_rdma_tx` for specialized Rx and Tx operations:
  - `conn_rdma_rx`: Handles RDMA reception logic with buffer management.
  - `conn_rdma_tx`: Handles RDMA transmission logic with buffer management.

**Key Changes**:
- New headers:
  - `conn_rdma.h`
  - `conn_rdma_rx.h`
  - `conn_rdma_tx.h`
- Implementation files:
  - `conn_rdma.cc`
  - `conn_rdma_rx.cc`
  - `conn_rdma_tx.cc`
- Unit tests for RDMA:
  - Added `conn_rdma_rx_tests.cc` and `conn_rdma_tx_tests.cc` to validate Rx/Tx functionalities.
  - Introduced mocks for RDMA (`conn_rdma_test_mocks.cc` and `.h`).

**Enhancements**:
- Updated `CMakeLists.txt` to include new tests and sources.
- Modified `conn.h` to align with RDMA connection structure.
- Adjusted `libfabric_ep.c` to integrate RDMA-specific operations.

**Test Coverage**:
- Verified RDMA Rx/Tx behavior through unit tests.
- Introduced `conn_rdma_real_ep_test` for real endpoint integration testing.
