### PR TITLE
Refactor and enhance RDMA implementation (verbs and tcp providers)

### DIFF
--- a/media-proxy/CMakeLists.txt
+++ b/media-proxy/CMakeLists.txt
@@ -139,7 +139,7 @@ include_directories(
 add_library(media_proxy_lib STATIC ${proxy_srcs} ${PROTO_SRCS} ${PROTO_HDRS} ${GRPC_SRCS}
             ${GRPC_HDRS})
 target_link_libraries(media_proxy_lib PUBLIC m ${MTL_LIB} ${MEMIF_LIB} ${LIBFABRIC}
-    gRPC::grpc++ protobuf::libprotobuf)
+    gRPC::grpc++ protobuf::libprotobuf rdmacm)
 
 add_executable(media_proxy ${proxy_srcs} src/media_proxy.cc)
 target_link_libraries(media_proxy PRIVATE media_proxy_lib)

--- a/media-proxy/include/libfabric_cq.h
+++ b/media-proxy/include/libfabric_cq.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include <rdma/fi_eq.h>
+#include <stdbool.h>
 
 /* forward declaration */
 typedef struct ep_ctx_t ep_ctx_t;
@@ -30,6 +31,7 @@ typedef struct {
     uint64_t cq_cntr;
     int cq_fd;
     int (*eq_read)(ep_ctx_t *ep_ctx, struct fi_cq_err_entry *entry, int timeout);
+    bool external;
 } cq_ctx_t;
 
 #ifdef UNIT_TESTS_ENABLED

--- a/media-proxy/include/libfabric_dev.h
+++ b/media-proxy/include/libfabric_dev.h
@@ -122,8 +122,8 @@ extern "C" {
  */
 typedef enum {
     KIND_UNDEFINED = 0,
-    KIND_TRANSMITTER,
-    KIND_RECEIVER,
+    FI_KIND_TRANSMITTER,
+    FI_KIND_RECEIVER,
 } conn_kind;
 typedef struct {
     struct fid_fabric *fabric;

--- a/media-proxy/include/libfabric_dev.h
+++ b/media-proxy/include/libfabric_dev.h
@@ -121,7 +121,7 @@ extern "C" {
  * Definition of connection kinds.
  */
 typedef enum {
-    KIND_UNDEFINED = 0,
+    FI_KIND_UNDEFINED = 0,
     FI_KIND_TRANSMITTER,
     FI_KIND_RECEIVER,
 } conn_kind;

--- a/media-proxy/include/libfabric_dev.h
+++ b/media-proxy/include/libfabric_dev.h
@@ -115,11 +115,34 @@ extern "C" {
         }                                                                                          \
     } while (0)
 
+/**
+ * Kind
+ * 
+ * Definition of connection kinds.
+ */
+typedef enum {
+    KIND_UNDEFINED = 0,
+    KIND_TRANSMITTER,
+    KIND_RECEIVER,
+} conn_kind;
 typedef struct {
     struct fid_fabric *fabric;
     struct fid_domain *domain;
     struct fi_info *info;
+    conn_kind kind;
+    const char *local_ip;
+    const char *remote_ip;
+    const char *local_port;
+    const char *remote_port;
+    bool is_initialized;       // Indicates if context is fully initialized
+    int ep_attr_type;          // Store EP type for endpoint creation
+    int addr_format;           // Store address format for endpoint creation
+    const char *provider_name; // Provider name (e.g., "tcp", "verbs")
 } libfabric_ctx;
+
+static void rdma_free_res(libfabric_ctx *rdma_ctx);
+static void rdma_freehints(struct fi_info *hints);
+static int  rdma_init_fabric(libfabric_ctx *rdma_ctx, struct fi_info *hints);
 
 #ifdef UNIT_TESTS_ENABLED
 int rdma_init(libfabric_ctx **ctx);

--- a/media-proxy/include/libfabric_ep.h
+++ b/media-proxy/include/libfabric_ep.h
@@ -43,6 +43,7 @@ typedef struct {
     rdma_addr remote_addr;
     rdma_addr local_addr;
     enum direction dir;
+    struct fid_cq *shared_rx_cq;
 } ep_cfg_t;
 
 /**

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <atomic>
 #include <queue>
+#include <array>
 
 #ifndef RDMA_DEFAULT_TIMEOUT
 #define RDMA_DEFAULT_TIMEOUT 1
@@ -26,6 +27,9 @@
 #endif
 #ifndef PAGE_SIZE
 #define PAGE_SIZE 4096
+#endif
+#ifndef RDMA_NUM_EPS
+#define RDMA_NUM_EPS  1
 #endif
 
 namespace mesh::connection {
@@ -79,13 +83,25 @@ protected:
 
     // RDMA-specific members
     libfabric_ctx *m_dev_handle;                // RDMA device handle
-    ep_ctx_t *ep_ctx;                           // RDMA endpoint context
+    // Configurable number of RDMA endpoints (default RDMA_NUM_EPS)
+    size_t               rdma_num_eps  = RDMA_NUM_EPS;
+    // Configurable provider: "tcp" or "verbs"
+    std::string          rdma_provider = "verbs"; // Default provider
+    // Endpoint contexts (one pointer per EP)
+    std::vector<ep_ctx_t*> ep_ctxs;
+    std::atomic<uint32_t>       next_tx_idx;
+    std::atomic<uint32_t>       next_rx_idx;
     ep_cfg_t ep_cfg;                            // RDMA endpoint configuration
     size_t trx_sz;                              // Data transfer size
     bool init;                                  // Indicates if RDMA is initialized
     void *buffer_block;                         // Pointer to the allocated buffer block
     int queue_size;                             // Number of buffers in the queue
     static std::atomic<int> active_connections; // Number of active RDMA connections
+
+    static constexpr size_t REORDER_WINDOW = 256;  // > max expected out-of-order
+    std::array<void*,REORDER_WINDOW> reorder_ring{{nullptr}};
+    uint64_t reorder_head = UINT64_MAX;
+    static constexpr size_t TRAILER = sizeof(uint64_t); // Size of the trailer for sequence number
 
     // Queue for managing buffers
     std::queue<void *> buffer_queue;      // Queue holding available buffers

--- a/media-proxy/include/mesh/conn_rdma.h
+++ b/media-proxy/include/mesh/conn_rdma.h
@@ -89,8 +89,6 @@ protected:
     std::string          rdma_provider = "verbs"; // Default provider
     // Endpoint contexts (one pointer per EP)
     std::vector<ep_ctx_t*> ep_ctxs;
-    std::atomic<uint32_t>       next_tx_idx;
-    std::atomic<uint32_t>       next_rx_idx;
     ep_cfg_t ep_cfg;                            // RDMA endpoint configuration
     size_t trx_sz;                              // Data transfer size
     bool init;                                  // Indicates if RDMA is initialized
@@ -98,9 +96,6 @@ protected:
     int queue_size;                             // Number of buffers in the queue
     static std::atomic<int> active_connections; // Number of active RDMA connections
 
-    static constexpr size_t REORDER_WINDOW = 256;  // > max expected out-of-order
-    std::array<void*,REORDER_WINDOW> reorder_ring{{nullptr}};
-    uint64_t reorder_head = UINT64_MAX;
     static constexpr size_t TRAILER = sizeof(uint64_t); // Size of the trailer for sequence number
 
     // Queue for managing buffers

--- a/media-proxy/include/mesh/conn_rdma_rx.h
+++ b/media-proxy/include/mesh/conn_rdma_rx.h
@@ -28,6 +28,10 @@ protected:
     // Receive data using RDMA
     void process_buffers_thread(context::Context& ctx);
     void rdma_cq_thread(context::Context& ctx);
+    std::atomic<uint32_t> next_rx_idx;
+    static constexpr size_t REORDER_WINDOW = 256; // > max expected out-of-order
+    std::array<void *, REORDER_WINDOW> reorder_ring{{nullptr}};
+    uint64_t reorder_head = UINT64_MAX;
 };
 
 } // namespace mesh::connection

--- a/media-proxy/include/mesh/conn_rdma_tx.h
+++ b/media-proxy/include/mesh/conn_rdma_tx.h
@@ -28,6 +28,8 @@ public:
 protected:
     virtual Result start_threads(context::Context& ctx);
     void rdma_cq_thread(context::Context& ctx);
+    // one 64-bit counter shared by all RdmaTx
+    inline static std::atomic<uint64_t> global_seq{0};    
 };
 
 } // namespace mesh::connection

--- a/media-proxy/include/mesh/conn_rdma_tx.h
+++ b/media-proxy/include/mesh/conn_rdma_tx.h
@@ -29,7 +29,8 @@ protected:
     virtual Result start_threads(context::Context& ctx);
     void rdma_cq_thread(context::Context& ctx);
     // one 64-bit counter shared by all RdmaTx
-    inline static std::atomic<uint64_t> global_seq{0};    
+    inline static std::atomic<uint64_t> global_seq{0};
+    std::atomic<uint32_t> next_tx_idx;
 };
 
 } // namespace mesh::connection

--- a/media-proxy/src/libfabric_dev.c
+++ b/media-proxy/src/libfabric_dev.c
@@ -9,6 +9,8 @@
 #include <getopt.h>
 
 #include <rdma/fi_cm.h>
+#include <rdma/rdma_verbs.h>
+#include <rdma/rdma_cma.h>
 
 #include "libfabric_dev.h"
 
@@ -53,7 +55,7 @@ static int rdma_init_fabric(libfabric_ctx *rdma_ctx, struct fi_info *hints)
 {
     int ret;
 
-    ret = fi_getinfo(FI_VERSION(1, 21), NULL, NULL, 0, hints, &rdma_ctx->info);
+    ret = fi_getinfo(FI_VERSION(2, 0), NULL, NULL, 0, hints, &rdma_ctx->info);
     if (ret) {
         RDMA_PRINTERR("fi_getinfo", ret);
         return ret;
@@ -65,18 +67,18 @@ static int rdma_init_fabric(libfabric_ctx *rdma_ctx, struct fi_info *hints)
         return ret;
     }
 
+    ret = fi_domain(rdma_ctx->fabric, rdma_ctx->info, &rdma_ctx->domain, NULL);
+    if (ret) {
+        RDMA_PRINTERR("fi_domain", ret);
+        return ret;
+    }
+
     /* TODO: future improvement: Add and monitor EQ to catch errors.
      * ret = fi_eq_open(rdma_ctx->fabric, &eq_attr, &eq, NULL);
      * if (ret) {
      *     RDMA_PRINTERR("fi_eq_open", ret);
      *     return ret;
      * } */
-
-    ret = fi_domain(rdma_ctx->fabric, rdma_ctx->info, &rdma_ctx->domain, NULL);
-    if (ret) {
-        RDMA_PRINTERR("fi_domain", ret);
-        return ret;
-    }
 
     /* TODO: future improvement: Add and monitor EQ to catch errors.
      * ret = fi_domain_bind(rdma_ctx->domain, &eq->fid, 0);
@@ -90,42 +92,186 @@ static int rdma_init_fabric(libfabric_ctx *rdma_ctx, struct fi_info *hints)
 
 int rdma_init(libfabric_ctx **ctx)
 {
-    struct fi_info *hints;
-    int op, ret = 0;
-    *ctx = calloc(1, sizeof(libfabric_ctx));
-    if (*ctx == NULL) {
-        RDMA_PRINTERR("calloc", -ENOMEM);
-        return -ENOMEM;
+    printf("[rdma_init] Entering function\n");
+    struct fi_info *hints = NULL;
+    struct rdma_addrinfo *rai_res = NULL;
+    struct rdma_addrinfo rai_hints;
+    int ret = 0;
+
+    if (!ctx || !(*ctx)) {
+        printf("[rdma_init] ERROR: ctx is NULL\n");
+        return -EINVAL;
     }
 
+    // Clear any previous initialization
+    if ((*ctx)->fabric || (*ctx)->domain || (*ctx)->info) {
+        printf("[rdma_init] WARNING: Context already contains initialized resources\n");
+        rdma_free_res(*ctx);
+    }
+
+    memset(&rai_hints, 0, sizeof(rai_hints));
+    printf("[rdma_init] Initialized rai_hints to zero\n");
+
+    /* Allocate fi_info hints */
     hints = fi_allocinfo();
     if (!hints) {
-        RDMA_PRINTERR("fi_allocinfo", ret);
-        libfabric_dev_ops.rdma_deinit(ctx);
+        printf("[rdma_init] ERROR: fi_allocinfo failed\n");
         return -ENOMEM;
     }
+    printf("[rdma_init] fi_allocinfo returned valid hints at %p\n", hints);
 
-    hints->domain_attr->mr_mode =
-        FI_MR_LOCAL | FI_MR_ENDPOINT | (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR);
-    hints->ep_attr->type = FI_EP_RDM;
-    hints->caps = FI_MSG;
-    hints->addr_format = FI_SOCKADDR_IN;
-    hints->fabric_attr->prov_name = strdup(LIB_FABRIC_ATTR_PROV_NAME_TCP);
-    hints->tx_attr->tclass = FI_TC_BULK_DATA;
-    hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-    hints->mode = FI_OPT_ENDPOINT;
-    hints->tx_attr->size = 32; // Transmit queue size
-    hints->rx_attr->size = 32; // Receive queue size
+    if ((*ctx)->provider_name && strcmp((*ctx)->provider_name, "verbs") == 0) {
+        hints->fabric_attr->prov_name = strdup(LIB_FABRIC_ATTR_PROV_NAME_VERBS);
+        hints->ep_attr->type          = FI_EP_RDM;  // Reliable datagram
+        hints->ep_attr->protocol      = FI_PROTO_RXM;
+        hints->addr_format            = FI_SOCKADDR_IN;  // IPv4
+        hints->domain_attr->av_type   = FI_AV_UNSPEC;
+        hints->domain_attr->mr_mode   =
+            FI_MR_LOCAL | FI_MR_ALLOCATED | FI_MR_VIRT_ADDR | FI_MR_PROV_KEY;
+        hints->domain_attr->data_progress = FI_PROGRESS_AUTO; // Use auto progress
 
-    ret = rdma_init_fabric(*ctx, hints);
-    rdma_freehints(hints);
-    if (ret) {
-        libfabric_dev_ops.rdma_deinit(ctx);
-        ERROR("Failed to initialize RDMA device");
-        return ret;
+        /* Adjust capabilities based on the direction */
+        if ((*ctx)->kind == KIND_RECEIVER) {
+            hints->caps = FI_MSG | FI_RECV | FI_RMA | FI_REMOTE_READ | FI_LOCAL_COMM;
+            hints->rx_attr = calloc(1, sizeof(struct fi_rx_attr));
+            if (hints->rx_attr) {
+                hints->rx_attr->size = 1024;  // Larger receive queue
+            }
+        } else {
+            hints->caps = FI_MSG | FI_SEND | FI_RMA | FI_REMOTE_WRITE | FI_LOCAL_COMM;
+            hints->tx_attr = calloc(1, sizeof(struct fi_tx_attr));
+            if (hints->tx_attr) {
+                hints->tx_attr->size = 1024;  // Larger send queue
+            }
+        }
+    } else {
+        hints->domain_attr->mr_mode =
+            FI_MR_LOCAL | FI_MR_VIRT_ADDR;
+        hints->ep_attr->type = FI_EP_RDM;
+        hints->caps = FI_MSG;
+        hints->addr_format = FI_SOCKADDR_IN;
+        hints->fabric_attr->prov_name = strdup(LIB_FABRIC_ATTR_PROV_NAME_TCP);
+        hints->tx_attr->tclass = FI_TC_BULK_DATA;
+        hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
+        hints->mode = FI_OPT_ENDPOINT;
+        hints->tx_attr->size = 1024; // Transmit queue size
+        hints->rx_attr->size = 1024; // Receive queue size
+        hints->domain_attr->threading = FI_THREAD_UNSPEC;
     }
 
+    /* Store configuration for later endpoint use */
+    (*ctx)->is_initialized = false;
+    (*ctx)->ep_attr_type = hints->ep_attr->type;
+    (*ctx)->addr_format = hints->addr_format;
+
+    /* Adjust capabilities based on the connection kind */
+    if ((*ctx)->kind == KIND_RECEIVER) {
+        /* For RX, resolve the local address */
+        ret = rdma_getaddrinfo((*ctx)->local_ip, (*ctx)->local_port, &rai_hints, &rai_res);
+        if (ret) {
+            printf("[rdma_init] ERROR: rdma_getaddrinfo (RX) returned %d\n", ret);
+            goto err;
+        }
+
+        hints->src_addr = malloc(rai_res->ai_src_len);
+        if (!hints->src_addr) {
+            ret = -ENOMEM;
+            goto err;
+        }
+
+        // Set the FI_SOURCE flag to tell provider to use src_addr for binding
+        hints->caps |= FI_SOURCE;
+
+        memcpy(hints->src_addr, rai_res->ai_src_addr, rai_res->ai_src_len);
+        hints->src_addrlen = rai_res->ai_src_len;
+    } else {
+        /* For TX, resolve the remote address */
+        ret = rdma_getaddrinfo((*ctx)->remote_ip, (*ctx)->remote_port, &rai_hints, &rai_res);
+        if (ret) {
+            printf("[rdma_init] ERROR: rdma_getaddrinfo (TX) returned %d\n", ret);
+            goto err;
+        }
+
+        // Handle source address
+        if (rai_res->ai_src_len > 0) {
+            hints->src_addr = malloc(rai_res->ai_src_len);
+            if (!hints->src_addr) {
+                ret = -ENOMEM;
+                goto err;
+            }
+            memcpy(hints->src_addr, rai_res->ai_src_addr, rai_res->ai_src_len);
+            hints->src_addrlen = rai_res->ai_src_len;
+        }
+
+        // Handle destination address
+        if (rai_res->ai_dst_len > 0) {
+            hints->dest_addr = malloc(rai_res->ai_dst_len);
+            if (!hints->dest_addr) {
+                ret = -ENOMEM;
+                goto err;
+            }
+            memcpy(hints->dest_addr, rai_res->ai_dst_addr, rai_res->ai_dst_len);
+            hints->dest_addrlen = rai_res->ai_dst_len;
+        }
+    }
+
+    /* Create fabric info, domain and fabric */
+    // For RX, pass hostname and port to enforce binding
+    if ((*ctx)->kind == KIND_RECEIVER) {
+        ret = fi_getinfo(FI_VERSION(2, 0), (*ctx)->local_ip, (*ctx)->local_port, 
+                        FI_SOURCE, hints, &(*ctx)->info);
+    } else {
+        // For TX, use the remote address info to force connectivity to specific endpoint
+        printf("[rdma_init] TX - Enforcing connection to remote %s:%s\n", (*ctx)->remote_ip,
+               (*ctx)->remote_port);
+
+        ret = fi_getinfo(FI_VERSION(2, 0), (*ctx)->remote_ip, (*ctx)->remote_port, 0, hints,
+                         &(*ctx)->info);
+    }
+    if (ret) {
+        fprintf(stderr, "[rdma_init] ERROR: fi_getinfo returned %d (%s)\n", ret, fi_strerror(-ret));
+        goto err;
+    }
+
+    ret = fi_fabric((*ctx)->info->fabric_attr, &(*ctx)->fabric, NULL);
+    if (ret) {
+        printf("[rdma_init] ERROR: fi_fabric returned %d\n", ret);
+        goto err_info;
+    }
+
+    ret = fi_domain((*ctx)->fabric, (*ctx)->info, &(*ctx)->domain, NULL);
+    if (ret) {
+        printf("[rdma_init] ERROR: fi_domain returned %d\n", ret);
+        goto err_fabric;
+    }
+
+    /* Clean up temporary resources */
+    rdma_freeaddrinfo(rai_res);
+    rdma_freehints(hints);  // We've already stored the info in ctx->info
+
+    (*ctx)->is_initialized = true;
+    printf("[rdma_init] Device context successfully initialized\n");
     return 0;
+
+err_fabric:
+    fi_close(&(*ctx)->fabric->fid);
+    (*ctx)->fabric = NULL;
+    
+err_info:
+    fi_freeinfo((*ctx)->info);
+    (*ctx)->info = NULL;
+    free(*ctx);
+    *ctx = NULL;
+    
+err:
+    if (rai_res) {
+        rdma_freeaddrinfo(rai_res);
+    }
+    if (hints) {
+        rdma_freehints(hints);
+    }
+    fprintf(stderr, "[rdma_init] Failed with error %d\n", ret);
+    return ret;
 }
 
 static void rdma_free_res(libfabric_ctx *rdma_ctx)

--- a/media-proxy/src/libfabric_dev.c
+++ b/media-proxy/src/libfabric_dev.c
@@ -142,13 +142,11 @@ int rdma_init(libfabric_ctx **ctx)
         /* Adjust capabilities based on the direction */
         if ((*ctx)->kind == FI_KIND_RECEIVER) {
             hints->caps = FI_MSG | FI_RECV | FI_RMA | FI_REMOTE_READ | FI_LOCAL_COMM;
-            hints->rx_attr = calloc(1, sizeof(struct fi_rx_attr));
             if (hints->rx_attr) {
                 hints->rx_attr->size = 1024;  // Larger receive queue
             }
         } else {
             hints->caps = FI_MSG | FI_SEND | FI_RMA | FI_REMOTE_WRITE | FI_LOCAL_COMM;
-            hints->tx_attr = calloc(1, sizeof(struct fi_tx_attr));
             if (hints->tx_attr) {
                 hints->tx_attr->size = 1024;  // Larger send queue
             }

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -7,6 +7,7 @@ namespace mesh::connection {
 
 RdmaRx::RdmaRx() : Rdma() {
     _kind = Kind::receiver; // Set the Kind in the constructor
+    next_rx_idx = 0; // Initialize the next receive index
 }
 
 RdmaRx::~RdmaRx()
@@ -133,7 +134,6 @@ void RdmaRx::rdma_cq_thread(context::Context& ctx) {
 
     while (!ctx.cancelled()) {
         bool did_work = false;
-
 
         // Poll each *unique* CQ only once
         struct fid_cq *last_cq = nullptr;

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -128,13 +128,6 @@ void RdmaRx::process_buffers_thread(context::Context& ctx)
  * @param ctx The context for managing thread cancellation and operations.
  */
 void RdmaRx::rdma_cq_thread(context::Context& ctx) {
-    // Window size must be a power of two and exceed any out‐of‐order gap
-    static constexpr size_t REORDER_WINDOW = 256;
-
-    // Per‐thread reorder buffer and head index
-    std::array<void*, REORDER_WINDOW> reorder_ring{};
-    uint64_t reorder_head = UINT64_MAX;
-
     constexpr int CQ_RETRY_DELAY_US = 100;
     struct fi_cq_entry cq_entries[CQ_BATCH_SIZE];
 

--- a/media-proxy/src/mesh/conn_rdma_rx.cc
+++ b/media-proxy/src/mesh/conn_rdma_rx.cc
@@ -1,6 +1,7 @@
 #include "conn_rdma_rx.h"
 #include <stdexcept>
 #include <queue>
+#include <immintrin.h>
 
 namespace mesh::connection {
 
@@ -61,34 +62,51 @@ Result RdmaRx::start_threads(context::Context& ctx) {
  */
 void RdmaRx::process_buffers_thread(context::Context& ctx)
 {
-
     while (!ctx.cancelled()) {
         void *buf = nullptr;
 
-        // Process all available buffers in the queue
+        // Drain all currently queued buffers
         while (!ctx.cancelled()) {
             Result res = consume_from_queue(ctx, &buf);
-            if (res == Result::success && buf != nullptr) {
-                int err = libfabric_ep_ops.ep_recv_buf(ep_ctx, buf, trx_sz, buf);
+            if (res == Result::success && buf) {
+                // Round-robin receive postings across the two QPs
+                uint32_t idx = next_rx_idx.fetch_add(1, std::memory_order_relaxed)
+                             % ep_ctxs.size();
+                ep_ctx_t* chosen = ep_ctxs[idx];
+                if (!chosen) {
+                    log::error("RDMA rx endpoint #%u is null, skipping buffer")
+                        ("idx", idx)("kind", kind2str(_kind));
+                    // Return buffer so it isn't lost
+                    add_to_queue(buf);
+                    break;
+                }
+
+                int err = libfabric_ep_ops.ep_recv_buf(chosen, buf, trx_sz + TRAILER, buf);
                 if (err) {
-                    log::error("Failed to pass empty buffer to RDMA rx to receive into")
-                              ("buffer_address", buf)("error", fi_strerror(-err))
-                              ("kind", kind2str(_kind));
+                    log::error("Failed to post recv buffer to RDMA rx")
+                        ("buffer_address", buf)
+                        ("error", fi_strerror(-err))
+                        ("kind", kind2str(_kind));
+                    // On error, put the buffer back on the queue
                     res = add_to_queue(buf);
                     if (res != Result::success) {
-                        log::error("Failed to add buffer to RDMA rx queue")("error", result2str(res))
-                                  ("kind", kind2str(_kind));
+                        log::error("Failed to re-queue buffer after recv error")
+                            ("error", result2str(res))
+                            ("kind", kind2str(_kind));
                         break;
                     }
                 }
             } else {
-                break; // Exit the loop to avoid spinning on errors
+                // No more buffers available right now
+                break;
             }
         }
-        // Wait for the buffer to become available
+
+        // Wait until new buffers are added
         wait_buf_available();
     }
 }
+
 
 /**
  * @brief Handles the RDMA completion queue (CQ) events in a dedicated thread.
@@ -110,73 +128,189 @@ void RdmaRx::process_buffers_thread(context::Context& ctx)
  * @param ctx The context for managing thread cancellation and operations.
  */
 void RdmaRx::rdma_cq_thread(context::Context& ctx) {
-    constexpr int CQ_RETRY_DELAY_US = 100;        // Retry delay for EAGAIN
-    struct fi_cq_entry cq_entries[CQ_BATCH_SIZE]; // Array to hold batch of CQ entries
+    // Window size must be a power of two and exceed any out‐of‐order gap
+    static constexpr size_t REORDER_WINDOW = 256;
+
+    // Per‐thread reorder buffer and head index
+    std::array<void*, REORDER_WINDOW> reorder_ring{};
+    uint64_t reorder_head = UINT64_MAX;
+
+    constexpr int CQ_RETRY_DELAY_US = 100;
+    struct fi_cq_entry cq_entries[CQ_BATCH_SIZE];
 
     while (!ctx.cancelled()) {
-        // Read a batch of completion events
-        int ret = fi_cq_read(ep_ctx->cq_ctx.cq, cq_entries, CQ_BATCH_SIZE);
-        if (ret > 0) {
-            for (int i = 0; i < ret; ++i) {
-                void *buf = cq_entries[i].op_context;
-                if (buf == nullptr) {
-                    log::error("RDMA rx null buffer context, skipping...")
-                              ("batch_index",i)("kind", kind2str(_kind));
-                    continue;
-                }
+        bool did_work = false;
 
-                // Process the buffer (e.g., transmit or handle)
-                Result res = transmit(ctx, buf, trx_sz);
-                if (res != Result::success) {
-                    log::error("RDMA rx failed to transmit buffer")("buffer_address", buf)
-                              ("size", trx_sz)("kind", kind2str(_kind));
-                    continue;
-                }
 
-                // Add the buffer back to the queue
-                res = add_to_queue(buf);
-                if (res == Result::success) {
-                    // Notify that a buffer is available
-                    notify_buf_available();
-                } else {
-                    log::error("Failed to add buffer back to the RDMA rx queue")
-                              ("buffer_address", buf)("kind", kind2str(_kind));
+        // Poll each *unique* CQ only once
+        struct fid_cq *last_cq = nullptr;
+        for (auto* ep : ep_ctxs) {
+            if (!ep) continue;
+
+            struct fid_cq *cq = ep->cq_ctx.cq;
+            if (cq == last_cq)           // duplicate of the one we just handled
+                continue;
+            last_cq = cq;
+
+            int ret = fi_cq_read(cq, cq_entries, CQ_BATCH_SIZE);
+            if (ret > 0) {
+                did_work = true;
+
+                for (int i = 0; i < ret; ++i) {
+                    void* buf = cq_entries[i].op_context;
+                    if (!buf) {
+                        log::error("RDMA rx null buffer context, skipping...")
+                            ("batch_index", i)
+                            ("kind", kind2str(_kind));
+                        continue;
+                    }
+
+                    // Read 64-bit trailer after payload
+                    auto* trailer_ptr = reinterpret_cast<uint64_t*>(
+                        reinterpret_cast<char*>(buf) + trx_sz);
+                    uint64_t seq = *trailer_ptr;
+
+                    if (reorder_head == UINT64_MAX) {
+                        reorder_head = seq;
+                    }
+                    // Slot into ring buffer
+                    size_t idx = seq & (REORDER_WINDOW - 1);
+                    reorder_ring[idx] = buf;
+
+                    // Flush any in-order entries
+                    while (true) {
+                        size_t head_idx = reorder_head & (REORDER_WINDOW - 1);
+                        void* ready = reorder_ring[head_idx];
+                        if (!ready) break;
+                        reorder_ring[head_idx] = nullptr;
+
+                        // Deliver payload (exclude trailer)
+                        Result r = transmit(ctx, ready, trx_sz);
+                        if (r != Result::success) {
+                            log::error("RDMA rx failed to transmit buffer")
+                                ("buffer_address", ready)
+                                ("size", trx_sz)
+                                ("kind", kind2str(_kind));
+                        }
+
+                        // Recycle buffer
+                        r = add_to_queue(ready);
+                        if (r == Result::success) {
+                            notify_buf_available();
+                        } else {
+                            log::error("Failed to recycle buffer to queue")
+                                ("buffer_address", ready)
+                                ("kind", kind2str(_kind));
+                        }
+                        ++reorder_head;
+                    }
                 }
             }
-        } else if (ret == -EAGAIN) {
-            // No events to process, yield CPU briefly to avoid busy looping
-            std::this_thread::sleep_for(std::chrono::microseconds(CQ_RETRY_DELAY_US));
-        } else if (ret == -FI_EAVAIL) {
-            // Read the error details
-            struct fi_cq_err_entry err_entry;
-            int err_ret = fi_cq_readerr(ep_ctx->cq_ctx.cq, &err_entry, 0);
-            if (err_ret >= 0) {
-                if (err_entry.err == -FI_ECONNRESET || err_entry.err == -FI_ENOTCONN) {
-                    log::warn("RDMA connection reset or endpoint not connected. Waiting for new connection.")
-                             ("error", fi_strerror(err_entry.err))("kind",kind2str(_kind));
-                    thread::Sleep(ctx, std::chrono::milliseconds(1000)); // Pause before retrying
+            else if (ret == -FI_EAVAIL) {
+                fi_cq_err_entry err_entry {};
+                int err_ret = fi_cq_readerr(ep->cq_ctx.cq, &err_entry, 0);
+                if (err_ret >= 0) {
+                    int err = err_entry.err;
+
+                    /* human-friendly diagnostics */
+                    if (err == -FI_ECANCELED) {
+                        log::warn("RDMA rx operation canceled")
+                            ("error", fi_strerror(err))("kind", kind2str(_kind));
+                    } else if (err == -FI_ECONNRESET || err == -FI_ENOTCONN) {
+                        log::warn("RDMA connection reset/not connected; retrying")
+                            ("error", fi_strerror(err))("kind", kind2str(_kind));
+                        thread::Sleep(ctx, std::chrono::milliseconds(1000));
+                    } else if (err == -FI_ECONNABORTED) {
+                        log::warn("RDMA rx connection aborted")
+                            ("error", fi_strerror(err))("kind", kind2str(_kind));
+                    } else {
+                        log::error("RDMA rx encountered CQ error")
+                            ("error", fi_strerror(err))("kind", kind2str(_kind));
+                    }
+
+                    /* recycle the buffer that was canceled / errored */
+                    if (err_entry.op_context) {
+                        if (add_to_queue(err_entry.op_context) == Result::success)
+                            notify_buf_available();
+                        else
+                            log::error("Failed to recycle buffer after CQ error")
+                                ("buffer_address", err_entry.op_context)
+                                ("kind", kind2str(_kind));
+                    }
+
+                    /* ---- if it was ECANCELED, repost done:  keep reorder_head,
+                       just try to flush any packet that became in-order now ---- */
+                    if (err == -FI_ECANCELED) {
+                        std::size_t flushed = 0;
+                        while (true) {
+                            size_t head_idx = reorder_head & (REORDER_WINDOW - 1);
+                            void*  ready    = reorder_ring[head_idx];
+                            if (!ready) break;   // next frame not here yet
+                            reorder_ring[head_idx] = nullptr;
+
+                            Result r = transmit(ctx, ready, trx_sz);
+                            if (r != Result::success)
+                                log::error("RDMA rx failed to transmit buffer")
+                                    ("buffer_address", ready)("size", trx_sz)
+                                    ("kind", kind2str(_kind));
+
+                            if (add_to_queue(ready) == Result::success)
+                                notify_buf_available();
+                            else
+                                log::error("Failed to recycle buffer to queue")
+                                    ("buffer_address", ready)("kind", kind2str(_kind));				
+                            ++reorder_head;
+                            ++flushed;
+                        }
+                        log::debug("RX ECANCELED: flushed %zu frame%s waiting in ring",
+                                   flushed, flushed == 1 ? "" : "s")
+                            ("kind", kind2str(_kind));
+                    }
+
+                    did_work = true;         // we handled something – no sleep
                 } else {
-                    log::error("RDMA rx encountered an error in CQ")(
-                        "error", fi_strerror(err_entry.err))("kind", kind2str(_kind));
+                    log::error("RDMA rx failed to read CQ error entry")
+                        ("error", fi_strerror(-err_ret))("kind", kind2str(_kind));
                 }
+            }
+            else if (ret != -EAGAIN && ret != -FI_ENOTCONN) {
+                // Fatal CQ read error
+                log::error("RDMA rx cq read failed")
+                    ("error", fi_strerror(-ret))
+                    ("kind", kind2str(_kind));
+                goto shutdown;
+            }
+            // else: -EAGAIN or -FI_ENOTCONN → retry
+        }
+
+        /* ---------- hybrid back-off when no CQ work was done ---------- */
+        static constexpr int SPIN_LIMIT  =  50;   // ≈ 1–2 µs of busy-wait
+        static constexpr int YIELD_LIMIT = 200;   // then ~200 sched_yield() calls
+        static thread_local int idle_cycles = 0;  // per-thread counter
+
+        if (!did_work) {
+            if (idle_cycles < SPIN_LIMIT) {
+                /* short spin: cheapest path at high packet rate */
+                _mm_pause();             // pause instruction = 40–100 ns
+            } else if (idle_cycles < SPIN_LIMIT + YIELD_LIMIT) {
+                /* medium wait: let other threads run */
+                std::this_thread::yield();
             } else {
-                log::error("RDMA rx failed to read CQ error entry")
-                          ("error", fi_strerror(-err_ret))("kind", kind2str(_kind));
+                /* long wait: nothing for a while – real sleep */
+                std::this_thread::sleep_for(
+                    std::chrono::microseconds(CQ_RETRY_DELAY_US));
             }
-        } else if (ret == -FI_ENOTCONN) {
-            // Handle disconnection (Transport endpoint is not connected)
-            log::warn("Transport endpoint is not connected. Waiting for new connection.")(
-                "error", fi_strerror(ret))("kind", kind2str(_kind));
-            thread::Sleep(ctx, std::chrono::milliseconds(1000)); // Pause before retrying
+            ++idle_cycles;               // back-off gets longer
         } else {
-            // Handle CQ read error
-            log::error("RDMA rx cq read failed")("error", fi_strerror(-ret))
-                      ("kind", kind2str(_kind));
-            break;
+            idle_cycles = 0;             // reset after we did useful work
         }
     }
 
-    ep_ctx->stop_flag = true; // Set the stop flag
+shutdown:
+    // Signal all endpoints to stop
+    for (auto* ep : ep_ctxs) {
+        if (ep) ep->stop_flag = true;
+    }
     log::info("RDMA RX CQ thread stopped.")("kind", kind2str(_kind));
 }
 

--- a/media-proxy/src/mesh/conn_rdma_tx.cc
+++ b/media-proxy/src/mesh/conn_rdma_tx.cc
@@ -192,7 +192,6 @@ Result RdmaTx::on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_
         std::memset(data_ptr + to_send, 0, trx_sz - to_send);
 
     // ---- write trailer at fixed offset ----
-    static constexpr size_t TRAILER = sizeof(uint64_t);
     uint64_t seq = global_seq.fetch_add(1, std::memory_order_relaxed);
     *reinterpret_cast<uint64_t*>(data_ptr + trx_sz) = seq;
 

--- a/media-proxy/src/mesh/conn_rdma_tx.cc
+++ b/media-proxy/src/mesh/conn_rdma_tx.cc
@@ -51,60 +51,94 @@ Result RdmaTx::start_threads(context::Context& ctx)
 
 void RdmaTx::rdma_cq_thread(context::Context& ctx)
 {
-    constexpr uint32_t RETRY_INTERVAL_US = 100; // Retry interval of 100 us
-    constexpr uint32_t TIMEOUT_US = 1000000;       // Total timeout of 1s
+    constexpr uint32_t RETRY_INTERVAL_US = 100;     // 100 µs back-off
+    constexpr uint32_t TIMEOUT_US        = 1'000'000; // 1 s max spin
+
+    // Buffer for batched completions
+    struct fi_cq_entry cq_entries[CQ_BATCH_SIZE];
 
     while (!ctx.cancelled()) {
-        // Wait for the buffer to become available after successful send
+        // Wait until at least one send has occurred
         wait_buf_available();
 
-        struct fi_cq_entry cq_entries[CQ_BATCH_SIZE];
+        uint32_t elapsed = 0;
+        bool     done    = false;
 
-        uint32_t elapsed_time = 0;
-        while (elapsed_time < TIMEOUT_US) {
-            int ret = fi_cq_read(ep_ctx->cq_ctx.cq, cq_entries, CQ_BATCH_SIZE);
+        while (!ctx.cancelled() && elapsed < TIMEOUT_US) {
+        /* We use a single CQ for all QPs – skip duplicates */
+        struct fid_cq *last_cq = nullptr;
+        for (auto *ep : ep_ctxs) {
+            if (!ep) continue;
 
-            if (ret > 0) {
-                for (int i = 0; i < ret; i++) {
-                    void *buf = cq_entries[i].op_context;
-                    if (buf == nullptr) {
-                        log::error("RDMA tx null buffer context, skipping...")
-                                  ("kind", kind2str(_kind));
-                        continue;
+            struct fid_cq *cq = ep->cq_ctx.cq;
+            if (cq == last_cq)           // already handled in this iteration
+                continue;
+            last_cq = cq;
+
+            int ret = fi_cq_read(cq, cq_entries, CQ_BATCH_SIZE);
+                if (ret > 0) {
+                    // We got completions on this QP
+                    for (int i = 0; i < ret; ++i) {
+                        void *buf = cq_entries[i].op_context;
+                        if (!buf) {
+                            log::error("RDMA tx null buffer context, skipping...")
+                                ("kind", kind2str(_kind));
+                            continue;
+                        }
+                        if (add_to_queue(buf) != Result::success) {
+                            log::error("RDMA tx failed to add buffer back to queue")
+                                ("buffer_address", buf)
+                                ("kind", kind2str(_kind));
+                        }
                     }
-
-                    // Replenish buffer
-                    Result res = add_to_queue(buf);
-                    if (res != Result::success) {
-                        log::error("RDMA tx failed to add buffer back to queue")
-                                  ("buffer_address", buf)("kind", kind2str(_kind));
-                    }
+                    done = true;
                 }
-                break; // Exit retry loop as CQ events were successfully processed
-            } else if (ret == -EAGAIN) {
-                // No events, introduce short wait to avoid busy looping
-                std::this_thread::sleep_for(std::chrono::microseconds(RETRY_INTERVAL_US));
-                elapsed_time += RETRY_INTERVAL_US;
-            } else {
-                // Handle errors
-                log::error("RDMA tx cq read failed")
-                          ("error", fi_strerror(-ret))("kind", kind2str(_kind));
-                break; // Exit retry loop on error
+                else if (ret == -FI_EAVAIL) {
+                    // asynchronous error completions ― recycle buffers too
+                    fi_cq_err_entry err {};
+                    if (fi_cq_readerr(ep->cq_ctx.cq, &err, 0) >= 0) {
+                        log::error("RDMA tx CQ error")("error", fi_strerror(err.err))
+                            ("kind", kind2str(_kind));
+                        if (err.op_context) {
+                            add_to_queue(err.op_context); // reclaim the failed buffer
+                        }
+                    } else {
+                        log::error("RDMA tx failed to read CQ error entry")
+                            ("kind", kind2str(_kind));
+                    }
+                    done = true;
+                }
+                else if (ret != -EAGAIN) {
+                    // fatal CQ read error
+                    log::error("RDMA tx cq read failed")
+                        ("error", fi_strerror(-ret))
+                        ("kind", kind2str(_kind));
+                    done = true;
+                }
+
+                if (done) break;     // processed something on this iteration
             }
 
-            if (ctx.cancelled()) {
-                break;
-            }
+            if (done) break;         // go back to outer loop
+
+            // No events yet on either CQ, back off a bit
+            std::this_thread::sleep_for(std::chrono::microseconds(RETRY_INTERVAL_US));
+            elapsed += RETRY_INTERVAL_US;
         }
 
-        // Log if timeout occurred without receiving any events after buffer should be already
-        // available
-        if (elapsed_time >= TIMEOUT_US) {
-            log::debug("RDMA tx cq read timed out after retries")("kind", kind2str(_kind));
+        if (elapsed >= TIMEOUT_US) {
+            log::debug("RDMA tx cq read timed out after retries")
+                ("kind", kind2str(_kind));
         }
     }
-        ep_ctx->stop_flag = true; // Set the stop flag
+
+    // Signal shutdown on all endpoints
+    for (auto *ep : ep_ctxs) {
+        if (ep) ep->stop_flag = true;
+    }
+    log::info("RDMA TX CQ thread stopped.")("kind", kind2str(_kind));
 }
+
 
 /**
  * @brief Handles sending data through RDMA by consuming a buffer, copying data, and transmitting it.
@@ -122,69 +156,80 @@ void RdmaTx::rdma_cq_thread(context::Context& ctx)
 Result RdmaTx::on_receive(context::Context& ctx, void *ptr, uint32_t sz, uint32_t& sent)
 {
     void *reg_buf = nullptr;
-    constexpr uint32_t TIMEOUT_US = 500000;     // 0.5-second timeout
-    constexpr uint32_t RETRY_INTERVAL_US = 100; // Retry interval of 100 us
-    uint32_t elapsed_time = 0;
+    constexpr uint32_t TIMEOUT_US         = 1000000; // 1-second timeout
+    constexpr uint32_t RETRY_INTERVAL_US = 100;     // 100 µs
+    uint32_t elapsed = 0;
 
-    // Attempt to consume a buffer from the queue with a timeout
-    while (elapsed_time < TIMEOUT_US && !ctx.cancelled()) {
-        Result res = consume_from_queue(ctx, &reg_buf);
-        if (res == Result::success) {
-            if (reg_buf != nullptr) {
-                break; // Successfully got a buffer
-            } else {
-                log::debug("RDMA tx buffer is null, retrying...")("kind", kind2str(_kind));
-            }
-        } else if (res != Result::error_no_buffer) {
-            // Log non-retryable errors and exit
-            log::error("RDMA tx failed to consume buffer from queue")("result", static_cast<int>(res))
-                      ("kind", kind2str(_kind));
-            sent = 0;
-            return res;
+    // 1) Acquire a buffer from our pool, with timeout
+    while (elapsed < TIMEOUT_US && !ctx.cancelled()) {
+        Result r = consume_from_queue(ctx, &reg_buf);
+        if (r == Result::success) {
+            if (reg_buf) break;
+            log::debug("RDMA tx buffer is null, retrying...")("kind", kind2str(_kind));
         }
-
-        // Wait before retrying
+        else if (r != Result::error_no_buffer) {
+            log::error("RDMA tx failed to consume buffer from queue")
+                ("result", static_cast<int>(r))("kind", kind2str(_kind));
+            sent = 0;
+            return r;
+        }
         std::this_thread::sleep_for(std::chrono::microseconds(RETRY_INTERVAL_US));
-        elapsed_time += RETRY_INTERVAL_US;
+        elapsed += RETRY_INTERVAL_US;
     }
 
-    // Check if we failed to get a buffer within the timeout
-    if (reg_buf == nullptr) {
-        log::error("RDMA tx failed to consume buffer within timeout")("timeout_ms", TIMEOUT_US)
-                  ("kind", kind2str(_kind));
+    if (!reg_buf) {
+        log::error("RDMA tx failed to consume buffer within timeout")
+            ("timeout_us", TIMEOUT_US)("kind", kind2str(_kind));
         sent = 0;
         return Result::error_timeout;
     }
 
-    uint32_t tmp_sent = std::min(static_cast<uint32_t>(trx_sz), sz);
-    if (tmp_sent != trx_sz) {
-        log::debug("RDMA tx sent size differs from transfer size")("requested_size", tmp_sent)
-                  ("trx_sz", trx_sz)("kind", kind2str(_kind));
+    // 2) Copy payload and pad to trx_sz
+    char* data_ptr = reinterpret_cast<char*>(reg_buf);
+    uint32_t to_send = std::min<uint32_t>(trx_sz, sz);
+    std::memcpy(data_ptr, ptr, to_send);
+    if (to_send < trx_sz)                       // pad any unused space
+        std::memset(data_ptr + to_send, 0, trx_sz - to_send);
+
+    // ---- write trailer at fixed offset ----
+    static constexpr size_t TRAILER = sizeof(uint64_t);
+    uint64_t seq = global_seq.fetch_add(1, std::memory_order_relaxed);
+    *reinterpret_cast<uint64_t*>(data_ptr + trx_sz) = seq;
+
+    // Always send full payload-slot + trailer
+    uint32_t total_len = trx_sz + static_cast<uint32_t>(TRAILER);
+
+    uint32_t idx = next_tx_idx.fetch_add(1, std::memory_order_relaxed)
+                   % static_cast<uint32_t>(ep_ctxs.size());
+    ep_ctx_t* chosen = ep_ctxs[idx];
+    if (!chosen) {
+        log::error("RDMA tx endpoint #%u is null, cannot send")("idx", idx);
+        sent = 0;
+        add_to_queue(reg_buf);
+        return Result::error_general_failure;
     }
 
-    std::memcpy(reg_buf, ptr, tmp_sent);
-
-    // Transmit the buffer through RDMA
-    int err = libfabric_ep_ops.ep_send_buf(ep_ctx, reg_buf, tmp_sent);
+    int rc = libfabric_ep_ops.ep_send_buf(chosen, reg_buf, total_len);
+    // Signal that there’s now room for more sends
     notify_buf_available();
-    sent = tmp_sent;
+    sent = to_send;
 
-    if (err) {
-        log::error("Failed to send buffer through RDMA tx")("error", fi_strerror(-err))
-                  ("kind", kind2str(_kind));
 
-        // Add the buffer back to the queue in case of failure
-        Result res = add_to_queue(reg_buf);
-        if (res != Result::success) {
-            log::error("Failed to add buffer to RDMA tx queue")("error", result2str(res))
-                      ("kind", kind2str(_kind));
+    if (rc) {
+        log::error("Failed to send buffer through RDMA tx")
+            ("error", fi_strerror(-rc))("kind", kind2str(_kind));
+        // Return buffer to pool
+        Result qr = add_to_queue(reg_buf);
+        if (qr != Result::success) {
+            log::error("Failed to return buffer to queue after send error")
+                ("error", result2str(qr))("kind", kind2str(_kind));
         }
-
         sent = 0;
         return Result::error_general_failure;
     }
 
     return Result::success;
 }
+
 
 } // namespace mesh::connection

--- a/media-proxy/src/mesh/conn_rdma_tx.cc
+++ b/media-proxy/src/mesh/conn_rdma_tx.cc
@@ -6,6 +6,7 @@ namespace mesh::connection {
 
 RdmaTx::RdmaTx() : Rdma() {
     _kind = Kind::transmitter; // Set the Kind in the constructor
+    next_tx_idx = 0; // Initialize the next transmit index
 }
 
 RdmaTx::~RdmaTx()

--- a/media-proxy/src/mesh/manager_bridges.cc
+++ b/media-proxy/src/mesh/manager_bridges.cc
@@ -228,6 +228,8 @@ int BridgesManager::create_bridge(context::Context& ctx, Connection*& bridge,
 
         req.payload_args.rdma_args.transfer_size = cfg.conn_config.buf_parts.total_size();
         req.payload_args.rdma_args.queue_size = 16;
+        req.payload_args.rdma_args.provider = strdup(cfg.conn_config.options.rdma.provider.c_str());
+        req.payload_args.rdma_args.num_endpoints = cfg.conn_config.options.rdma.num_endpoints;
 
         // Create Egress RDMA Bridge
         if (cfg.kind == Kind::transmitter) {

--- a/media-proxy/src/mesh/manager_bridges.cc
+++ b/media-proxy/src/mesh/manager_bridges.cc
@@ -229,6 +229,7 @@ int BridgesManager::create_bridge(context::Context& ctx, Connection*& bridge,
         req.payload_args.rdma_args.transfer_size = cfg.conn_config.buf_parts.total_size();
         req.payload_args.rdma_args.queue_size = 16;
         req.payload_args.rdma_args.provider = strdup(cfg.conn_config.options.rdma.provider.c_str());
+        char* _rdma_provider_dup = req.payload_args.rdma_args.provider;
         req.payload_args.rdma_args.num_endpoints = cfg.conn_config.options.rdma.num_endpoints;
 
         // Create Egress RDMA Bridge
@@ -247,6 +248,7 @@ int BridgesManager::create_bridge(context::Context& ctx, Connection*& bridge,
             if (res != Result::success) {
                 log::error("Error configuring RDMA Egress bridge: %s",
                            result2str(res));
+                free(_rdma_provider_dup);
                 delete egress_bridge;
                 return -1;
             }
@@ -256,6 +258,7 @@ int BridgesManager::create_bridge(context::Context& ctx, Connection*& bridge,
         } else if (cfg.kind == Kind::receiver) {
             auto ingress_bridge = new(std::nothrow) RdmaRx;
             if (!ingress_bridge)
+                free(_rdma_provider_dup);
                 return -ENOMEM;
 
             req.type = is_rx;
@@ -268,14 +271,18 @@ int BridgesManager::create_bridge(context::Context& ctx, Connection*& bridge,
             if (res != Result::success) {
                 log::error("Error configuring RDMA Ingress bridge: %s",
                            result2str(res));
+                free(_rdma_provider_dup);
                 delete ingress_bridge;
                 return -1;
             }
             bridge = ingress_bridge;
 
         } else {
+            free(_rdma_provider_dup);
             return -1;
         }
+        // we've handed off the provider into Rdma::configure, free our copy
+        free(_rdma_provider_dup);
     }
 
     // log::debug("BEFORE ESTABLISH");

--- a/media-proxy/tests/CMakeLists.txt
+++ b/media-proxy/tests/CMakeLists.txt
@@ -52,6 +52,16 @@ file(GLOB PHYS_RDMA_TEST_SOURCES
 )
 
 # Find source files for physical-RDMA-specific tests
+file(GLOB PHYS_RDMA_RX_TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/rdma_rx_test.cpp"
+)
+
+# Find source files for physical-RDMA-specific tests
+file(GLOB PHYS_RDMA_TX_TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/rdma_tx_test.cpp"
+)
+
+# Find source files for physical-RDMA-specific tests
 file(GLOB RDMA_BASE_TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_tests.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/conn_rdma_test_mocks.cc"
@@ -96,6 +106,26 @@ target_include_directories(conn_rdma_base_unit_tests PUBLIC
 add_executable(conn_rdma_real_ep_test ${PHYS_RDMA_TEST_SOURCES})
 target_link_libraries(conn_rdma_real_ep_test PRIVATE gtest gtest_main ${MP_LIB})
 target_include_directories(conn_rdma_real_ep_test PUBLIC
+    ${CMAKE_SOURCE_DIR}/media-proxy/include
+    ${CMAKE_BINARY_DIR}/media-proxy/generated
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/sdk/3rdparty/libmemif/src
+)
+
+# Add an executable for physical-RDMA-RX-specific test
+add_executable(rdma_rx_test ${PHYS_RDMA_RX_TEST_SOURCES})
+target_link_libraries(rdma_rx_test PRIVATE gtest gtest_main ${MP_LIB} rdmacm)
+target_include_directories(rdma_rx_test PUBLIC
+    ${CMAKE_SOURCE_DIR}/media-proxy/include
+    ${CMAKE_BINARY_DIR}/media-proxy/generated
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/sdk/3rdparty/libmemif/src
+)
+
+# Add an executable for physical-RDMA-TX-specific test
+add_executable(rdma_tx_test ${PHYS_RDMA_TX_TEST_SOURCES})
+target_link_libraries(rdma_tx_test PRIVATE gtest gtest_main ${MP_LIB} rdmacm)
+target_include_directories(rdma_tx_test PUBLIC
     ${CMAKE_SOURCE_DIR}/media-proxy/include
     ${CMAKE_BINARY_DIR}/media-proxy/generated
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/media-proxy/tests/libfabric_dev_tests.cc
+++ b/media-proxy/tests/libfabric_dev_tests.cc
@@ -70,7 +70,7 @@ void LibfabricDevTest::SetUp() {
     ctx = (libfabric_ctx*)malloc(sizeof(libfabric_ctx));
     memset(ctx, 0, sizeof(libfabric_ctx));
     // Set receiver parameters.
-    ctx->kind = KIND_RECEIVER;
+    ctx->kind = FI_KIND_RECEIVER;
     ctx->local_ip = strdup("127.0.0.1");
     ctx->local_port = strdup("12345");
 

--- a/media-proxy/tests/libfabric_dev_tests.cc
+++ b/media-proxy/tests/libfabric_dev_tests.cc
@@ -1,154 +1,192 @@
-extern "C" {
-#include "libfabric_dev.h"
-}
+// Define FFF globals exactly once.
+#define DEFINE_FFF_GLOBALS
+#include <fff.h>
 
-#include <gtest/gtest.h>
-#include "libfabric_mocks.h"
+#include "libfabric_dev_tests.h"
+#include <rdma/rdma_cma.h>
+#include <cstring>
+#include <cstdlib>
 
-// Mock functions
+// ---------------------------------------------------------------------------
+// Additional fake declarations not present in libfabric_mocks.h.
 FAKE_VALUE_FUNC(int, fi_fabric, struct fi_fabric_attr *, struct fid_fabric **, void *);
 FAKE_VALUE_FUNC(int, domain, struct fid_fabric *, struct fi_info *, struct fid_domain **, void *);
 
-class LibfabricDevTest : public ::testing::Test
-{
-  protected:
-    void SetUp() override
-    {
-        ops_fabric = {.domain = domain};
-        ops = {.close = custom_close};
-        fabric = {.fid = {.ops = &ops}, .ops = &ops_fabric};
-        dom = {.fid = {.ops = &ops}};
+// rdma_getaddrinfo and rdma_freeaddrinfo declarations matching the system header.
+FAKE_VALUE_FUNC(int, rdma_getaddrinfo, const char*, const char*, const struct rdma_addrinfo*, struct rdma_addrinfo**);
+FAKE_VOID_FUNC(rdma_freeaddrinfo, struct rdma_addrinfo*);
 
-        RESET_FAKE(fi_getinfo);
-        RESET_FAKE(fi_freeinfo);
-        RESET_FAKE(fi_fabric);
-        RESET_FAKE(domain);
+
+// ---------------------------------------------------------------------------
+// Custom fake for rdma_getaddrinfo: allocate a minimal dummy structure.
+static int rdma_getaddrinfo_custom_fake(const char *ip, const char *port,
+                                          const struct rdma_addrinfo *hints,
+                                          struct rdma_addrinfo **res) {
+    *res = (struct rdma_addrinfo *)malloc(sizeof(struct rdma_addrinfo));
+    // Set minimal fields for both RX and TX.
+    (*res)->ai_src_len = sizeof(struct sockaddr_in);
+    (*res)->ai_src_addr = (struct sockaddr *)malloc(sizeof(struct sockaddr_in));
+    memset((*res)->ai_src_addr, 0, sizeof(struct sockaddr_in));
+    (*res)->ai_dst_len = sizeof(struct sockaddr_in);
+    (*res)->ai_dst_addr = (struct sockaddr *)malloc(sizeof(struct sockaddr_in));
+    memset((*res)->ai_dst_addr, 0, sizeof(struct sockaddr_in));
+    return 0;
+}
+
+// Custom fake for rdma_freeaddrinfo: free the allocated structure.
+static void rdma_freeaddrinfo_custom_fake(struct rdma_addrinfo *res) {
+    if (res) {
+        if (res->ai_src_addr)
+            free(res->ai_src_addr);
+        if (res->ai_dst_addr)
+            free(res->ai_dst_addr);
+        free(res);
     }
+}
 
-    void TearDown() override {}
+// ---------------------------------------------------------------------------
+// Global objects for our additional mocks.
+static struct fi_ops_fabric ops_fabric;
+static struct fid_domain dom;
+static fid_fabric fabric;
+static struct fi_ops ops;
 
-    static struct fi_ops_fabric ops_fabric;
-    static struct fid_domain dom;
-    static fid_fabric fabric;
-    static struct fi_ops ops;
+// Custom fake implementations for fi_fabric and domain.
+static int fi_fabric_custom_fake(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context) {
+    *fabric = &::fabric;
+    return 0;
+}
 
-    static int fi_fabric_custom_fake(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
-                                     void *context)
-    {
-        *fabric = &LibfabricDevTest::fabric;
-        return 0;
-    }
-    static int domain_custom_fake(struct fid_fabric *fabric, struct fi_info *info,
-                                  struct fid_domain **dom, void *context)
-    {
-        *dom = &LibfabricDevTest::dom;
-        return 0;
-    }
-};
+static int domain_custom_fake(struct fid_fabric *fabric, struct fi_info *info,
+                                struct fid_domain **dom, void *context) {
+    *dom = &::dom;
+    return 0;
+}
 
-struct fid_fabric LibfabricDevTest::fabric;
-struct fi_ops_fabric LibfabricDevTest::ops_fabric;
-struct fi_ops LibfabricDevTest::ops;
-struct fid_domain LibfabricDevTest::dom;
+// ---------------------------------------------------------------------------
+// Test fixture implementation.
+void LibfabricDevTest::SetUp() {
+    // Allocate a dummy libfabric context.
+    ctx = (libfabric_ctx*)malloc(sizeof(libfabric_ctx));
+    memset(ctx, 0, sizeof(libfabric_ctx));
+    // Set receiver parameters.
+    ctx->kind = KIND_RECEIVER;
+    ctx->local_ip = strdup("127.0.0.1");
+    ctx->local_port = strdup("12345");
 
-TEST_F(LibfabricDevTest, TestRdmaInitSuccess)
-{
-    libfabric_ctx *ctx = nullptr;
-    fi_getinfo_fake.custom_fake = fi_getinfo_custom_fake;
+    // Initialize additional mock objects.
+    ops_fabric.domain = domain;
+    ops.close = custom_close;  // custom_close is defined in libfabric_mocks.cc.
+    fabric.fid.ops = &ops;
+    fabric.ops = &ops_fabric;
+    dom.fid.ops = &ops;
+
+    // Reset all fakes.
+    RESET_FAKE(fi_getinfo);
+    RESET_FAKE(fi_freeinfo);
+    RESET_FAKE(fi_fabric);
+    RESET_FAKE(domain);
+    RESET_FAKE(rdma_getaddrinfo);
+    RESET_FAKE(rdma_freeaddrinfo);
+
+    // Set custom fake functions.
+    fi_getinfo_fake.custom_fake = fi_getinfo_custom_fake; // Defined in libfabric_mocks.cc.
     fi_fabric_fake.custom_fake = fi_fabric_custom_fake;
     domain_fake.return_val = 0;
+    rdma_getaddrinfo_fake.custom_fake = rdma_getaddrinfo_custom_fake;
+    rdma_freeaddrinfo_fake.custom_fake = rdma_freeaddrinfo_custom_fake;
+}
 
+void LibfabricDevTest::TearDown() {
+    if (ctx)
+        libfabric_dev_ops.rdma_deinit(&ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+
+TEST_F(LibfabricDevTest, TestRdmaInitSuccess) {
     int ret = libfabric_dev_ops.rdma_init(&ctx);
-
     ASSERT_EQ(ret, 0);
     ASSERT_NE(ctx, nullptr);
+    // Expect one call each for fi_getinfo, fi_fabric, and domain, and one free of hints.
     ASSERT_EQ(fi_getinfo_fake.call_count, 1);
     ASSERT_EQ(fi_fabric_fake.call_count, 1);
     ASSERT_EQ(domain_fake.call_count, 1);
     ASSERT_EQ(fi_freeinfo_fake.call_count, 1);
-
     libfabric_dev_ops.rdma_deinit(&ctx);
 }
 
-TEST_F(LibfabricDevTest, TestRdmaInitFailGetinfo)
-{
-    libfabric_ctx *ctx = nullptr;
+TEST_F(LibfabricDevTest, TestRdmaInitFailGetinfo) {
+    fi_getinfo_fake.custom_fake = NULL;
     fi_getinfo_fake.return_val = -1;
-
+    
     std::string captured_stderr;
     testing::internal::CaptureStderr();
 
     int ret = libfabric_dev_ops.rdma_init(&ctx);
-
     captured_stderr = testing::internal::GetCapturedStderr();
     EXPECT_FALSE(captured_stderr.empty());
-
+    
     ASSERT_EQ(ret, -1);
-    ASSERT_EQ(ctx, nullptr);
+    ASSERT_FALSE(ctx->is_initialized);
+    
     ASSERT_EQ(fi_getinfo_fake.call_count, 1);
     ASSERT_EQ(fi_fabric_fake.call_count, 0);
     ASSERT_EQ(domain_fake.call_count, 0);
     ASSERT_EQ(fi_freeinfo_fake.call_count, 1);
 }
 
-TEST_F(LibfabricDevTest, TestRdmaInitFailFabric)
-{
-    libfabric_ctx *ctx = nullptr;
+TEST_F(LibfabricDevTest, TestRdmaInitFailFabric) {
     fi_getinfo_fake.custom_fake = fi_getinfo_custom_fake;
+    fi_fabric_fake.custom_fake = NULL;
     fi_fabric_fake.return_val = -1;
-
     std::string captured_stderr;
     testing::internal::CaptureStderr();
 
     int ret = libfabric_dev_ops.rdma_init(&ctx);
-
     captured_stderr = testing::internal::GetCapturedStderr();
     EXPECT_FALSE(captured_stderr.empty());
-
     ASSERT_EQ(ret, -1);
     ASSERT_EQ(ctx, nullptr);
     ASSERT_EQ(fi_getinfo_fake.call_count, 1);
     ASSERT_EQ(fi_fabric_fake.call_count, 1);
     ASSERT_EQ(domain_fake.call_count, 0);
+    // Expect two freeinfo calls: one for hints and one for partially allocated info.
     ASSERT_EQ(fi_freeinfo_fake.call_count, 2);
 }
 
-TEST_F(LibfabricDevTest, TestRdmaInitFailDomain)
-{
-    libfabric_ctx *ctx = nullptr;
+TEST_F(LibfabricDevTest, TestRdmaInitFailDomain) {
     fi_getinfo_fake.custom_fake = fi_getinfo_custom_fake;
     fi_fabric_fake.custom_fake = fi_fabric_custom_fake;
+    domain_fake.custom_fake = NULL;
     domain_fake.return_val = -1;
-
     std::string captured_stderr;
     testing::internal::CaptureStderr();
 
     int ret = libfabric_dev_ops.rdma_init(&ctx);
-
     captured_stderr = testing::internal::GetCapturedStderr();
     EXPECT_FALSE(captured_stderr.empty());
-
     ASSERT_EQ(ret, -1);
     ASSERT_EQ(ctx, nullptr);
     ASSERT_EQ(fi_getinfo_fake.call_count, 1);
     ASSERT_EQ(fi_fabric_fake.call_count, 1);
     ASSERT_EQ(domain_fake.call_count, 1);
+    // Expect two freeinfo calls: one for hints and one for partially allocated info.
     ASSERT_EQ(fi_freeinfo_fake.call_count, 2);
 }
 
-TEST_F(LibfabricDevTest, TestRdmaDeinitSuccess)
-{
-    libfabric_ctx *ctx = nullptr;
-    fi_getinfo_fake.custom_fake = fi_getinfo_custom_fake;
-    fi_fabric_fake.custom_fake = fi_fabric_custom_fake;
-    domain_fake.return_val = 0;
-
-    libfabric_dev_ops.rdma_init(&ctx);
+TEST_F(LibfabricDevTest, TestRdmaDeinitSuccess) {
+    int ret = libfabric_dev_ops.rdma_init(&ctx);
     ASSERT_NE(ctx, nullptr);
-
-    int ret = libfabric_dev_ops.rdma_deinit(&ctx);
-
+    ret = libfabric_dev_ops.rdma_deinit(&ctx);
     ASSERT_EQ(ret, 0);
     ASSERT_EQ(ctx, nullptr);
+    // Expect a total of two freeinfo calls.
     ASSERT_EQ(fi_freeinfo_fake.call_count, 2);
+}
+
+TEST_F(LibfabricDevTest, TestRdmaInitNullContext) {
+    int ret = libfabric_dev_ops.rdma_init(nullptr);
+    ASSERT_EQ(ret, -EINVAL);
 }

--- a/media-proxy/tests/libfabric_dev_tests.h
+++ b/media-proxy/tests/libfabric_dev_tests.h
@@ -1,0 +1,17 @@
+#ifndef LIBFABRIC_DEV_TESTS_H
+#define LIBFABRIC_DEV_TESTS_H
+
+#include <fff.h>
+#include <gtest/gtest.h>
+#include "libfabric_dev.h"
+#include "libfabric_mocks.h"  // This header declares fi_getinfo_custom_fake and custom_close.
+
+class LibfabricDevTest : public ::testing::Test {
+  protected:
+    void SetUp() override;
+    void TearDown() override;
+    // Test context used by libfabric_dev.
+    libfabric_ctx* ctx;
+};
+
+#endif // LIBFABRIC_DEV_TESTS_H

--- a/media-proxy/tests/metrics.h
+++ b/media-proxy/tests/metrics.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+
+/* wire header that prefixes every RDMA payload */
+#pragma pack(push, 1)
+struct FrameHdr {
+    uint32_t frame;   /* network-order */
+    uint64_t tx_ns;   /* network-order, CLOCK_REALTIME in ns */
+};
+#pragma pack(pop)
+
+/*UDP message RX→TX with results */
+struct StatsMsg {
+    uint32_t payload_mb;        /* MB for this run              */
+    uint32_t queue;             /* queue size                   */
+    double   ttlb_spaced_ms;    /* TTLB @60fps                  */
+    double   ttlb_full_ms;      /* TTLB @ max throughput        */
+    double   cpu_tx_pct;        /* TX process CPU-load percent  */
+    double   cpu_rx_pct;        /* RX process CPU-load percent  */
+};

--- a/media-proxy/tests/rdma_rx_test.cpp
+++ b/media-proxy/tests/rdma_rx_test.cpp
@@ -10,6 +10,12 @@
 #include "logger.h"
 #include <arpa/inet.h>
 
+#include "metrics.h"               // FrameHdr + StatsMsg
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
 using namespace mesh::log;
 
 namespace mesh {
@@ -27,9 +33,33 @@ class PerfReceiver : public connection::Connection {
 public:
     std::atomic<uint64_t> received_count{0};
     // Track last frame and total missing
-    bool     have_last_     = false;
-    uint32_t last_frame_    = 0;
+    bool     have_last_  = false;
+    uint32_t last_frame_ = 0;
     std::atomic<uint64_t> missing_frames_{0};
+    std::atomic<uint64_t> first_tx_ns{0};
+    std::atomic<uint64_t> first_rx_ns{0};
+    std::atomic<uint64_t> last_rx_ns{0};
+    std::atomic<uint32_t> ttlb_seen{0};
+    std::atomic<uint64_t> ttlb_ns_sum{0};
+    std::atomic<uint64_t> first_ttlb_tx_ns{0};
+    std::atomic<uint64_t> last_ttlb_rx_ns{0};
+    // paced‐probe (phase A) stats
+    std::atomic<uint64_t> ttlb_spaced_ns_sum{0};
+    std::atomic<uint32_t> ttlb_spaced_seen  {0};
+    std::vector<uint64_t> ttlb_spaced_samples_;
+
+    // full‐speed (phase B) stats
+    std::atomic<uint64_t> ttlb_full_ns_sum  {0};
+    std::atomic<uint32_t> ttlb_full_seen    {0};
+    std::vector<uint64_t> ttlb_full_samples_;
+
+    std::vector<uint64_t> ttlb_samples_;
+    void clearLatencySamples() {
+    ttlb_spaced_samples_.clear();
+    ttlb_full_samples_.clear();
+    }
+    const std::vector<uint64_t>& getTtlbSpacedSamples() const { return ttlb_spaced_samples_; }
+    const std::vector<uint64_t>& getTtlbFullSamples()   const { return ttlb_full_samples_; }
 
     PerfReceiver(context::Context& ctx)
     {
@@ -48,43 +78,79 @@ public:
         return connection::Result::success;
     }
 
-    connection::Result on_receive(context::Context& ctx, void* ptr, uint32_t sz,
-                                  uint32_t& sent) override
+    connection::Result on_receive(context::Context& /*ctx*/,
+                                        void*         ptr,
+                                        uint32_t      sz,
+                                        uint32_t&     sent) override
     {
-        // 1) pull off the 4-byte header (network order → host order)
-        uint32_t netframe;
-        std::memcpy(&netframe, ptr, sizeof(netframe));
-        uint32_t frame = ntohl(netframe);
+        static constexpr uint32_t TTLB_ITERS = 200;  // frames per phase
 
-        if (have_last_) {
-            if (frame == last_frame_) {
-                // duplicate—ignore
-            }
-            else if (frame == last_frame_ + 1) {
-                // perfectly consecutive—nothing to do
-            }
-            else if (frame > last_frame_ + 1) {
-                uint32_t gap = frame - last_frame_ - 1;
-                missing_frames_.fetch_add(gap, std::memory_order_relaxed);
-                std::cerr << "[RX] Missing " << gap
-                          << " frame(s) between " << last_frame_
-                          << " and " << frame << "\n";
-            }
-            else {
-                // optional: handle wrap-around or out-of-order
-                std::cerr << "[RX] Unexpected frame order: "
-                          << frame << " after " << last_frame_ << "\n";
-            }
+        if (sz < sizeof(FrameHdr)) {
+            std::cerr << "[RX] Packet too small (" << sz << " B)\n";
+            return connection::Result::error_bad_argument;
         }
-        else {
-            have_last_ = true;  // first packet, just seed last_frame_
-        }
-        last_frame_ = frame;
 
-        // 3) Count the valid receipt
-        received_count.fetch_add(1, std::memory_order_relaxed);
-        return connection::Result::success;
-    }
+        // parse header + timestamps
+        auto*    hdr   = reinterpret_cast<FrameHdr*>(ptr);
+        uint32_t frame = ntohl(hdr->frame);
+        uint64_t tx_ns = be64toh(hdr->tx_ns);
+
+        uint64_t rx_ns = std::chrono::time_point_cast<std::chrono::nanoseconds>(
+                            std::chrono::high_resolution_clock::now())
+                            .time_since_epoch()
+                            .count();
+
+        // —————— TTLB book-keeping ——————
+        // Warmup phase: first 200 frames
+        if (frame < TTLB_ITERS) {
+            // ignore 
+            }
+            // Phase A: paced probes (frames 0…199)
+            else if (frame < 2 * TTLB_ITERS) {
+                uint64_t dt = rx_ns - tx_ns;
+                ttlb_spaced_ns_sum.fetch_add(dt, std::memory_order_relaxed);
+                ttlb_spaced_seen.fetch_add(1, std::memory_order_relaxed);
+                ttlb_spaced_samples_.push_back(dt);
+            }
+            // Phase B: full-speed probes (frames 200…399)
+            else if (frame < 3 * TTLB_ITERS) {
+                uint64_t dt = rx_ns - tx_ns;
+                ttlb_full_ns_sum.fetch_add(dt, std::memory_order_relaxed);
+                ttlb_full_seen.fetch_add(1, std::memory_order_relaxed);
+                ttlb_full_samples_.push_back(dt);
+            }
+
+            // —————— first / last arrival stamps (diagnostics) ——————
+            {
+                uint64_t exp = 0;
+                first_tx_ns.compare_exchange_strong(exp, tx_ns, std::memory_order_relaxed);
+                exp = 0;
+                first_rx_ns.compare_exchange_strong(exp, rx_ns, std::memory_order_relaxed);
+                last_rx_ns.store(rx_ns, std::memory_order_relaxed);
+            }
+
+            // —————— loss / ordering tracking (unchanged) ——————
+            if (have_last_) {
+                if (frame == last_frame_ + 1) {
+                    // in‐order
+                } else if (frame > last_frame_ + 1) {
+                    uint32_t gap = frame - last_frame_ - 1;
+                    missing_frames_.fetch_add(gap, std::memory_order_relaxed);
+                    std::cerr << "[RX] Missing " << gap << " between " << last_frame_ << " and "
+                              << frame << "\n";
+                } else if (frame != last_frame_) {
+                    std::cerr << "[RX] Out-of-order " << frame << " after " << last_frame_ << "\n";
+                }
+            } else {
+                have_last_ = true;
+            }
+            last_frame_ = frame;
+
+            // —————— count it and consume ——————
+            received_count.fetch_add(1, std::memory_order_relaxed);
+            sent = 0;
+            return connection::Result::success;
+        }
 
     connection::Result configure(context::Context& ctx)
     {
@@ -150,69 +216,156 @@ protected:
     }
 };
 
-/**
- * Test: MultipleReception
- * - Receive a certain number of messages (or run indefinitely).
- * - We simply loop until we see enough messages arrive. 
- * - Because PerfReceiver doesn't copy or log data, overhead is minimized.
- */
+// ---------------------------------------------------------------------------
+//  RdmaRealEndpointsRxTest
+//  Matches the three-phase TX scheme:
+//
+//    • first  200 normal-size frames     → average **TTLB**
+//    • remaining frames (to 16 GiB)     → throughput, no timing
+//
+//  The averages are accumulated inside PerfReceiver with
+//     ttlb_seen / ttfb_ns_sum / ttlb_ns_sum
+// ---------------------------------------------------------------------------
 TEST_F(RdmaRealEndpointsRxTest, MultipleReception)
 {
-    /* ---------- payload / queue parameters MUST match the Tx test ---------- */
-    const size_t total_data_size = 16ULL * 1024ULL * 1024ULL * 1024ULL;  // 16 GiB
-    const size_t payload_sizes[] = {1 << 20, 8 << 20, 3840ULL * 2160ULL * 4ULL, 64 << 20};
-    const int    queue_sizes[]   = {8, 16, 32, 64};
-    const size_t msgs_per_size   = 2200;          // how many packets to wait for
+    /* --------------------------- test matrix ------------------------------ */
+    const size_t payload_sizes[] = {
+        568ULL * 320ULL * 4ULL,     // 320p
+        1280ULL * 720ULL * 4ULL,    // 720p
+        1920ULL * 1080ULL * 4ULL,   // 1080p
+        3840ULL * 2160ULL * 4ULL    // 4K
+    };
+    const int    queue_sizes[]      = {1, 4, 16};
+    char*        providers[]        = {"tcp", "verbs"};
+    const int    endpoint_counts[]  = {1, 2, 4};
 
-    for (int qsz : queue_sizes) {
-        for (size_t psz : payload_sizes) {
+    const size_t TOTAL_STREAM_BYTES = 16ULL * 1024ULL * 1024ULL * 1024ULL; // 16 GiB
 
-            /* --- tear down any previous connection ---- */
-            if (conn_rx) {
-                ASSERT_EQ(conn_rx->shutdown(ctx), connection::Result::success);
-                delete conn_rx;
-                conn_rx = nullptr;
-            }
+    /* --------------------------- constants -------------------------------- */
+    static constexpr size_t TTLB_ITERS = 200;
 
-            /* --- create a fresh Rx endpoint that uses the current payload size --- */
-            conn_rx = new RdmaRx();
-            mcm_conn_param rx_request = {};
-            rx_request.type = is_rx;
-            rx_request.local_addr = {.ip = "192.168.2.30", .port = "9002"};
-            // rx_request.local_addr = {.ip = "192.168.2.20", .port = "9002"};
-            rx_request.payload_args.rdma_args.transfer_size = psz;   // <-- match Tx
-            rx_request.payload_args.rdma_args.queue_size    = qsz;
+    constexpr char TX_IP[]   = "192.168.2.20";
+    constexpr int  METRICS_PORT = 9999;
 
-            ASSERT_EQ(conn_rx->configure(ctx, rx_request, rx_dev_handle),
-                      connection::Result::success);
-            ASSERT_EQ(conn_rx->establish(ctx), connection::Result::success);
+    auto cpu_seconds = []() -> double {
+        rusage ru{};  getrusage(RUSAGE_SELF, &ru);
+        return ru.ru_utime.tv_sec  + ru.ru_utime.tv_usec/1e6 +
+               ru.ru_stime.tv_sec  + ru.ru_stime.tv_usec/1e6;
+    };
 
-            /* re-link to the same PerfReceiver */
-            conn_rx->set_link(ctx, perf_rx);
-
-            /* reset counters */
-            const size_t msgs_expected = total_data_size / psz;
-            perf_rx->received_count.store(0, std::memory_order_relaxed);
-            perf_rx->missing_frames_.store(0, std::memory_order_relaxed);
-            perf_rx->have_last_  = false;
-
-            std::cout << "\n[RX] waiting for ≈" << msgs_expected + 200
-                      << " messages of " << (psz / (1024*1024)) << " MiB, queue "
-                      << qsz << " …" << std::endl;
-
-            /* ------- busy-wait until the desired number of packets arrives ---- */
-            while (perf_rx->received_count.load(std::memory_order_relaxed) <
-                   msgs_expected + 200)
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            }
-
-            std::cout << "[RX] done for payload "
-                      << (psz / (1024*1024)) << " MiB, queue "
-                      << qsz << ", missing = "
-                      << perf_rx->missing_frames_.load(std::memory_order_relaxed)
-                      << std::endl;
+    /* ===================================================================== */
+    for (auto prov : providers)
+    for (int num_eps : endpoint_counts)
+    for (int qsz : queue_sizes)
+    for (size_t psz : payload_sizes)
+    {
+        if (prov == "tcp" && num_eps > 1) {
+            std::cerr << "[RX] ⚠ TCP provider does not support multiple endpoints\n";
+            continue;
         }
+
+        /* ---- clean any prior connection --------------------------------- */
+        if (conn_rx) {
+            EXPECT_EQ(conn_rx->shutdown(ctx), connection::Result::success);
+            delete conn_rx;  conn_rx = nullptr;
+        }
+
+        /* ---- create fresh RX endpoint ----------------------------------- */
+        conn_rx = new RdmaRx();
+        mcm_conn_param p{};  p.type = is_rx;
+        p.local_addr = {.ip = "192.168.2.30", .port = "9002"};
+        p.payload_args.rdma_args.transfer_size = psz;
+        p.payload_args.rdma_args.queue_size    = qsz;
+        p.payload_args.rdma_args.provider      = prov;
+        p.payload_args.rdma_args.num_endpoints = num_eps;
+
+        ASSERT_EQ(conn_rx->configure(ctx, p, rx_dev_handle),
+                  connection::Result::success);
+        ASSERT_EQ(conn_rx->establish(ctx), connection::Result::success);
+        conn_rx->set_link(ctx, perf_rx);
+
+        /* ---- reset per-run counters in PerfReceiver --------------------- */
+        const size_t msgs_expected =
+            TOTAL_STREAM_BYTES/psz + 3 * TTLB_ITERS;  // only TTLB probes
+
+        perf_rx->received_count .store(0, std::memory_order_relaxed);
+        perf_rx->missing_frames_.store(0, std::memory_order_relaxed);
+        perf_rx->have_last_      = false;
+
+        perf_rx->ttlb_full_ns_sum  .store(0, std::memory_order_relaxed);
+        perf_rx->ttlb_full_seen    .store(0, std::memory_order_relaxed);
+        perf_rx->ttlb_spaced_ns_sum.store(0, std::memory_order_relaxed);
+        perf_rx->ttlb_spaced_seen  .store(0, std::memory_order_relaxed);
+        perf_rx->clearLatencySamples();
+
+        std::cout << "\n[RX] waiting for " << msgs_expected
+                  << " msgs of " << (psz/1024/1024) << " MiB,"
+                  << " q" << qsz
+                  << " Prov " << prov
+                  << " #EP " << num_eps << " …\n";
+
+        /* ---- CPU-load anchors ------------------------------------------ */
+        auto   wall_start = std::chrono::steady_clock::now();
+        double cpu_start  = cpu_seconds();
+
+        /* ---- wait until all expected frames have arrived --------------- */
+        while (perf_rx->received_count.load(std::memory_order_relaxed)
+               < msgs_expected)
+        {
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+
+        /* ---- compute TTLB average --------------------------------------- */
+        double spaced_avg_ms =
+            double(perf_rx->ttlb_spaced_ns_sum.load()) / perf_rx->ttlb_spaced_seen.load() / 1e6;
+        double full_avg_ms =
+            double(perf_rx->ttlb_full_ns_sum.load()) / perf_rx->ttlb_full_seen.load() / 1e6;
+
+        auto   wall_end = std::chrono::steady_clock::now();
+        double wall_sec = std::chrono::duration<double>(wall_end - wall_start).count();
+        double cpu_pct  = 100.0*(cpu_seconds() - cpu_start)/wall_sec;
+
+        /* percentile helper */
+        auto computePercentileMs = [&](std::vector<uint64_t> v, double p) {
+            if (v.empty()) return 0.0;
+            size_t idx = size_t(p * (v.size() - 1));
+            std::nth_element(v.begin(), v.begin() + idx, v.end());
+            return double(v[idx]) / 1e6;
+        };
+
+        /* fetch TTLB samples */
+        auto ttlb_samples = perf_rx->getTtlbFullSamples();
+
+        /* print TTLB percentiles */
+        std::cout << "[RX] TTLB avg=" << full_avg_ms << " ms  "
+                  << "P25=" << computePercentileMs(ttlb_samples, 0.25) << " ms  "
+                  << "P50=" << computePercentileMs(ttlb_samples, 0.50) << " ms  "
+                  << "P90=" << computePercentileMs(ttlb_samples, 0.90) << " ms  "
+                  << "P99=" << computePercentileMs(ttlb_samples, 0.99) << " ms\n";
+
+        std::cout << "[RX] done " << (psz/1024/1024)
+                  << " MiB,q" << qsz
+                  << "  missing=" << perf_rx->missing_frames_.load()
+                  << "  TTLB=" << full_avg_ms
+                  << " ms CPU=" << cpu_pct << "%\n";
+
+        /* ---- send StatsMsg to the transmitter -------------------------- */
+        StatsMsg sm{
+            .payload_mb     = static_cast<uint32_t>(psz/(1024*1024)),
+            .queue          = static_cast<uint32_t>(qsz),
+            .ttlb_spaced_ms = spaced_avg_ms,
+            .ttlb_full_ms   = full_avg_ms,
+            .cpu_tx_pct     = 0.0,
+            .cpu_rx_pct     = cpu_pct
+        };
+
+        int s = socket(AF_INET, SOCK_DGRAM, 0);
+        sockaddr_in tx{};  tx.sin_family = AF_INET;
+        tx.sin_port = htons(METRICS_PORT);
+        inet_pton(AF_INET, TX_IP, &tx.sin_addr);
+        sendto(s, &sm, sizeof(sm), 0,
+               reinterpret_cast<sockaddr*>(&tx), sizeof(tx));
+        close(s);
     }
 }
 

--- a/media-proxy/tests/rdma_rx_test.cpp
+++ b/media-proxy/tests/rdma_rx_test.cpp
@@ -1,0 +1,228 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <iostream>
+
+// Include your RDMA Rx and logging interfaces
+#include "mesh/conn_rdma_rx.h"
+#include "mesh/concurrency.h"
+#include "logger.h"
+#include <arpa/inet.h>
+
+using namespace mesh::log;
+
+namespace mesh {
+namespace connection {
+
+/** Logging level (optional) **/
+Level log_level = Level::fatal;
+
+/** --------------------------------------------------------------------
+ *  PerfReceiver:
+ *     - Extends Connection to handle incoming data with minimal overhead
+ *     - Increments a counter per receive, does no string copy or print
+ * ------------------------------------------------------------------ **/
+class PerfReceiver : public connection::Connection {
+public:
+    std::atomic<uint64_t> received_count{0};
+    // Track last frame and total missing
+    bool     have_last_     = false;
+    uint32_t last_frame_    = 0;
+    std::atomic<uint64_t> missing_frames_{0};
+
+    PerfReceiver(context::Context& ctx)
+    {
+        _kind = connection::Kind::receiver;
+        set_state(ctx, connection::State::configured);
+    }
+
+    connection::Result on_establish(context::Context& ctx) override
+    {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context& ctx) override
+    {
+        return connection::Result::success;
+    }
+
+    connection::Result on_receive(context::Context& ctx, void* ptr, uint32_t sz,
+                                  uint32_t& sent) override
+    {
+        // 1) pull off the 4-byte header (network order → host order)
+        uint32_t netframe;
+        std::memcpy(&netframe, ptr, sizeof(netframe));
+        uint32_t frame = ntohl(netframe);
+
+        if (have_last_) {
+            if (frame == last_frame_) {
+                // duplicate—ignore
+            }
+            else if (frame == last_frame_ + 1) {
+                // perfectly consecutive—nothing to do
+            }
+            else if (frame > last_frame_ + 1) {
+                uint32_t gap = frame - last_frame_ - 1;
+                missing_frames_.fetch_add(gap, std::memory_order_relaxed);
+                std::cerr << "[RX] Missing " << gap
+                          << " frame(s) between " << last_frame_
+                          << " and " << frame << "\n";
+            }
+            else {
+                // optional: handle wrap-around or out-of-order
+                std::cerr << "[RX] Unexpected frame order: "
+                          << frame << " after " << last_frame_ << "\n";
+            }
+        }
+        else {
+            have_last_ = true;  // first packet, just seed last_frame_
+        }
+        last_frame_ = frame;
+
+        // 3) Count the valid receipt
+        received_count.fetch_add(1, std::memory_order_relaxed);
+        return connection::Result::success;
+    }
+
+    connection::Result configure(context::Context& ctx)
+    {
+        set_state(ctx, connection::State::configured);
+        return connection::Result::success;
+    }
+};
+
+/** --------------------------------------------------------------------
+ *  RdmaRealEndpointsRxTest:
+ *     - GTest fixture for the RX side
+ * ------------------------------------------------------------------ **/
+class RdmaRealEndpointsRxTest : public ::testing::Test {
+protected:
+    context::Context ctx;
+    RdmaRx* conn_rx;
+    PerfReceiver* perf_rx;
+    libfabric_ctx* rx_dev_handle;
+    std::atomic<bool> keep_running;
+
+    void SetUp() override
+    {
+        ctx = context::WithCancel(context::Background());
+
+        // Create RDMA receiver connection
+        conn_rx     = new RdmaRx();
+        perf_rx     = new PerfReceiver(ctx);
+        rx_dev_handle = nullptr;
+        keep_running = true;
+
+        // Adjust these for your environment:
+        // A larger transfer_size ensures the posted buffer is big enough
+        // for the largest messages you expect from the transmitter.
+        // A bigger queue_size can boost throughput by posting multiple receives.
+        mcm_conn_param rx_request = {};
+        rx_request.type = is_rx;
+        rx_request.local_addr = {.ip = "192.168.2.30", .port = "9002"};
+        // rx_request.local_addr = {.ip = "192.168.2.20", .port = "9002"};
+        rx_request.payload_args.rdma_args.transfer_size = 3840ULL * 2160ULL * 4ULL;
+        rx_request.payload_args.rdma_args.queue_size    = 64;
+
+        // Configure & establish the RDMA Rx
+        ASSERT_EQ(conn_rx->configure(ctx, rx_request, rx_dev_handle),
+                  connection::Result::success);
+        ASSERT_EQ(conn_rx->establish(ctx), connection::Result::success);
+
+        // Configure & establish our PerfReceiver
+        ASSERT_EQ(perf_rx->configure(ctx), connection::Result::success);
+        ASSERT_EQ(perf_rx->establish(ctx), connection::Result::success);
+
+        // Link the RDMA Rx to our PerfReceiver
+        conn_rx->set_link(ctx, perf_rx);
+    }
+
+    void TearDown() override
+    {
+        keep_running = false;
+        ASSERT_EQ(conn_rx->shutdown(ctx), connection::Result::success);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+        delete conn_rx;
+        delete perf_rx;
+    }
+};
+
+/**
+ * Test: MultipleReception
+ * - Receive a certain number of messages (or run indefinitely).
+ * - We simply loop until we see enough messages arrive. 
+ * - Because PerfReceiver doesn't copy or log data, overhead is minimized.
+ */
+TEST_F(RdmaRealEndpointsRxTest, MultipleReception)
+{
+    /* ---------- payload / queue parameters MUST match the Tx test ---------- */
+    const size_t total_data_size = 16ULL * 1024ULL * 1024ULL * 1024ULL;  // 16 GiB
+    const size_t payload_sizes[] = {1 << 20, 8 << 20, 3840ULL * 2160ULL * 4ULL, 64 << 20};
+    const int    queue_sizes[]   = {8, 16, 32, 64};
+    const size_t msgs_per_size   = 2200;          // how many packets to wait for
+
+    for (int qsz : queue_sizes) {
+        for (size_t psz : payload_sizes) {
+
+            /* --- tear down any previous connection ---- */
+            if (conn_rx) {
+                ASSERT_EQ(conn_rx->shutdown(ctx), connection::Result::success);
+                delete conn_rx;
+                conn_rx = nullptr;
+            }
+
+            /* --- create a fresh Rx endpoint that uses the current payload size --- */
+            conn_rx = new RdmaRx();
+            mcm_conn_param rx_request = {};
+            rx_request.type = is_rx;
+            rx_request.local_addr = {.ip = "192.168.2.30", .port = "9002"};
+            // rx_request.local_addr = {.ip = "192.168.2.20", .port = "9002"};
+            rx_request.payload_args.rdma_args.transfer_size = psz;   // <-- match Tx
+            rx_request.payload_args.rdma_args.queue_size    = qsz;
+
+            ASSERT_EQ(conn_rx->configure(ctx, rx_request, rx_dev_handle),
+                      connection::Result::success);
+            ASSERT_EQ(conn_rx->establish(ctx), connection::Result::success);
+
+            /* re-link to the same PerfReceiver */
+            conn_rx->set_link(ctx, perf_rx);
+
+            /* reset counters */
+            const size_t msgs_expected = total_data_size / psz;
+            perf_rx->received_count.store(0, std::memory_order_relaxed);
+            perf_rx->missing_frames_.store(0, std::memory_order_relaxed);
+            perf_rx->have_last_  = false;
+
+            std::cout << "\n[RX] waiting for ≈" << msgs_expected + 200
+                      << " messages of " << (psz / (1024*1024)) << " MiB, queue "
+                      << qsz << " …" << std::endl;
+
+            /* ------- busy-wait until the desired number of packets arrives ---- */
+            while (perf_rx->received_count.load(std::memory_order_relaxed) <
+                   msgs_expected + 200)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+
+            std::cout << "[RX] done for payload "
+                      << (psz / (1024*1024)) << " MiB, queue "
+                      << qsz << ", missing = "
+                      << perf_rx->missing_frames_.load(std::memory_order_relaxed)
+                      << std::endl;
+        }
+    }
+}
+
+} // namespace connection
+} // namespace mesh
+
+/**
+ * main() for the RX side test executable.
+ */
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/media-proxy/tests/rdma_tx_test.cpp
+++ b/media-proxy/tests/rdma_tx_test.cpp
@@ -1,0 +1,297 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include <atomic>
+#include <cstring>
+#include <chrono>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+// Include your RDMA Tx and logging interfaces
+#include "mesh/conn_rdma_tx.h"
+#include "mesh/concurrency.h"
+#include "logger.h"
+#include <arpa/inet.h>
+
+using namespace mesh::log;
+
+namespace mesh {
+namespace connection {
+
+/** Logging level (optional) **/
+Level log_level = Level::fatal;
+
+/** --------------------------------------------------------------------
+ *  EmulatedTransmitter:
+ *     - Minimal transmitter that sends data.
+ * ------------------------------------------------------------------ **/
+class EmulatedTransmitter : public connection::Connection {
+public:
+    EmulatedTransmitter(context::Context& ctx) {
+        _kind = connection::Kind::transmitter;
+        set_state(ctx, connection::State::configured);
+    }
+
+    connection::Result on_establish(context::Context& ctx) override {
+        set_state(ctx, connection::State::active);
+        return connection::Result::success;
+    }
+
+    connection::Result on_shutdown(context::Context& ctx) override {
+        return connection::Result::success;
+    }
+
+    connection::Result configure(context::Context& ctx) {
+        set_state(ctx, connection::State::configured);
+        return connection::Result::success;
+    }
+
+    connection::Result transmit_plaintext(context::Context& ctx, const void *ptr, size_t sz) {
+        // RDMA transmit expects a void*, so cast away const
+        return transmit(ctx, const_cast<void *>(ptr), sz);
+    }
+};
+
+/** --------------------------------------------------------------------
+ *  RdmaRealEndpointsTxTest:
+ *     - GTest fixture for the TX side
+ * ------------------------------------------------------------------ **/
+class RdmaRealEndpointsTxTest : public ::testing::Test {
+protected:
+    context::Context ctx;
+    RdmaTx *conn_tx;
+    EmulatedTransmitter *emulated_tx;
+    libfabric_ctx *tx_dev_handle;
+    std::atomic<bool> keep_running;
+
+    void SetUp() override {
+        // We won't establish a connection here, because we want to mimic
+        // the single-machine approach of re-creating connections for each
+        // (payload_size, queue_size) pair. We'll do that in the test itself.
+        ctx = context::WithCancel(context::Background());
+        conn_tx = nullptr;
+        emulated_tx = nullptr;
+        tx_dev_handle = nullptr;
+        keep_running = true;
+    }
+
+    void TearDown() override {
+        // If a connection is active at the end, clean it up here
+        if (conn_tx || emulated_tx) {
+            CleanupRdmaConnectionsTx();
+        }
+    }
+
+public:
+    /**
+     * SetupRdmaConnectionsTx:
+     * Similar to single-machine SetupRdmaConnections, but only
+     * creates and configures the TX side (since RX is on another machine).
+     */
+    void SetupRdmaConnectionsTx(size_t payload_size, int queue_size) {
+        // Create new transmitter components
+        conn_tx = new RdmaTx();
+        emulated_tx = new EmulatedTransmitter(ctx);
+        tx_dev_handle = nullptr;
+
+        // Prepare connection params
+        mcm_conn_param tx_request = {};
+        tx_request.type = is_tx;
+        tx_request.local_addr = {.ip = "192.168.2.20", .port = "9003"};  // adjust to your local
+        tx_request.remote_addr = {.ip = "192.168.2.30", .port = "9002"}; // the remote Rx
+        // tx_request.local_addr = {.ip = "192.168.2.30", .port = "9003"};  // adjust to your local
+        // tx_request.remote_addr = {.ip = "192.168.2.20", .port = "9002"}; // the remote Rx
+        tx_request.payload_args.rdma_args.transfer_size = payload_size;
+        tx_request.payload_args.rdma_args.queue_size = queue_size;
+
+        // Configure & establish
+        ASSERT_EQ(conn_tx->configure(ctx, tx_request, tx_dev_handle), connection::Result::success);
+        ASSERT_EQ(conn_tx->establish(ctx), connection::Result::success);
+
+        // Configure & establish the emulated Tx
+        ASSERT_EQ(emulated_tx->configure(ctx), connection::Result::success);
+        ASSERT_EQ(emulated_tx->establish(ctx), connection::Result::success);
+
+        // Link them
+        emulated_tx->set_link(ctx, conn_tx);
+
+        keep_running = true;
+    }
+
+    /**
+     * CleanupRdmaConnectionsTx:
+     * Mimic the single-machine CleanupRdmaConnections approach
+     */
+    void CleanupRdmaConnectionsTx() {
+        keep_running = false;
+        // In single-machine code, there's an Rx as well; here we only handle Tx side
+        if (conn_tx) {
+            ASSERT_EQ(conn_tx->shutdown(ctx), connection::Result::success);
+        }
+        // Give some time for the shutdown
+        std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+
+        delete conn_tx;
+        delete emulated_tx;
+
+        conn_tx = nullptr;
+        emulated_tx = nullptr;
+    }
+};
+
+// /**
+//  * Test 1: Basic Transmission Example
+//  * - Sends a small amount of data 5 times.
+//  *   (Adapted from simpler usage.)
+//  */
+// TEST_F(RdmaRealEndpointsTxTest, ConcurrentTransmission)
+// {
+//     // Setup connections with some default size & queue
+//     SetupRdmaConnectionsTx(/*payload_size*/ 1024, /*queue_size*/ 8);
+
+//     std::thread tx_thread([&]() {
+//         const char* test_data = "Hello RDMA World!";
+//         size_t data_size      = strlen(test_data) + 1;
+
+//         for (int i = 0; i < 5 && keep_running; ++i) {
+//             auto res = emulated_tx->transmit_plaintext(ctx, test_data, data_size);
+//             EXPECT_EQ(res, connection::Result::success);
+//             std::cout << "[TX] Sent iteration #" << (i + 1)
+//                       << " data: " << test_data << std::endl;
+//             std::this_thread::sleep_for(std::chrono::milliseconds(100));
+//         }
+//         keep_running = false;
+//     });
+
+//     tx_thread.join();
+
+//     // Cleanup when done
+//     CleanupRdmaConnectionsTx();
+// }
+
+/**
+ * Test 2: Latency & Bandwidth over multiple (payload_size, queue_size) combos
+ *
+ * This mimics the original single-machine approach:
+ * 1) For each payload_size & queue_size:
+ *    - Cleanup (if existing) and re-Setup fresh Tx connections
+ *    - Measure "latency" by timing a small number of transmissions
+ *    - Measure "bandwidth" by sending a large total amount of data
+ *    - Then Cleanup
+ *
+ * Note: Without a round-trip ACK from the Rx side, this is purely the local
+ *       "post-send" time on the Tx side. If you want real end-to-end times,
+ *       you must implement an ACK and wait for it here.
+ */
+TEST_F(RdmaRealEndpointsTxTest, LatencyAndBandwidthForVaryingPayloadSizesAndQueueSizes) {
+    // Match the original single-machine values
+    const size_t payload_sizes[] = {1 << 20, 8 << 20, 3840ULL * 2160ULL * 4ULL,
+                                    64 << 20}; // 1MB, 8MB, ~32MB
+    const int queue_sizes[] = {8, 16, 32, 64};
+    const size_t total_data_size = 16ULL * 1024ULL * 1024ULL * 1024ULL; // 16 GB
+    const size_t num_iterations = 200;
+    const char filler = 'A';
+
+    // Store results for: (PayloadMB, QueueSize, AvgLatencyMS, BandwidthGB/s)
+    std::vector<std::tuple<double, int, double, double>> results;
+
+    for (int qsz : queue_sizes) {
+        for (size_t psz : payload_sizes) {
+            printf("\nTesting payload size: %zu bytes, queue size: %d\n", psz, qsz);
+            sleep(1);
+            // 2) Set up a new Tx connection for this (psz, qsz)
+            SetupRdmaConnectionsTx(psz, qsz);
+
+            // Prepare data
+            // Reserve space for a 4-byte frame number + payload
+            const size_t header_size = sizeof(uint32_t);
+            std::vector<char> test_data(header_size + psz - header_size, filler);
+
+            // Frame counter
+            uint32_t frame_number = 0;
+
+            // --- Measure latency (local post-send time) ---
+            double total_latency_ms = 0.0;
+            for (size_t i = 0; i < num_iterations; ++i) {
+                auto start = std::chrono::high_resolution_clock::now();
+                // --- insert frame number in network byte-order at start of buffer ---
+                uint32_t netfn = htonl(frame_number);
+                std::memcpy(test_data.data(), &netfn, header_size);
+
+                auto res = emulated_tx->transmit_plaintext(ctx, test_data.data(), test_data.size());
+                EXPECT_EQ(res, connection::Result::success);
+                frame_number++;
+
+                // If you want real end-to-end times, you need an ACK from receiver here:
+                // e.g. WaitForReceiverAck();
+
+                auto end = std::chrono::high_resolution_clock::now();
+                total_latency_ms += std::chrono::duration<double, std::milli>(end - start).count();
+            }
+            double avg_latency_ms = total_latency_ms / num_iterations;
+
+            // --- Measure bandwidth ---
+            size_t num_sends = total_data_size / psz;
+            auto bdw_start = std::chrono::high_resolution_clock::now();
+
+            for (size_t i = 0; i < num_sends; ++i) {
+
+                // keep numbering across the bandwidth test too,
+                // and send in network-byte-order
+                uint32_t netfn = htonl(frame_number);
+                std::memcpy(test_data.data(), &netfn, header_size);
+
+                auto res = emulated_tx->transmit_plaintext(ctx, test_data.data(), test_data.size());
+                EXPECT_EQ(res, connection::Result::success);
+                frame_number++;
+                // WaitForReceiverAck(); // if doing real round-trip
+            }
+
+            auto bdw_end = std::chrono::high_resolution_clock::now();
+            double elapsed_sec = std::chrono::duration<double>(bdw_end - bdw_start).count();
+
+            double total_gb = (static_cast<double>(psz) * num_sends) / (1024.0 * 1024.0 * 1024.0);
+            double throughput_gb_s = total_gb / elapsed_sec;
+
+            // Save results
+            results.emplace_back(static_cast<double>(psz) / (1024.0 * 1024.0), qsz, avg_latency_ms,
+                                 throughput_gb_s);
+            sleep(1); // Give some time before next test
+            std::cout << "[TX] Completed payload size: " << psz / (1024 * 1024)
+                      << " MB, queue size: " << qsz
+                      << ", Avg Latency: " << avg_latency_ms
+                      << " ms, Throughput: " << throughput_gb_s
+                      << " GB/s\n";
+            // 3) Clean up the connection after finishing this (psz, qsz)
+            CleanupRdmaConnectionsTx();
+        }
+    }
+
+    // Print results in a table
+    std::cout
+        << "\n+-------------------+-------------+--------------------+----------------------+\n";
+    std::cout
+        << "| Payload Size (MB) | Queue Size  |    Latency (ms)    | Transfer Rate (GB/s) |\n";
+    std::cout
+        << "+-------------------+-------------+--------------------+----------------------+\n";
+    for (auto& entry : results) {
+        std::cout << "| " << std::setw(17) << std::fixed << std::setprecision(2)
+                  << std::get<0>(entry) << " | " << std::setw(11) << std::get<1>(entry) << " | "
+                  << std::setw(18) << std::fixed << std::setprecision(3) << std::get<2>(entry)
+                  << " | " << std::setw(20) << std::fixed << std::setprecision(3)
+                  << std::get<3>(entry) << " |\n";
+    }
+    std::cout
+        << "+-------------------+-------------+--------------------+----------------------+\n";
+}
+
+} // namespace connection
+} // namespace mesh
+
+/**
+ * main() for the TX side test executable.
+ */
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/sdk/include/mcm_dp.h
+++ b/sdk/include/mcm_dp.h
@@ -204,6 +204,8 @@ typedef struct {
 typedef struct {
     size_t transfer_size;
     int queue_size;
+    char     *provider;
+    uint16_t  num_endpoints;
 } mcm_rdma_args;
 
 typedef struct {


### PR DESCRIPTION
- Introduced Verbs RDMA provider
- User can choose provider and number of endpoints used for transmission
- Introduced a new test suite for libfabric development, including comprehensive tests for RDMA initialisation and teardown.
- Added custom fake functions for RDMA address info handling to improve test isolation and reliability.
- Created a new header file for libfabric development tests to encapsulate test setup and teardown logic.
- Implemented performance testing for RDMA receiver and transmitter, focusing on TTLB and bandwidth metrics across varying payload and queue sizes.
- Enhanced the mcm_rdma_args structure to include the provider and the number of endpoints for improved configuration flexibility.
- Updated existing tests to remove unnecessary calls to fi_getinfo, ensuring tests focus on relevant functionality.
- Improved memory management in tests to prevent leaks and ensure proper cleanup of allocated resources.