### PR TITLE
Add local conn activation flow

### DIFF
--- a/media-proxy/include/mesh/manager_local.h
+++ b/media-proxy/include/mesh/manager_local.h
@@ -20,6 +20,8 @@ public:
                               mcm_conn_param *param, memif_conn_param *memif_param,
                               const Config& conn_config, std::string& err_str);
 
+    int activate_connection_sdk(context::Context& ctx, const std::string& id);
+
     int delete_connection_sdk(context::Context& ctx, const std::string& id,
                               bool do_unregister = true);
 

--- a/media-proxy/src/mesh/conn_local.cc
+++ b/media-proxy/src/mesh/conn_local.cc
@@ -104,7 +104,7 @@ Result Local::on_establish(context::Context& ctx)
         return set_result(Result::error_out_of_memory);
     }
 
-    set_state(ctx, State::active);
+    set_state(ctx, State::suspended);
     return set_result(Result::success);
 }
 

--- a/media-proxy/src/mesh/manager_local.cc
+++ b/media-proxy/src/mesh/manager_local.cc
@@ -148,6 +148,24 @@ int LocalManager::create_connection_sdk(context::Context& ctx, std::string& id,
     return 0;
 }
 
+int LocalManager::activate_connection_sdk(context::Context& ctx, const std::string& id)
+{
+    auto conn = registry_sdk.get(id);
+    if (!conn)
+        return -1;
+
+    log::debug("Activate local conn")("conn_id", conn->id)("id", id);
+
+    {
+        lock(); // TODO: Check if locking is needed for conn activation.
+        thread::Defer d([this]{ unlock(); });
+
+        conn->resume(ctx);
+    }
+
+    return 0;
+}
+
 int LocalManager::delete_connection_sdk(context::Context& ctx, const std::string& id,
                                         bool do_unregister)
 {

--- a/media-proxy/src/mesh/sdk_api.cc
+++ b/media-proxy/src/mesh/sdk_api.cc
@@ -26,6 +26,8 @@ using grpc::StatusCode;
 using sdk::SDKAPI;
 using sdk::CreateConnectionRequest;
 using sdk::CreateConnectionResponse;
+using sdk::ActivateConnectionRequest;
+using sdk::ActivateConnectionResponse;
 using sdk::DeleteConnectionRequest;
 using sdk::DeleteConnectionResponse;
 using sdk::ConnectionConfig;
@@ -95,6 +97,23 @@ public:
 
         log::info("[SDK] Connection created")("id", resp->conn_id())
                                              ("client_id", resp->client_id());
+        return Status::OK;
+    }
+
+    Status ActivateConnection(ServerContext* sctx, const ActivateConnectionRequest* req,
+                              ActivateConnectionResponse* resp) override {
+
+        auto ctx = context::WithCancel(context::Background());
+        auto conn_id = req->conn_id();
+
+        auto& mgr = connection::local_manager;
+        int err = mgr.activate_connection_sdk(ctx, conn_id);
+        if (err)
+            ; // log::error("activate_local_conn err (%d)", err);
+        else
+            log::info("[SDK] Connection active")("id", req->conn_id())
+                                                ("client_id", req->client_id());
+
         return Status::OK;
     }
 

--- a/protos/sdk.proto
+++ b/protos/sdk.proto
@@ -10,6 +10,7 @@ import "conn-config.proto";
 
 service SDKAPI {
   rpc CreateConnection (CreateConnectionRequest) returns (CreateConnectionResponse);
+  rpc ActivateConnection (ActivateConnectionRequest) returns (ActivateConnectionResponse);
   rpc DeleteConnection (DeleteConnectionRequest) returns (DeleteConnectionResponse);
 }
 
@@ -23,6 +24,14 @@ message CreateConnectionResponse {
   string client_id       = 1;
   string conn_id         = 2;
   bytes memif_conn_param = 3;
+}
+
+message ActivateConnectionRequest {
+  string client_id = 1;
+  string conn_id   = 2;
+}
+
+message ActivateConnectionResponse {
 }
 
 message DeleteConnectionRequest {


### PR DESCRIPTION
When SDK requests creation of a local connection, Media Proxy creates a primary memif connection, sends a RegisterConnection request to Mesh Agent, after that sends a response back to SDK, and then SDK creates a secondary memif connection. After that, SDK is ready to get or put buffers.

A race condition occurs when Mesh Agent links the registered local connection to an existing multipoint group, where some traffic is passing. After that, Mesh Agent applies the updated configuration to Media Proxy, which then links the local connection to the multipoint group. In some cases that linkage happens before the secondary memif connection is fully established in SDK, which leads to undefined behavior resulting in memif error messages and Media Proxy crashing. The issue is stably observed on audio traffic where packets are coming 1000 times per second.

To fix that, make Media Proxy create the local connection in suspended mode to avoid passing traffic prematurely. After the secondary memif connection is established, SDK sends an activation request that makes Media Proxy move the local connection from suspended mode to active mode.