### PR TITLE
Installation script fixes

### DIFF
--- a/scripts/setup_ice_irdma.sh
+++ b/scripts/setup_ice_irdma.sh
@@ -18,7 +18,6 @@ function install_os_dependencies()
             cmake \
             cython3 \
             debhelper \
-            dh-systemd \
             dh-python \
             dpkg-dev \
             libnl-3-dev \


### PR DESCRIPTION
- Remove dh-systemd package, which does not exist in Ubuntu 22.04 repository