### PR TITLE
Fix: payload_type to protocol_type for rdma check in `mcm_parse_conn_param()`

### DIFF
--- a/ffmpeg-plugin/mcm_common.c
+++ b/ffmpeg-plugin/mcm_common.c
@@ -184,7 +184,7 @@ int mcm_parse_conn_param(AVFormatContext* avctx, MeshConnection *conn,
         err = mesh_apply_connection_config_memif(conn, &cfg);
         if (err)
             return err;
-    } else if (!strcmp(payload_type, "rdma")) {
+    } else if (!strcmp(protocol_type, "rdma")) {
         MeshConfig_RDMA cfg;
 
         if (kind == MESH_CONN_KIND_SENDER) {


### PR DESCRIPTION
Draft, as this code is unreachable (not able to execute it), thus it is impossible to check whether it works properly or not.

SDBQ-2075