### PR TITLE
Fix CI job on main branch documentation-build-and-publish

### DIFF
--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -5,7 +5,7 @@
 
 # Minimal makefile for Sphinx documentation
 
-SPHINXOPTS    ?= --conf-dir .
+SPHINXOPTS    ?= -c .
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = ../../
 BUILDDIR      = ../_build


### PR DESCRIPTION
Fix CI job on main branch **documentation-build-and-publish**

Based on https://www.sphinx-doc.org/en/master/man/sphinx-build.html, **--conf-dir** option was added in sphinx-build version 7.3, CI job is using older version. 
Replace **--conf-dir** with its short option  **-c**