### PR TITLE
Fix race conditions in Mesh Agent

### DIFF
--- a/control-plane-agent/internal/agent.go
+++ b/control-plane-agent/internal/agent.go
@@ -23,6 +23,7 @@ import (
 	"control-plane-agent/internal/config"
 	"control-plane-agent/internal/event"
 	"control-plane-agent/internal/logic"
+	"control-plane-agent/internal/logic/mesh"
 	"control-plane-agent/internal/registry"
 )
 
@@ -90,6 +91,13 @@ func RunAgent() {
 	go func() {
 		defer wg.Done()
 		controlPlaneAPI.Run(ctx)
+		cancel()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mesh.ApplyProxyConfigQueue.Run(ctx)
 		cancel()
 	}()
 

--- a/control-plane-agent/internal/logic/actions/action-all-proxies-apply-config.go
+++ b/control-plane-agent/internal/logic/actions/action-all-proxies-apply-config.go
@@ -28,16 +28,10 @@ func (a *Action_AllProxiesApplyConfig) Perform(ctx context.Context, modifier str
 		return ctx, false, err
 	}
 
-	groups, err := registry.MultipointGroupRegistry.List(ctx, nil, false, false)
-	if err != nil {
-		logrus.Errorf("all proxies apply cfg list groups err: %v", err)
-		return ctx, false, err
-	}
-
 	for i := range proxies {
-		err = mesh.ApplyProxyConfig(ctx, &proxies[i], groups)
+		err = mesh.ApplyProxyConfigQueue.EnqueueProxyId(ctx, proxies[i].Id)
 		if err != nil {
-			logrus.Errorf("all proxies apply cfg cmd err: %v, proxy id: %v", err, proxies[i].Id)
+			logrus.Errorf("all proxies apply cfg enqueue err: %v, proxy id: %v", err, proxies[i].Id)
 		}
 	}
 

--- a/control-plane-agent/internal/logic/actions/action-proxy-apply-config.go
+++ b/control-plane-agent/internal/logic/actions/action-proxy-apply-config.go
@@ -12,7 +12,6 @@ import (
 
 	"control-plane-agent/internal/event"
 	"control-plane-agent/internal/logic/mesh"
-	"control-plane-agent/internal/registry"
 
 	"github.com/sirupsen/logrus"
 )
@@ -29,20 +28,9 @@ func (a *Action_ProxyApplyConfig) Perform(ctx context.Context, modifier string, 
 		return ctx, false, fmt.Errorf("proxy apply config id err: %w", err)
 	}
 
-	proxy, err := registry.MediaProxyRegistry.Get(ctx, proxyId, false)
+	err = mesh.ApplyProxyConfigQueue.EnqueueProxyId(ctx, proxyId)
 	if err != nil {
-		return ctx, false, err
-	}
-
-	groups, err := registry.MultipointGroupRegistry.List(ctx, nil, false, false)
-	if err != nil {
-		logrus.Errorf("proxy apply cfg list groups err: %v", err)
-		return ctx, false, err
-	}
-
-	err = mesh.ApplyProxyConfig(ctx, &proxy, groups)
-	if err != nil {
-		logrus.Errorf("proxy apply config cmd err: %v", err)
+		logrus.Errorf("proxy apply config enqueue err: %v", err)
 	}
 
 	return ctx, true, nil

--- a/control-plane-agent/internal/utils/readiness.go
+++ b/control-plane-agent/internal/utils/readiness.go
@@ -21,7 +21,6 @@ func (rc *ReadinessChannel) Set(newState bool) {
 
 func (rc *ReadinessChannel) Run(ctx context.Context) {
 	defer close(rc.notReadyCh)
-	defer close(rc.queue)
 	for {
 		if rc.ready {
 			select {


### PR DESCRIPTION
* Make applying proxy configuration asynchronous to the event queue to avoid mutual locking happened on the proxy gRPC comm channel.
* Avoid unnecessary closing of the proxy readiness channel that sometimes led to writing to the closed channel.