### PR TITLE
Minor changes to scripts and MTL parameters  

### DIFF
--- a/media-proxy/README.md
+++ b/media-proxy/README.md
@@ -38,7 +38,7 @@ The Media Proxy requires Mesh Agent to be running and listening at `localhost:50
 
 If Media Proxy successfully launches up, it opens a port for listening to control requests from SDK via gRPC (default 8002).
 
-All supported parameters can get with the program "helper" function.
+All supported parameters for `media_proxy` can be printed by passing `-h` argument as follows:
 
 ```bash
 media_proxy -h
@@ -52,6 +52,14 @@ Usage: media_proxy [OPTION]
 -i, --st2110_ip=ip_address      IP address for SMPTE 2110 (default: 192.168.96.1)
 -r, --rdma_ip=ip_address        IP address for RDMA (default: 192.168.96.2)
 -p, --rdma_ports=ports_ranges   Local port ranges for incoming RDMA connections (default: 9100-9999)
+```
+
+Additionally, by having environment variables `MEDIA_PROXY_MAIN_LCORE`, `MEDIA_PROXY_LCORES` or `KAHAWAI_CFG_PATH` defined in your `shell` environment before the execution of `media_proxy` you can influence more low level behaviour as explained bellow. Setting the variables is optional and should be accompanied by OS pre-configuration:
+
+```
+MEDIA_PROXY_LCORES="1,5-9,64-69"..: list/range of lcores that will available to media_proxy stack for usage.
+MEDIA_PROXY_MAIN_LCORE="32".......: force lcore number passed to be used for handling DPDK/MTL main stack/loop.
+KAHAWAI_CFG_PATH="/etc/mtl.json"..: absolute path to the exact location of mtl.json file [refer MTL for help].
 ```
 
 ### Run Media Proxy using `native_af_xdp`

--- a/media-proxy/src/mesh/st2110.cc
+++ b/media-proxy/src/mesh/st2110.cc
@@ -130,6 +130,17 @@ void get_mtl_dev_params(mtl_init_params& st_param, const std::string& dev_port,
     if (getenv("KAHAWAI_CFG_PATH") == NULL) {
         setenv("KAHAWAI_CFG_PATH", "/usr/local/etc/imtl.json", 0);
     }
+    if (getenv("MEDIA_PROXY_MAIN_LCORE") != NULL) {
+        try {
+            st_param.main_lcore = std::stoul(std::string(getenv("MEDIA_PROXY_MAIN_LCORE")));
+        } catch (const std::invalid_argument& e) {
+            log::error("Conversion failed, Env MEDIA_PROXY_MAIN_LCORE must be an integer");
+            st_param.main_lcore = 0;
+        } catch (const std::out_of_range& e) {
+            log::error("Conversion failed, Env MEDIA_PROXY_MAIN_LCORE is out of range");
+            st_param.main_lcore = 0;
+        }
+    }
     strlcpy(st_param.port[MTL_PORT_P], dev_port.c_str(), MTL_PORT_MAX_LEN);
     inet_pton(AF_INET, ip_addr.c_str(), st_param.sip_addr[MTL_PORT_P]);
     st_param.pmd[MTL_PORT_P] = mtl_pmd_by_port_name(st_param.port[MTL_PORT_P]);
@@ -137,6 +148,7 @@ void get_mtl_dev_params(mtl_init_params& st_param, const std::string& dev_port,
     st_param.flags = MTL_FLAG_BIND_NUMA;
     st_param.flags |= MTL_FLAG_TX_VIDEO_MIGRATE;
     st_param.flags |= MTL_FLAG_RX_VIDEO_MIGRATE;
+    st_param.flags |= MTL_FLAG_RX_SEPARATE_VIDEO_LCORE;
     st_param.flags |= MTL_FLAG_RX_UDP_PORT_ONLY;
     st_param.pacing = ST21_TX_PACING_WAY_AUTO;
     st_param.log_level = log_level;
@@ -148,7 +160,7 @@ void get_mtl_dev_params(mtl_init_params& st_param, const std::string& dev_port,
     // setting rx_queues_cnt/tx_queues_cnt to max supported size
     st_param.rx_queues_cnt[MTL_PORT_P] = 16;
     st_param.tx_queues_cnt[MTL_PORT_P] = 16;
-    st_param.lcores = NULL;
+    st_param.lcores = getenv("MEDIA_PROXY_LCORES");
     st_param.memzone_max = 9000;
 }
 

--- a/media-proxy/src/proxy_context.cc
+++ b/media-proxy/src/proxy_context.cc
@@ -105,17 +105,6 @@ uint32_t ProxyContext::incrementMSessionCount(bool postIncrement=true)
 
 void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* st_param)
 {
-    if (getenv("MEDIA_PROXY_MAIN_LCORE") != NULL) {
-        try {
-            st_param->main_lcore = std::stoul(std::string(getenv("MEDIA_PROXY_MAIN_LCORE")));
-        } catch (const std::invalid_argument& e) {
-            ERROR("Conversion failed, Env MEDIA_PROXY_MAIN_LCORE must be an integer");
-            st_param->main_lcore = 0;
-        } catch (const std::out_of_range& e) {
-            ERROR("Conversion failed, Env MEDIA_PROXY_MAIN_LCORE is out of range");
-            st_param->main_lcore = 0;
-        }
-    }
     strlcpy(st_param->port[MTL_PORT_P], getDevicePort().c_str(), MTL_PORT_MAX_LEN);
     inet_pton(AF_INET, getDataPlaneAddress().c_str(), st_param->sip_addr[MTL_PORT_P]);
     st_param->pmd[MTL_PORT_P] = mtl_pmd_by_port_name(st_param->port[MTL_PORT_P]);
@@ -123,7 +112,6 @@ void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_in
     st_param->flags = MTL_FLAG_BIND_NUMA;
     st_param->flags |= MTL_FLAG_TX_VIDEO_MIGRATE;
     st_param->flags |= MTL_FLAG_RX_VIDEO_MIGRATE;
-    st_param->flags |= MTL_FLAG_RX_SEPARATE_VIDEO_LCORE;
     st_param->flags |= request->payload_mtl_flags_mask;
     st_param->pacing = (st21_tx_pacing_way) request->payload_mtl_pacing;
     st_param->log_level = MTL_LOG_LEVEL_DEBUG;
@@ -137,8 +125,7 @@ void ProxyContext::ParseStInitParam(const mcm_conn_param* request, struct mtl_in
       st_param->rx_queues_cnt[MTL_PORT_P] = 128;
       st_param->tx_queues_cnt[MTL_PORT_P] = 128;
     }
-    st_param->lcores = getenv("MEDIA_PROXY_LCORES");
-    st_param->main_lcore = 10;
+    st_param->lcores = NULL;
     st_param->memzone_max = 9000;
 
     INFO("ProxyContext: ParseStInitParam(const mcm_conn_param* request, struct mtl_init_params* st_param)");

--- a/scripts/setup_build_env.sh
+++ b/scripts/setup_build_env.sh
@@ -151,6 +151,22 @@ function install_yum_package_dependencies()
     return 0 || return 1
 }
 
+function apply_dpdk_patches()
+{
+    mapfile -t PATCH_LIST < <(find "${MTL_DIR}/patches/dpdk/${DPDK_VER}" -path "${MTL_DIR}/patches/dpdk/${DPDK_VER}/windows" -prune -o -name '*.patch' -print | sort)
+    for pt in "${PATCH_LIST[@]}"; do
+        log_info "Apply patch ${pt}"
+        patch -d "${DPDK_DIR}" -p1 -i <(cat "${pt}")
+        error="$?"
+        if [[ "${error}" == "0" ]]; then
+            log_success "Ok. ${pt}"
+        else
+            log_error "Error (${error}): Faild to apply ${pt}"
+            exit 1
+        fi
+    done
+}
+
 # Download and unpack dependencies from source code.
 function get_download_unpack_dependencies()
 {
@@ -164,9 +180,7 @@ function get_download_unpack_dependencies()
     git_download_strip_unpack "OpenVisualCloud/Media-Transport-Library" "${MTL_VER}" "${MTL_DIR}"
     git_download_strip_unpack "dpdk/dpdk" "refs/tags/v${DPDK_VER}" "${DPDK_DIR}"
     git_download_strip_unpack "OpenVisualCloud/SVT-JPEG-XS" "${JPEGXS_VER}" "${JPEGXS_DIR}"
-    patch -d "${DPDK_DIR}" -p1 -i <(cat "${MTL_DIR}/patches/dpdk/${DPDK_VER}/"*.patch)
-    patch -d "${DPDK_DIR}" -p1 < "${MTL_DIR}/patches/dpdk/${DPDK_VER}/hdr_split/"*.patch || true
-    patch -d "${DPDK_DIR}" -p1 < "${MTL_DIR}/patches/dpdk/${DPDK_VER}/tsn/"*.patch || true
+    apply_dpdk_patches
 }
 
 # Download and install rpm repo for nasm

--- a/scripts/setup_build_env.sh
+++ b/scripts/setup_build_env.sh
@@ -161,7 +161,7 @@ function apply_dpdk_patches()
         if [[ "${error}" == "0" ]]; then
             log_success "Ok. ${pt}"
         else
-            log_error "Error (${error}): Faild to apply ${pt}"
+            log_error "Error (${error}): Failed to apply ${pt}"
             exit 1
         fi
     done

--- a/scripts/setup_ice_irdma.sh
+++ b/scripts/setup_ice_irdma.sh
@@ -157,7 +157,7 @@ then
     set -exEo pipefail
     install_os_dependencies && \
     get_and_patch_intel_drivers && \
-    build_install_and_config_intel_drivers && \
+    build_install_and_config_intel_drivers
     build_install_and_config_irdma_drivers && \
     config_intel_rdma_driver
     return_code="$?"


### PR DESCRIPTION
ADD: Lcores list and main_lcore from env variable.
- MEDIA_PROXY_MAIN_LCORE: mtl dpdk main_lcore id.
- MEDIA_PROXY_LCORES: mtl lcores list variable
ADD: Add flag to use separate cores for RX and TX.

FIX: DPDK patches apply script to include subdirectories:
- moved patching to another method apply_dpdk_patches
- create patches list and make sure it is sorted
- include subdirectories without windows subdir