### PR TITLE
Fix: Fix driver installation script

### DIFF
--- a/scripts/setup_ice_irdma.sh
+++ b/scripts/setup_ice_irdma.sh
@@ -4,8 +4,8 @@ set -eEo pipefail
 set +x
 
 SCRIPT_DIR="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
-WORKING_DIR="${BUILD_DIR:-${REPO_DIR}/build/rdma}"
-PERF_DIR="${DRIVERS_DIR}/perftest"
+export WORKING_DIR="${BUILD_DIR:-${REPO_DIR}/build/rdma}"
+export PERF_DIR="${DRIVERS_DIR}/perftest"
 
 . "${SCRIPT_DIR}/common.sh"
 

--- a/scripts/setup_ice_irdma.sh
+++ b/scripts/setup_ice_irdma.sh
@@ -12,6 +12,9 @@ PERF_DIR="${DRIVERS_DIR}/perftest"
 function get_and_patch_intel_drivers()
 {
     log_info "Intel drivers: Starting download and patching actions."
+    if [[ ! -d "${MTL_DIR}" ]]; then
+        git_download_strip_unpack "OpenVisualCloud/Media-Transport-Library" "${MTL_VER}" "${MTL_DIR}"
+    fi
     if [ ! -d "${MTL_DIR}/patches/ice_drv/${ICE_VER}/" ]; then
         log_error  "MTL patch for ICE=v${ICE_VER} could not be found: ${MTL_DIR}/patches/ice_drv/${ICE_VER}"
         return 1
@@ -20,9 +23,6 @@ function get_and_patch_intel_drivers()
     git_download_strip_unpack "intel/ethernet-linux-iavf" "refs/tags/v${IAVF_VER}" "${IAVF_DIR}" && \
     git_download_strip_unpack "intel/ethernet-linux-ice"  "refs/tags/v${ICE_VER}"  "${ICE_DIR}"
 
-    if [[ ! -d "${MTL_DIR}" ]]; then
-        git_download_strip_unpack "OpenVisualCloud/Media-Transport-Library" "${MTL_VER}" "${MTL_DIR}"
-    fi
     pushd "${ICE_DIR}" && \
     patch -p1 -i <(cat "${MTL_DIR}/patches/ice_drv/${ICE_VER}/"*.patch) && \
     popd && \


### PR DESCRIPTION
Found a bug when trying to install MCM dependencies. After running `setup_ice_irdma.sh` script (following the steps described in https://openvisualcloud.github.io/Media-Communications-Mesh/docs/README.html#getting-started):

```
sudo ./scripts/setup_ice_irdma.sh 
```

there is an error:

```
INFO: Intel drivers: Starting download and patching actions.
ERROR:  MTL patch for ICE=v1.14.9 could not be found: /home/pstaszczuk/Media-Communications-Mesh/_build/mtl/patches/ice_drv/1.14.9
ERROR:  Intel drivers configuration/installation failed.
```

The script is trying to find MTL patches before MTL is downloaded.

Moved MTL download before checking the patches.