### PR TITLE
Add: Improvements to TestApp (validation)

### DIFF
--- a/tests/tools/TestApp/src/mcm.c
+++ b/tests/tools/TestApp/src/mcm.c
@@ -26,6 +26,8 @@ int mcm_send_video_frames(MeshConnection *connection, const char *filename) {
 
     unsigned int frame_num = 0;
     size_t read_size = 1;
+    float one_sec = 1000000; /* microseconds (usec) */
+    float requested_fps = 25.0; /* FIXME: Read requested fps value */
     while (1) {
 
         /* Ask the mesh to allocate a shared memory buffer for user data */
@@ -47,9 +49,7 @@ int mcm_send_video_frames(MeshConnection *connection, const char *filename) {
             goto close_file;
         }
 
-        /* Temporary implementation for pacing */
-        /* TODO: Implement pacing calculation */
-        usleep(40000);
+        usleep(one_sec/requested_fps);
     }
     LOG("[TX] data sent successfully");
 close_file:


### PR DESCRIPTION
- [ ] Ctrl+C graceful shutdown - inform media_proxy instance about deactivating the tx/rx app (SIGINT handler)
- [ ] Pacing is hardcoded at 25 fps at the moment https://github.com/OpenVisualCloud/Media-Communications-Mesh/blob/9552a01919dd9a9928a1fc737a427273d20cc991/tests/tools/TestApp/src/mcm.c#L52 it would be great if we improve it by making it editable by the user (parametrized)
- [ ] Looping - allow the user to read the file as many times as needed; either make it loopable endlessly, or allow to put the exact number of loops

Connected to: SDBQ-2080