### PR TITLE
Fix Argument "bridge_config.type" to format specifier "%s"

### DIFF
--- a/media-proxy/src/mesh/proxy_api.cc
+++ b/media-proxy/src/mesh/proxy_api.cc
@@ -333,7 +333,7 @@ int ProxyAPIClient::StartCommandQueue(context::Context& ctx)
                     case Bridge::kRdma:
                         if (bridge_config.type.compare("rdma")) {
                             log::error("rdma bridge config provided for type '%s'",
-                                       bridge_config.type);
+                                       bridge_config.type.c_str());
                         } else {
                             auto& req = bridge.rdma();
                             


### PR DESCRIPTION
Fix Argument "bridge_config.type" to format specifier "%s" expected char* got std::string