### PR TITLE
Fix data plane atomic pointer implementation

### DIFF
--- a/media-proxy/include/mesh/conn.h
+++ b/media-proxy/include/mesh/conn.h
@@ -242,7 +242,7 @@ protected:
 
     Kind _kind = Kind::undefined; // must be properly set in the derived class ctor
 
-    sync::DataplaneAtomicUint64 dp_link;
+    sync::DataplaneAtomicPtr dp_link;
 
     struct {
         std::atomic<uint64_t> inbound_bytes;

--- a/media-proxy/include/mesh/multipoint.h
+++ b/media-proxy/include/mesh/multipoint.h
@@ -41,10 +41,11 @@ private:
     std::list<Connection *> outputs;
     std::mutex outputs_mx;
 
-    sync::DataplaneAtomicUint64 outputs_ptr;
+    sync::DataplaneAtomicPtr outputs_ptr;
 
-    std::list<Connection *> * get_hotpath_outputs();
-    void set_hotpath_outputs(const std::list<Connection *> *new_outputs);
+    std::list<Connection *> * get_hotpath_outputs_lock();
+    void hotpath_outputs_unlock();
+    void set_hotpath_outputs(std::list<Connection *> *new_outputs);
 };
 
 } // namespace mesh::multipoint

--- a/media-proxy/src/mesh/conn_local.cc
+++ b/media-proxy/src/mesh/conn_local.cc
@@ -175,7 +175,8 @@ int Local::callback_on_interrupt(memif_conn_handle_t conn, void *private_ctx,
         return err;
     }
 
-    _this->on_memif_receive(shm_bufs.data, shm_bufs.len);
+    if (shm_bufs.data && shm_bufs.len)
+        _this->on_memif_receive(shm_bufs.data, shm_bufs.len);
 
     err = memif_refill_queue(_this->memif_conn, qid, buf_num, 0);
     if (err != MEMIF_ERR_SUCCESS) {

--- a/media-proxy/src/mesh/proxy_api.cc
+++ b/media-proxy/src/mesh/proxy_api.cc
@@ -452,7 +452,6 @@ int ProxyAPIClient::Run(context::Context& ctx)
         return -1;
     }
 
-    log::debug("Proxy API client thread exited");
     return 0;
 }
 


### PR DESCRIPTION
* Rework the data plane atomic pointer class to avoid bypassing the lock after timeout.
* Use atomic dual purpose command/state storage to pass new pointer value.
* Implement lock/unlock functionality to instantiate a critical section.
* Add protection in the Local Rx class to avoid passing a null buffer or an empty buffer.