### PR TITLE
Val: video test stubs and media-proxy related fixtures

### DIFF
--- a/tests/validation/Engine/connection.py
+++ b/tests/validation/Engine/connection.py
@@ -72,7 +72,7 @@ class St2110(Connection):
         return {
             "connection": {
                 "st2110": {
-                    "transport": self.transport.value[0],
+                    "transport": self.transport.value,
                     "remoteIpAddr": self.remoteIpAddr,
                     "remotePort": self.remotePort,
                     "pacing": self.pacing,

--- a/tests/validation/Engine/engine_mcm.py
+++ b/tests/validation/Engine/engine_mcm.py
@@ -50,6 +50,14 @@ def stop_rx_app(rx: Engine.execute.AsyncProcess):
     rx.process.wait()
 
 
+def remove_sent_file(file_path: str, app_path: str):
+    # filepath "/x/y/z.yuv", app_path "/a/b/"
+    # removes /a/b/z.yuv
+    removal_path = f'{app_path}/{file_path.split("/")[-1]}'
+    logging.debug(f"Removing: {removal_path}")
+    os.remove(removal_path)
+
+
 def run_rx_tx_with_file(file_path: str, build: str):
     app_path = os.path.join(build, "tests", "tools", "TestApp", "build")
 
@@ -59,3 +67,5 @@ def run_rx_tx_with_file(file_path: str, build: str):
         handle_tx_failure(tx)
     finally:
         stop_rx_app(rx)
+        # TODO: Add checks for transmission errors
+        remove_sent_file(file_path, app_path)

--- a/tests/validation/Engine/fixtures_mcm.py
+++ b/tests/validation/Engine/fixtures_mcm.py
@@ -16,10 +16,34 @@ def build_TestApp(build):
     subprocess.run("make", cwd=path, shell=True, timeout=10)
 
 
-@pytest.fixture(scope="package")
-def media_proxy_single():
-    # Run single media proxy
-    pass
+def kill_all_existing_media_proxies():
+    "Kills all existing media_proxy processes using their PIDs found with px -aux"
+    existing_mps = subprocess.run("ps -aux | awk '/media_proxy/{print($2)}'", shell=True, capture_output=True)
+    mp_pids = existing_mps.stdout.decode("utf-8").split()  # returns an array of PIDs
+    (subprocess.run(f"kill -9 {mp_pid}", shell=True) for mp_pid in mp_pids)
+
+
+@pytest.fixture(scope="package", autouse=False)
+def media_proxy_single(sender_mp_port: int, receiver_mp_port: int, kill_existing: bool = True):
+    """Opens new media_proxies for sender and receiver.
+    May optionally kill the already-running media_proxies first.
+
+    Arguments:
+        sender_mp_port(int): specifies the port number for sender
+        receiver_mp_port(int): specifies the port number for receiver
+
+    Keyword arguments:
+        kill_existing(bool, optional): if use kill_all_existing_media_proxies() function to kill -9 all existing
+                                       media_proxies before running new instances
+    """
+    if kill_existing:
+        kill_all_existing_media_proxies()
+    # create new media_proxy processes for sender and receiver
+    sender_mp_proc = subprocess.Popen(f"media_proxy -t {sender_mp_port}")  # sender's media_proxy
+    receiver_mp_proc = subprocess.Popen(f"media_proxy -t {receiver_mp_port}")  # receiver media_proxy
+    yield
+    sender_mp_proc.terminate()
+    receiver_mp_proc.terminate()
 
 
 @pytest.fixture(scope="package")

--- a/tests/validation/Engine/fixtures_mcm.py
+++ b/tests/validation/Engine/fixtures_mcm.py
@@ -10,13 +10,14 @@ import pytest
 @pytest.fixture(scope="session")
 def build_TestApp(build):
     path = os.path.join(build, "tests", "tools", "TestApp", "build")
-    subprocess.run(f"rm -rf {path}", shell=True, timeout=10)
-    subprocess.run(f"mkdir -p {path}", shell=True, timeout=10)
+    subprocess.run(f'rm -rf "{path}"', shell=True, timeout=10)
+    subprocess.run(f'mkdir -p "{path}"', shell=True, timeout=10)
     subprocess.run("cmake ..", cwd=path, shell=True, timeout=10)
     subprocess.run("make", cwd=path, shell=True, timeout=10)
 
 
 def kill_all_existing_media_proxies():
+    # TODO: This assumes the way previous media_proxy worked will not change in the new version, which is unlikely
     "Kills all existing media_proxy processes using their PIDs found with px -aux"
     existing_mps = subprocess.run("ps -aux | awk '/media_proxy/{print($2)}'", shell=True, capture_output=True)
     mp_pids = existing_mps.stdout.decode("utf-8").split()  # returns an array of PIDs
@@ -25,6 +26,7 @@ def kill_all_existing_media_proxies():
 
 @pytest.fixture(scope="package", autouse=False)
 def media_proxy_single(sender_mp_port: int, receiver_mp_port: int, kill_existing: bool = True):
+    # TODO: This assumes the way previous media_proxy worked will not change in the new version, which is unlikely
     """Opens new media_proxies for sender and receiver.
     May optionally kill the already-running media_proxies first.
 

--- a/tests/validation/functional/cluster/video/test_video.py
+++ b/tests/validation/functional/cluster/video/test_video.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+# Intel® Media Communications Mesh
+import os
+import pytest
+
+import Engine.client_json
+import Engine.connection
+import Engine.connection_json
+import Engine.engine_mcm as utils
+import Engine.execute
+import Engine.payload
+from Engine.media_files import yuv_files
+
+
+@pytest.mark.parametrize("video_type", [k for k in yuv_files.keys()])
+def test_video(build_TestApp, build: str, media: str, video_type):
+    client = Engine.client_json.ClientJson()
+    conn_mpg = Engine.connection.Rdma()
+    payload = Engine.payload.Video(
+        width=yuv_files[video_type]["width"],
+        height=yuv_files[video_type]["height"],
+        fps=yuv_files[video_type]["fps"],
+        pixelFormat=yuv_files[video_type]["format"],
+    )
+    connection = Engine.connection_json.ConnectionJson(connection=conn_mpg, payload=payload)
+
+    utils.create_client_json(build, client)
+    utils.create_connection_json(build, connection)
+
+    # Use a specified file from media_files.py
+    media_file = yuv_files[video_type]["filename"]
+    media_file_path = os.path.join(media, media_file)
+
+    utils.run_rx_tx_with_file(file_path=media_file_path, build=build)

--- a/tests/validation/functional/local/video/test_video.py
+++ b/tests/validation/functional/local/video/test_video.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Intel Corporation
 # Intel® Media Communications Mesh
 import os
+import pytest
 
 import Engine.client_json
 import Engine.connection
@@ -10,9 +11,12 @@ import Engine.engine_mcm as utils
 import Engine.execute
 import Engine.payload
 from Engine.media_files import yuv_files
+from Engine.fixtures_mcm import media_proxy_single, build_TestApp
 
 
-def test_video(build_TestApp, build: str, media: str):
+@pytest.mark.fixture(media_proxy_single)
+@pytest.mark.fixture(build_TestApp)
+def test_video(build: str, media: str):
     client = Engine.client_json.ClientJson()
     conn_mpg = Engine.connection.MultipointGroup()
     payload = Engine.payload.Video(width=3840, height=2160)

--- a/tests/validation/functional/local/video/test_video.py
+++ b/tests/validation/functional/local/video/test_video.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Intel Corporation
 # Intel® Media Communications Mesh
 import os
+import pytest
 
 import Engine.client_json
 import Engine.connection
@@ -12,17 +13,23 @@ import Engine.payload
 from Engine.media_files import yuv_files
 
 
-def test_video(build_TestApp, build: str, media: str):
+@pytest.mark.parametrize("video_type", [k for k in yuv_files.keys()])
+def test_video(build_TestApp, build: str, media: str, video_type):
     client = Engine.client_json.ClientJson()
     conn_mpg = Engine.connection.MultipointGroup()
-    payload = Engine.payload.Video(width=3840, height=2160)
+    payload = Engine.payload.Video(
+        width=yuv_files[video_type]["width"],
+        height=yuv_files[video_type]["height"],
+        fps=yuv_files[video_type]["fps"],
+        pixelFormat=yuv_files[video_type]["format"],
+    )
     connection = Engine.connection_json.ConnectionJson(connection=conn_mpg, payload=payload)
 
     utils.create_client_json(build, client)
     utils.create_connection_json(build, connection)
 
     # Use a specified file from media_files.py
-    media_file = yuv_files["i2160p25"]["filename"]
+    media_file = yuv_files[video_type]["filename"]
     media_file_path = os.path.join(media, media_file)
 
     utils.run_rx_tx_with_file(file_path=media_file_path, build=build)

--- a/tests/validation/functional/local/video/test_video.py
+++ b/tests/validation/functional/local/video/test_video.py
@@ -2,7 +2,6 @@
 # Copyright 2024 Intel Corporation
 # Intel® Media Communications Mesh
 import os
-import pytest
 
 import Engine.client_json
 import Engine.connection
@@ -11,12 +10,9 @@ import Engine.engine_mcm as utils
 import Engine.execute
 import Engine.payload
 from Engine.media_files import yuv_files
-from Engine.fixtures_mcm import media_proxy_single, build_TestApp
 
 
-@pytest.mark.fixture(media_proxy_single)
-@pytest.mark.fixture(build_TestApp)
-def test_video(build: str, media: str):
+def test_video(build_TestApp, build: str, media: str):
     client = Engine.client_json.ClientJson()
     conn_mpg = Engine.connection.MultipointGroup()
     payload = Engine.payload.Video(width=3840, height=2160)

--- a/tests/validation/functional/st2110/st20/test_video.py
+++ b/tests/validation/functional/st2110/st20/test_video.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Intel Corporation
+# Intel® Media Communications Mesh
+import os
+import pytest
+
+import Engine.client_json
+import Engine.connection
+import Engine.connection_json
+import Engine.engine_mcm as utils
+import Engine.execute
+import Engine.payload
+from Engine.media_files import yuv_files
+
+
+@pytest.mark.parametrize("video_type", [k for k in yuv_files.keys()])
+def test_video(build_TestApp, build: str, media: str, video_type):
+    client = Engine.client_json.ClientJson()
+    conn_mpg = Engine.connection.St2110()
+    payload = Engine.payload.Video(
+        width=yuv_files[video_type]["width"],
+        height=yuv_files[video_type]["height"],
+        fps=yuv_files[video_type]["fps"],
+        pixelFormat=yuv_files[video_type]["format"],
+    )
+    connection = Engine.connection_json.ConnectionJson(connection=conn_mpg, payload=payload)
+
+    utils.create_client_json(build, client)
+    utils.create_connection_json(build, connection)
+
+    # Use a specified file from media_files.py
+    media_file = yuv_files[video_type]["filename"]
+    media_file_path = os.path.join(media, media_file)
+
+    utils.run_rx_tx_with_file(file_path=media_file_path, build=build)


### PR DESCRIPTION
Add: stub for fixtures relating to media_proxy process lifecycle (spawning, killing)
Add: removal of sent file at the end of test to avoid disk full errors
Add: tests of mock for cluster and st2110 video transfers
Fix: wrong connection.st2110.transport value
Add: todos for further code extension

**WARN: Merge only post #296 and after base branch is changed to `main`!**