### PR TITLE
Fix shutdown signal handling in FFmpeg MCM plugin

### DIFF
--- a/ffmpeg-plugin/mcm_audio_rx.c
+++ b/ffmpeg-plugin/mcm_audio_rx.c
@@ -138,14 +138,18 @@ static int mcm_audio_read_packet(AVFormatContext* avctx, AVPacket* pkt)
         goto error_close_conn;
     }
     if (err) {
-        av_log(avctx, AV_LOG_ERROR, "Get buffer error: %s (%d)\n",
-               mesh_err2str(err), err);
-        ret = AVERROR(EIO);
+        if (mcm_shutdown_requested()) {
+            ret = AVERROR_EXIT;
+        } else {
+            av_log(avctx, AV_LOG_ERROR, "Get buffer error: %s (%d)\n",
+                   mesh_err2str(err), err);
+            ret = AVERROR(EIO);
+        }
         goto error_close_conn;
     }
 
     if (mcm_shutdown_requested()) {
-        ret = AVERROR_EOF;
+        ret = AVERROR_EXIT;
         goto error_put_buf;
     }
 

--- a/ffmpeg-plugin/mcm_common.c
+++ b/ffmpeg-plugin/mcm_common.c
@@ -24,8 +24,17 @@ void mcm_replace_back_quotes(char *str) {
     }
 }
 
+static volatile __sighandler_t prev_SIGINT_handler;
+static volatile __sighandler_t prev_SIGTERM_handler;
+
 static void mcm_handle_signal(int signal) {
     atomic_store(&shutdown_requested, true);
+
+    if (signal == SIGINT && prev_SIGINT_handler) {
+        prev_SIGINT_handler(signal);
+    } else if (signal == SIGTERM && prev_SIGTERM_handler) {
+        prev_SIGTERM_handler(signal);
+    }
 }
 
 /**
@@ -66,9 +75,23 @@ int mcm_get_client(MeshClient **mc)
         if (err) {
             client = NULL;
         } else {
+            struct sigaction action = { 0 };
+                    
+            sigfillset(&action.sa_mask);
+
+            action.sa_flags = SA_RESTART;
+            action.sa_handler = mcm_handle_signal;
+
+            if (!prev_SIGINT_handler) {
+                prev_SIGINT_handler = signal(SIGINT, SIG_DFL);
+                sigaction(SIGINT, &action, NULL);
+            }
+            if (!prev_SIGTERM_handler) {
+                prev_SIGTERM_handler = signal(SIGTERM, SIG_DFL);
+                sigaction(SIGTERM, &action, NULL);
+            }
+
             refcnt = 1;
-            signal(SIGINT, mcm_handle_signal);
-            signal(SIGTERM, mcm_handle_signal);
         }
     } else {
         refcnt++;


### PR DESCRIPTION
* Register the signal handler that sets the shutdown flag and then calls the overridden original signal handler registered by FFmpeg.
* Adjust the shutdown handling flow to avoid printing unrelated log messages.