### PR TITLE
Add timestamp printing in log messages in tests

### DIFF
--- a/tests/tools/TestApp/CMakeLists.txt
+++ b/tests/tools/TestApp/CMakeLists.txt
@@ -18,7 +18,7 @@ execute_process(
 message(STATUS "************* root project dir: ${GIT_REPO_ROOT} *************")
 
 set(INC ${GIT_REPO_ROOT}/sdk/include Inc)
-set(SRC src/input.c src/mcm.c)
+set(SRC src/input.c src/mcm.c src/misc.c)
 
 include_directories(${INC})
 

--- a/tests/tools/TestApp/Inc/misc.h
+++ b/tests/tools/TestApp/Inc/misc.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _MISC_H_
+#define _MISC_H_
+
+void LOG(const char *format, ...);
+
+#endif /* _MISC_H_ */

--- a/tests/tools/TestApp/rx_app.c
+++ b/tests/tools/TestApp/rx_app.c
@@ -1,8 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include "Inc/input.h"
 #include "Inc/mcm.h"
+#include "Inc/misc.h"
 
 char *client_cfg;
 char *conn_cfg;
@@ -25,32 +32,32 @@ int main(int argc, char *argv[]) {
     MeshConnection *connection = NULL;
     MeshClient *client = NULL;
 
-    printf("[RX] Launching RX App \n");
-    printf("[RX] Reading client configuration... \n");
+    LOG("[RX] Launching RX App");
+    LOG("[RX] Reading client configuration...");
     client_cfg = parse_json_to_string(client_cfg_file);
-    printf("[RX] Reading connection configuration... \n");
+    LOG("[RX] Reading connection configuration...");
     conn_cfg = parse_json_to_string(conn_cfg_file);
 
     /* Initialize mcm client */
     int err = mesh_create_client_json(&client, client_cfg);
     if (err) {
-        printf("[RX] Failed to create mesh client: %s (%d)\n", mesh_err2str(err), err);
+        LOG("[RX] Failed to create mesh client: %s (%d)", mesh_err2str(err), err);
         goto safe_exit;
     }
 
     /* Create mesh connection */
     err = mesh_create_rx_connection(client, &connection, conn_cfg);
     if (err) {
-        printf("[RX] Failed to create connection: %s (%d)\n", mesh_err2str(err), err);
+        LOG("[RX] Failed to create connection: %s (%d)", mesh_err2str(err), err);
         mesh_delete_client(&client);
         goto safe_exit;
     }
-    printf("[RX] Waiting for frames... \n");
+    LOG("[RX] Waiting for frames...");
     read_data_in_loop(connection, out_filename);
-    printf("[RX] Shuting down connection and client\n");
+    LOG("[RX] Shuting down connection and client");
     mesh_delete_connection(&connection);
     mesh_delete_client(&client);
-    printf("[RX] Shutdown completed exiting\n");
+    LOG("[RX] Shutdown completed exiting");
 
 safe_exit:
     free(client_cfg);

--- a/tests/tools/TestApp/src/mcm.c
+++ b/tests/tools/TestApp/src/mcm.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include "mcm.h"
 #include "mesh_dp.h"
+#include "misc.h"
 
 /* PRIVATE */
 void buffer_to_file(FILE *file, MeshBuffer *buf);
@@ -18,7 +19,7 @@ int mcm_send_video_frames(MeshConnection *connection, const char *filename) {
     MeshBuffer *buf;
     FILE *file = fopen(filename, "rb");
     if (file == NULL) {
-        printf("[TX] Failed to serialize video: file is null \n");
+        LOG("[TX] Failed to serialize video: file is null");
         err = 1;
         return err;
     }
@@ -30,7 +31,7 @@ int mcm_send_video_frames(MeshConnection *connection, const char *filename) {
         /* Ask the mesh to allocate a shared memory buffer for user data */
         err = mesh_get_buffer(connection, &buf);
         if (err) {
-            printf("[TX] Failed to get buffer: %s (%d)\n", mesh_err2str(err), err);
+            LOG("[TX] Failed to get buffer: %s (%d)", mesh_err2str(err), err);
             goto close_file;
         }
         read_size = fread(buf->payload_ptr, 1, buf->payload_len, file);
@@ -39,10 +40,10 @@ int mcm_send_video_frames(MeshConnection *connection, const char *filename) {
         }
 
         /* Send the buffer */
-        printf("[TX] Sending frame: %d\n", ++frame_num);
+        LOG("[TX] Sending frame: %d", ++frame_num);
         err = mesh_put_buffer(&buf);
         if (err) {
-            printf("[TX] Failed to put buffer: %s (%d)\n", mesh_err2str(err), err);
+            LOG("[TX] Failed to put buffer: %s (%d)", mesh_err2str(err), err);
             goto close_file;
         }
 
@@ -50,7 +51,7 @@ int mcm_send_video_frames(MeshConnection *connection, const char *filename) {
         /* TODO: Implement pacing calculation */
         usleep(40000);
     }
-    printf("[TX] data sent successfully \n");
+    LOG("[TX] data sent successfully");
 close_file:
     fclose(file);
     return err;
@@ -73,12 +74,12 @@ void read_data_in_loop(MeshConnection *connection, const char *filename) {
         /* Receive a buffer from the mesh */
         err = mesh_get_buffer_timeout(connection, &buf, timeout);
         if (err == MESH_ERR_CONN_CLOSED) {
-            printf("[RX] Connection closed\n");
+            LOG("[RX] Connection closed");
             break;
         }
-        printf("[RX] Fetched mesh data buffer\n");
+        LOG("[RX] Fetched mesh data buffer");
         if (err) {
-            printf("[RX] Failed to get buffer: %s (%d)\n", mesh_err2str(err), err);
+            LOG("[RX] Failed to get buffer: %s (%d)", mesh_err2str(err), err);
             break;
         }
         /* Process the received user data */
@@ -86,23 +87,23 @@ void read_data_in_loop(MeshConnection *connection, const char *filename) {
 
         err = mesh_put_buffer(&buf);
         if (err) {
-            printf("[RX] Failed to put buffer: %s (%d)\n", mesh_err2str(err), err);
+            LOG("[RX] Failed to put buffer: %s (%d)", mesh_err2str(err), err);
             break;
         }
-        printf("[RX] Frame: %d\n", ++frame);
+        LOG("[RX] Frame: %d", ++frame);
     }
     fclose(out);
-    printf("[RX] Done reading the data \n");
+    LOG("[RX] Done reading the data");
 }
 
 void buffer_to_file(FILE *file, MeshBuffer *buf) {
     if (file == NULL) {
-        perror("[RX] Failed to open file for writing");
+        LOG("[RX] Failed to open file for writing");
         return;
     }
     // Write the buffer to the file
     fwrite(buf->payload_ptr, buf->payload_len, 1, file);
-    printf("[RX] Saving buffer data to a file\n");
+    LOG("[RX] Saving buffer data to a file");
 }
 
 int is_root() { return geteuid() == 0; }

--- a/tests/tools/TestApp/src/misc.c
+++ b/tests/tools/TestApp/src/misc.c
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "misc.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+
+void LOG(const char *format, ...) {
+    time_t rawtime;
+    struct tm *timeinfo;
+    char time_buffer[20];
+    struct timespec ts;
+
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
+    clock_gettime(CLOCK_REALTIME, &ts);
+
+    strftime(time_buffer, sizeof(time_buffer), "%b %d %H:%M:%S", timeinfo);
+
+    printf("%s.%03ld  ", time_buffer, ts.tv_nsec / 1000000);
+
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+
+    printf("\n");
+}

--- a/tests/tools/TestApp/tx_app.c
+++ b/tests/tools/TestApp/tx_app.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -5,6 +11,7 @@
 
 #include "Inc/input.h"
 #include "Inc/mcm.h"
+#include "Inc/misc.h"
 
 char *client_cfg;
 char *conn_cfg;
@@ -27,23 +34,23 @@ int main(int argc, char **argv) {
     MeshConnection *connection = NULL;
     MeshClient *client = NULL;
 
-    printf("[TX] Launching TX app \n");
-    printf("[TX] Reading client configuration... \n");
+    LOG("[TX] Launching TX app");
+    LOG("[TX] Reading client configuration...");
     client_cfg = parse_json_to_string(client_cfg_file);
-    printf("[TX] Reading connection configuration... \n");
+    LOG("[TX] Reading connection configuration...");
     conn_cfg = parse_json_to_string(conn_cfg_file);
 
     /* Initialize mcm client */
     int err = mesh_create_client_json(&client, client_cfg);
     if (err) {
-        printf("[TX] Failed to create mesh client: %s (%d)\n", mesh_err2str(err), err);
+        LOG("[TX] Failed to create mesh client: %s (%d)", mesh_err2str(err), err);
         goto safe_exit;
     }
 
     /* Create mesh connection */
     err = mesh_create_tx_connection(client, &connection, conn_cfg);
     if (err) {
-        printf("[TX] Failed to create connection: %s (%d)\n", mesh_err2str(err), err);
+        LOG("[TX] Failed to create connection: %s (%d)", mesh_err2str(err), err);
         mesh_delete_client(&client);
         goto safe_exit;
     }
@@ -51,10 +58,10 @@ int main(int argc, char **argv) {
     /* Open file and send its contents */
 
     err = mcm_send_video_frames(connection, video_file);
-    printf("[TX] Shuting down connection and client\n");
+    LOG("[TX] Shuting down connection and client");
     mesh_delete_connection(&connection);
     mesh_delete_client(&client);
-    printf("[TX] Shutdown completed. Exiting\n");
+    LOG("[TX] Shutdown completed. Exiting");
 
 safe_exit:
     free(client_cfg);


### PR DESCRIPTION
Usage:
```c
LOG("Message with format %d", 123);
```

Output:
```shell
Jan 30 14:20:02.534  Message with format 123
```