### PR TITLE
Add missing include to fix gcc-13.3.0 compilation

### DIFF
--- a/sdk/include/mesh_client.h
+++ b/sdk/include/mesh_client.h
@@ -8,6 +8,7 @@
 
 #include <list>
 #include <mutex>
+#include <string>
 #include "mesh_dp.h"
 
 namespace mesh {


### PR DESCRIPTION
Add missing include that cause compilation error when using gcc-13.3.0
```
sdk/include/mesh_client.h:21:10: error: ‘string’ in namespace ‘std’ does not name a type
   21 |     std::string api_version
```