### PR TITLE
FIX: Trivy reported update to Dockerfile

### DIFF
--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -60,10 +60,10 @@ ARG IMAGE_CACHE_REGISTRY
 ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
-LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh FFmpeg"
 LABEL org.opencontainers.image.description="Media Communications Mesh FFmpeg with MCM-Muxer and MCM-Demuxer plugins. Ubuntu 22.04 Docker Release Image."
-LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.version="1.25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -100,5 +100,4 @@ EXPOSE 8001/tcp 8002/tcp
 CMD ["--help"]
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT ["/usr/local/bin/ffmpeg"]
-
-HEALTHCHECK --interval=30s --timeout=5s CMD ps aux | grep "ffmpeg" || exit 1
+HEALTHCHECK --interval=30s --timeout=5s CMD if(( $(ps aux | grep "ffmpeg\|ffplay" | wc -l) != 2 )); then exit 1; fi

--- a/ffmpeg-plugin/Dockerfile
+++ b/ffmpeg-plugin/Dockerfile
@@ -63,7 +63,7 @@ FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh FFmpeg"
 LABEL org.opencontainers.image.description="Media Communications Mesh FFmpeg with MCM-Muxer and MCM-Demuxer plugins. Ubuntu 22.04 Docker Release Image."
-LABEL org.opencontainers.image.version="1.25.03"
+LABEL org.opencontainers.image.version="25.03.0"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -142,7 +142,7 @@ FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as media-proxy
 LABEL maintainer="milosz.linkiewicz@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Media Proxy"
 LABEL org.opencontainers.image.description="Media Communications Mesh Media Proxy application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="1.25.03"
+LABEL org.opencontainers.image.version="25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -189,7 +189,7 @@ FROM media-proxy as mtl-manager
 LABEL maintainer="milosz.linkiewicz@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Mtl Manager"
 LABEL org.opencontainers.image.description="Media Communications Mesh Mtl Manager application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="1.25.03"
+LABEL org.opencontainers.image.version="25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -203,7 +203,7 @@ FROM media-proxy as mesh-agent
 LABEL maintainer="milosz.linkiewicz@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Mesh Agent"
 LABEL org.opencontainers.image.description="Media Communications Mesh Mesh Agent application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="1.25.03"
+LABEL org.opencontainers.image.version="25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -139,10 +139,10 @@ ARG IMAGE_CACHE_REGISTRY
 ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as media-proxy
 
-LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Media Proxy"
 LABEL org.opencontainers.image.description="Media Communications Mesh Media Proxy application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="25.03"
+LABEL org.opencontainers.image.version="25.03.0"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -186,10 +186,10 @@ HEALTHCHECK --interval=30s --timeout=5s CMD ps aux | grep "media_proxy" || exit 
 
 FROM media-proxy as mtl-manager
 
-LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Mtl Manager"
 LABEL org.opencontainers.image.description="Media Communications Mesh Mtl Manager application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="25.03"
+LABEL org.opencontainers.image.version="25.03.0"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -200,10 +200,10 @@ HEALTHCHECK --interval=30s --timeout=5s CMD if(( $(ps aux | grep "MtlManager" | 
 
 FROM media-proxy as mesh-agent
 
-LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Mesh Agent"
 LABEL org.opencontainers.image.description="Media Communications Mesh Mesh Agent application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="25.03"
+LABEL org.opencontainers.image.version="25.03.0"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 

--- a/media-proxy/Dockerfile
+++ b/media-proxy/Dockerfile
@@ -142,7 +142,7 @@ FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME} as media-proxy
 LABEL maintainer="milosz.linkiewicz@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Media Proxy"
 LABEL org.opencontainers.image.description="Media Communications Mesh Media Proxy application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.version="1.25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -189,7 +189,7 @@ FROM media-proxy as mtl-manager
 LABEL maintainer="milosz.linkiewicz@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Mtl Manager"
 LABEL org.opencontainers.image.description="Media Communications Mesh Mtl Manager application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="25.03"
+LABEL org.opencontainers.image.version="1.25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -203,7 +203,7 @@ FROM media-proxy as mesh-agent
 LABEL maintainer="milosz.linkiewicz@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh Mesh Agent"
 LABEL org.opencontainers.image.description="Media Communications Mesh Mesh Agent application. Ubuntu 22.04 Docker Container Release Image"
-LABEL org.opencontainers.image.version="25.03"
+LABEL org.opencontainers.image.version="1.25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -44,7 +44,7 @@ FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh SDK"
 LABEL org.opencontainers.image.description="Media Communications Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image"
-LABEL org.opencontainers.image.version="1.25.03-rc5"
+LABEL org.opencontainers.image.version="1.25.03"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -44,7 +44,7 @@ FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh SDK"
 LABEL org.opencontainers.image.description="Media Communications Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image"
-LABEL org.opencontainers.image.version="1.25.03"
+LABEL org.opencontainers.image.version="25.03.0"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -41,10 +41,10 @@ ARG IMAGE_CACHE_REGISTRY
 ARG IMAGE_NAME
 FROM ${IMAGE_CACHE_REGISTRY}/${IMAGE_NAME}
 
-LABEL maintainer="milosz.linkiewicz@intel.com"
+LABEL maintainer="milosz.linkiewicz@intel.com,konstantin.ilichev@intel.com"
 LABEL org.opencontainers.image.title="Media Communications Mesh SDK"
 LABEL org.opencontainers.image.description="Media Communications Mesh SDK sample applications. Ubuntu 22.04 Docker Release Image"
-LABEL org.opencontainers.image.version="1.0.0"
+LABEL org.opencontainers.image.version="1.25.03-rc5"
 LABEL org.opencontainers.image.vendor="Intel Corporation"
 LABEL org.opencontainers.image.licenses="BSD 3-Clause License"
 
@@ -81,3 +81,4 @@ USER mcm
 CMD ["--help"]
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT ["${MCM_DIR}/recver_app"]
+HEALTHCHECK --interval=30s --timeout=5s CMD if(( $(ps aux | grep "recver_app\|sender_app" | wc -l) != 2 )); then exit 1; fi


### PR DESCRIPTION
FIX: Trivy reported update to Dockerfile.

Add `HEALTHCHECK` to `SDK` Dockerfile so that Trivy does not report an issues pointing that health-check keyword is mandatory.