### PR TITLE
Disable clang-format

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,8 +42,7 @@ jobs:
           GITHUB_STATUS_UPDATES: false
           VALIDATE_BASH_EXEC: true
           VALIDATE_BASH: true
-          VALIDATE_CLANG_FORMAT: true
-          DISABLE_CLANG_FORMAT_ERRORS: true
+          VALIDATE_CLANG_FORMAT: false # Do not enforce clang-format since the code style differs. Instead, use it locally.
           VALIDATE_CPP: true
           VALIDATE_GO: true
           VALIDATE_GITHUB_ACTIONS: true


### PR DESCRIPTION
Do not enforce clang-format since the code style differs. Enforcing clang-format requires huge refactoring in the code base.

Instead, use clang-format locally, per source file.