### PR TITLE
Move Running Rx and Tx App to Engine and Add Media File Utilization

### DIFF
--- a/tests/validation/Engine/engine_utils.py
+++ b/tests/validation/Engine/engine_utils.py
@@ -4,22 +4,27 @@
 
 import logging
 import signal
+import os
 import Engine.client_json
 import Engine.connection
 import Engine.connection_json
 import Engine.execute
 import Engine.payload
 
-def create_client_json(client, output_path):
+def create_client_json(build, client):
     logging.debug("Client JSON:")
     for line in client.to_json().splitlines():
         logging.debug(line)
+    output_path = os.path.join(build, "client.json")
+    logging.debug(f"Client JSON path: {output_path}")
     client.prepare_and_save_json(output_path=output_path)
 
-def create_connection_json(connection, output_path):
+def create_connection_json(build, connection):
     logging.debug("Connection JSON:")
     for line in connection.to_json().splitlines():
         logging.debug(line)
+    output_path = os.path.join(build, "connection.json")
+    logging.debug(f"Connection JSON path: {output_path}")
     connection.prepare_and_save_json(output_path=output_path)
 
 def run_rx_app(cwd, timeout=0):
@@ -36,7 +41,15 @@ def stop_rx_app(rx):
     rx.process.send_signal(signal.SIGINT)
     rx.process.wait()
 
-def run_rx_tx_with_file(file_path, cwd):
+def run_rx_tx_with_file(file_path, build):
+    cwd = build
+    logging.debug(f"Constructed cwd path: {cwd}")
+
+    # Check if the TxApp executable exists
+    tx_app_path = os.path.join(cwd, "TxApp")
+    if not os.path.isfile(tx_app_path):
+        raise FileNotFoundError(f"TxApp executable not found at {tx_app_path}")
+
     try:
         rx = run_rx_app(cwd=cwd)
         tx = run_tx_app(file_path=file_path, rx_pid=rx.process.pid, cwd=cwd)

--- a/tests/validation/Engine/engine_utils.py
+++ b/tests/validation/Engine/engine_utils.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+# Intel® Media Communications Mesh
+
+import logging
+import signal
+import Engine.client_json
+import Engine.connection
+import Engine.connection_json
+import Engine.execute
+import Engine.payload
+
+def create_client_json(client, output_path):
+    logging.debug("Client JSON:")
+    for line in client.to_json().splitlines():
+        logging.debug(line)
+    client.prepare_and_save_json(output_path=output_path)
+
+def create_connection_json(connection, output_path):
+    logging.debug("Connection JSON:")
+    for line in connection.to_json().splitlines():
+        logging.debug(line)
+    connection.prepare_and_save_json(output_path=output_path)
+
+def run_rx_app(cwd, timeout=0):
+    return Engine.execute.call("./RxApp", cwd=cwd, timeout=timeout)
+
+def run_tx_app(file_path, rx_pid, cwd, testcmd=True):
+    return Engine.execute.run(f"./TxApp {file_path} {rx_pid}", testcmd=testcmd, cwd=cwd)
+
+def handle_tx_failure(tx):
+    if tx.returncode != 0:
+        Engine.execute.log_fail(f"TxApp failed with return code {tx.returncode}")
+
+def stop_rx_app(rx):
+    rx.process.send_signal(signal.SIGINT)
+    rx.process.wait()
+
+def run_rx_tx_with_file(file_path, cwd):
+    try:
+        rx = run_rx_app(cwd=cwd)
+        tx = run_tx_app(file_path=file_path, rx_pid=rx.process.pid, cwd=cwd)
+        handle_tx_failure(tx)
+    finally:
+        stop_rx_app(rx)

--- a/tests/validation/functional/local/video/test_video.py
+++ b/tests/validation/functional/local/video/test_video.py
@@ -1,39 +1,28 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2024 Intel Corporation
 # Intel® Media Communications Mesh
-import logging
+import pytest
+import os
 
 import Engine.client_json
 import Engine.connection
 import Engine.connection_json
 import Engine.execute
 import Engine.payload
+import Engine.engine_utils as utils
+from Engine.media_files import yuv_files
 
-
-def test_video():
+def test_video(media):
     client = Engine.client_json.ClientJson()
     conn_mpg = Engine.connection.MultipointGroup()
     payload = Engine.payload.Video(width=3840, height=2160)
     connection = Engine.connection_json.ConnectionJson(connection=conn_mpg, payload=payload)
 
-    logging.debug("Client JSON:")
-    for line in client.to_json().splitlines():
-        logging.debug(line)
-    client.prepare_and_save_json(output_path="../tools/TestApp/build/client.json")
-    logging.debug("Connection JSON:")
-    for line in connection.to_json().splitlines():
-        logging.debug(line)
-    connection.prepare_and_save_json(output_path="../tools/TestApp/build/connection.json")
+    utils.create_client_json(client, output_path="../tools/TestApp/build/client.json")
+    utils.create_connection_json(connection, output_path="../tools/TestApp/build/connection.json")
 
-    # Create a 1MB random file (for testing purposes)
-    Engine.execute.run("dd if=/dev/urandom of=/tmp/random_file.bin bs=1M count=1")
-    try:
-        rx = Engine.execute.call("./RxApp", cwd="../tools/TestApp/build", timeout=0)
-        tx = Engine.execute.run(
-            f"./TxApp /tmp/random_file.bin {rx.process.pid}", testcmd=True, cwd="../tools/TestApp/build"
-        )
-        if tx.returncode != 0:
-            Engine.execute.log_fail(f"TxApp failed with return code {tx.returncode}")
-    finally:
-        rx.process.send_signal(2)  # SIGINT
-        rx.process.wait()
+    # Use a specified file from media_files.py
+    media_file = yuv_files['i2160p25']['filename']
+    media_file_path = os.path.join(media, media_file)
+
+    utils.run_rx_tx_with_file(file_path=media_file_path, cwd="../tools/TestApp/build")

--- a/tests/validation/functional/local/video/test_video.py
+++ b/tests/validation/functional/local/video/test_video.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2024 Intel Corporation
 # Intel® Media Communications Mesh
-import pytest
 import os
 
 import Engine.client_json
@@ -12,17 +11,17 @@ import Engine.payload
 import Engine.engine_utils as utils
 from Engine.media_files import yuv_files
 
-def test_video(media):
+def test_video(build, media):
     client = Engine.client_json.ClientJson()
     conn_mpg = Engine.connection.MultipointGroup()
     payload = Engine.payload.Video(width=3840, height=2160)
     connection = Engine.connection_json.ConnectionJson(connection=conn_mpg, payload=payload)
 
-    utils.create_client_json(client, output_path="../tools/TestApp/build/client.json")
-    utils.create_connection_json(connection, output_path="../tools/TestApp/build/connection.json")
+    utils.create_client_json(build, client)
+    utils.create_connection_json(build, connection)
 
     # Use a specified file from media_files.py
     media_file = yuv_files['i2160p25']['filename']
     media_file_path = os.path.join(media, media_file)
 
-    utils.run_rx_tx_with_file(file_path=media_file_path, cwd="../tools/TestApp/build")
+    utils.run_rx_tx_with_file(file_path=media_file_path, build=build)


### PR DESCRIPTION
- refactors the test_video.py script to move the general functionality of running the Rx and Tx applications into the Engine module
- integrates the use of media files specified in media_files.py 
- utilizes the media path provided via the --media option